### PR TITLE
Rename terse variables to human-readable names

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -22,9 +22,9 @@ type handler struct {
 	usageCh  chan<- store.UsageEntry
 
 	// Admin rate limiter: 10 req/min, single bucket
-	rlMu     sync.Mutex
-	rlTokens float64
-	rlLast   time.Time
+	rateLimitMu       sync.Mutex
+	rateLimitTokens   float64
+	rateLimitLastTime time.Time
 }
 
 type createKeyRequest struct {
@@ -49,22 +49,22 @@ type keyResponse struct {
 	Revoked   bool      `json:"revoked"`
 }
 
-func NewHandler(s *store.Store, adminKey string, usageCh chan<- store.UsageEntry) http.Handler {
-	h := &handler{
-		store:    s,
-		adminKey: adminKey,
-		usageCh:  usageCh,
-		rlTokens: 10,
-		rlLast:   time.Now(),
+func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.UsageEntry) http.Handler {
+	handler := &handler{
+		store:             dataStore,
+		adminKey:          adminKey,
+		usageCh:           usageCh,
+		rateLimitTokens:   10,
+		rateLimitLastTime: time.Now(),
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /admin/keys", h.createKey)
-	mux.HandleFunc("GET /admin/keys", h.listKeys)
-	mux.HandleFunc("DELETE /admin/keys/{id}", h.revokeKey)
-	mux.HandleFunc("GET /admin/usage", h.getUsage)
+	mux.HandleFunc("POST /admin/keys", handler.createKey)
+	mux.HandleFunc("GET /admin/keys", handler.listKeys)
+	mux.HandleFunc("DELETE /admin/keys/{id}", handler.revokeKey)
+	mux.HandleFunc("GET /admin/usage", handler.getUsage)
 
-	return h.authMiddleware(mux)
+	return handler.authMiddleware(mux)
 }
 
 func (h *handler) authMiddleware(next http.Handler) http.Handler {
@@ -91,16 +91,16 @@ func (h *handler) authMiddleware(next http.Handler) http.Handler {
 }
 
 func (h *handler) adminAllow() bool {
-	h.rlMu.Lock()
-	defer h.rlMu.Unlock()
+	h.rateLimitMu.Lock()
+	defer h.rateLimitMu.Unlock()
 
 	now := time.Now()
-	elapsed := now.Sub(h.rlLast).Seconds()
-	h.rlTokens = min(10, h.rlTokens+elapsed*(10.0/60.0))
-	h.rlLast = now
+	elapsed := now.Sub(h.rateLimitLastTime).Seconds()
+	h.rateLimitTokens = min(10, h.rateLimitTokens+elapsed*(10.0/60.0))
+	h.rateLimitLastTime = now
 
-	if h.rlTokens >= 1 {
-		h.rlTokens--
+	if h.rateLimitTokens >= 1 {
+		h.rateLimitTokens--
 		return true
 	}
 	return false
@@ -158,14 +158,14 @@ func (h *handler) listKeys(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := make([]keyResponse, len(keys))
-	for i, k := range keys {
+	for i, apiKey := range keys {
 		resp[i] = keyResponse{
-			ID:        k.ID,
-			Name:      k.Name,
-			KeyPrefix: k.KeyPrefix,
-			RateLimit: k.RateLimit,
-			CreatedAt: k.CreatedAt,
-			Revoked:   k.Revoked,
+			ID:        apiKey.ID,
+			Name:      apiKey.Name,
+			KeyPrefix: apiKey.KeyPrefix,
+			RateLimit: apiKey.RateLimit,
+			CreatedAt: apiKey.CreatedAt,
+			Revoked:   apiKey.Revoked,
 		}
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -51,16 +51,16 @@ func HashKey(raw string) string {
 }
 
 func hashKey(raw string) string {
-	h := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(h[:])
+	hashBytes := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(hashBytes[:])
 }
 
 func extractBearer(r *http.Request) string {
-	auth := r.Header.Get("Authorization")
-	if !strings.HasPrefix(auth, "Bearer ") {
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
 		return ""
 	}
-	return strings.TrimPrefix(auth, "Bearer ")
+	return strings.TrimPrefix(authHeader, "Bearer ")
 }
 
 func writeAuthError(w http.ResponseWriter, message string) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -46,8 +46,8 @@ func NewHandler(ollamaRawURL string, usageCh chan<- store.UsageEntry, maxBody in
 		log.Fatalf("invalid OLLAMA_URL: %v", err)
 	}
 
-	rp := httputil.NewSingleHostReverseProxy(target)
-	rp.Director = func(req *http.Request) {
+	reverseProxy := httputil.NewSingleHostReverseProxy(target)
+	reverseProxy.Director = func(req *http.Request) {
 		req.URL.Scheme = target.Scheme
 		req.URL.Host = target.Host
 		req.Host = target.Host
@@ -60,7 +60,7 @@ func NewHandler(ollamaRawURL string, usageCh chan<- store.UsageEntry, maxBody in
 
 	return &handler{
 		ollamaURL:    target,
-		reverseProxy: rp,
+		reverseProxy: reverseProxy,
 		client:       client,
 		usageCh:      usageCh,
 		maxBody:      maxBody,
@@ -191,9 +191,9 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 	defer resp.Body.Close()
 
 	// Copy upstream headers
-	for k, vv := range resp.Header {
-		for _, v := range vv {
-			w.Header().Add(k, v)
+	for headerKey, headerValues := range resp.Header {
+		for _, headerValue := range headerValues {
+			w.Header().Add(headerKey, headerValue)
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
@@ -211,11 +211,11 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 	// Raw tee passthrough with observation
 	var ud usageData
 	ud.Model = model
-	reader := bufio.NewReader(resp.Body)
+	lineReader := bufio.NewReader(resp.Body)
 	status := "completed"
 
 	for {
-		line, err := reader.ReadBytes('\n')
+		line, err := lineReader.ReadBytes('\n')
 		if len(line) > 0 {
 			w.Write(line)
 			flusher.Flush()
@@ -313,8 +313,8 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 
 // Flush implements http.Flusher for the recorder.
 func (r *responseRecorder) Flush() {
-	if f, ok := r.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
+	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
 	}
 }
 

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -25,7 +25,7 @@ type Limiter struct {
 }
 
 func New() *Limiter {
-	l := &Limiter{
+	limiter := &Limiter{
 		buckets: make(map[int64]*bucket),
 	}
 	// Prune stale buckets every minute
@@ -33,10 +33,10 @@ func New() *Limiter {
 		ticker := time.NewTicker(1 * time.Minute)
 		defer ticker.Stop()
 		for range ticker.C {
-			l.prune()
+			limiter.prune()
 		}
 	}()
-	return l
+	return limiter
 }
 
 // Allow checks if a request is allowed for the given key ID and rate limit.
@@ -46,37 +46,37 @@ func (l *Limiter) Allow(keyID int64, rateLimit int) (bool, float64) {
 	defer l.mu.Unlock()
 
 	now := time.Now()
-	b, exists := l.buckets[keyID]
+	tokenBucket, exists := l.buckets[keyID]
 
 	if !exists {
-		b = &bucket{
+		tokenBucket = &bucket{
 			tokens:     float64(rateLimit) - 1, // consume one token now
 			capacity:   float64(rateLimit),
 			refillRate: float64(rateLimit) / 60.0,
 			lastRefill: now,
 			lastAccess: now,
 		}
-		l.buckets[keyID] = b
+		l.buckets[keyID] = tokenBucket
 		return true, 0
 	}
 
 	// Update capacity/refill if rate limit changed
-	b.capacity = float64(rateLimit)
-	b.refillRate = float64(rateLimit) / 60.0
+	tokenBucket.capacity = float64(rateLimit)
+	tokenBucket.refillRate = float64(rateLimit) / 60.0
 
 	// Refill tokens based on elapsed time
-	elapsed := now.Sub(b.lastRefill).Seconds()
-	b.tokens = math.Min(b.capacity, b.tokens+elapsed*b.refillRate)
-	b.lastRefill = now
-	b.lastAccess = now
+	elapsed := now.Sub(tokenBucket.lastRefill).Seconds()
+	tokenBucket.tokens = math.Min(tokenBucket.capacity, tokenBucket.tokens+elapsed*tokenBucket.refillRate)
+	tokenBucket.lastRefill = now
+	tokenBucket.lastAccess = now
 
-	if b.tokens >= 1 {
-		b.tokens--
+	if tokenBucket.tokens >= 1 {
+		tokenBucket.tokens--
 		return true, 0
 	}
 
 	// Calculate retry-after: time until 1 token is available
-	retryAfter := (1 - b.tokens) / b.refillRate
+	retryAfter := (1 - tokenBucket.tokens) / tokenBucket.refillRate
 	return false, retryAfter
 }
 
@@ -84,9 +84,9 @@ func (l *Limiter) prune() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	cutoff := time.Now().Add(-10 * time.Minute)
-	for id, b := range l.buckets {
-		if b.lastAccess.Before(cutoff) {
-			delete(l.buckets, id)
+	for keyID, tokenBucket := range l.buckets {
+		if tokenBucket.lastAccess.Before(cutoff) {
+			delete(l.buckets, keyID)
 		}
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -62,14 +62,14 @@ func New(dbPath string) (*Store, error) {
 	writeDB.SetMaxOpenConns(1)
 	writeDB.SetMaxIdleConns(1)
 
-	s := &Store{readDB: readDB, writeDB: writeDB}
-	if err := s.migrate(); err != nil {
+	dataStore := &Store{readDB: readDB, writeDB: writeDB}
+	if err := dataStore.migrate(); err != nil {
 		readDB.Close()
 		writeDB.Close()
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 
-	return s, nil
+	return dataStore, nil
 }
 
 func (s *Store) Close() error {
@@ -104,8 +104,8 @@ func (s *Store) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_usage_logs_created ON usage_logs(created_at)`,
 	}
 
-	for _, m := range migrations {
-		if _, err := s.writeDB.Exec(m); err != nil {
+	for _, migration := range migrations {
+		if _, err := s.writeDB.Exec(migration); err != nil {
 			return fmt.Errorf("exec migration: %w", err)
 		}
 	}
@@ -126,20 +126,20 @@ func (s *Store) CreateKey(name, keyHash, keyPrefix string, rateLimit int) (int64
 
 // GetKeyByHash looks up an active (non-revoked) key by its SHA-256 hash.
 func (s *Store) GetKeyByHash(hash string) (*APIKey, error) {
-	var k APIKey
+	var apiKey APIKey
 	var revoked int
 	err := s.readDB.QueryRow(
 		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked
 		 FROM api_keys WHERE key_hash = ? AND revoked = 0`, hash,
-	).Scan(&k.ID, &k.Name, &k.KeyHash, &k.KeyPrefix, &k.RateLimit, &k.CreatedAt, &revoked)
+	).Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyHash, &apiKey.KeyPrefix, &apiKey.RateLimit, &apiKey.CreatedAt, &revoked)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	k.Revoked = revoked != 0
-	return &k, nil
+	apiKey.Revoked = revoked != 0
+	return &apiKey, nil
 }
 
 // ListKeys returns all API keys (for admin display).
@@ -154,13 +154,13 @@ func (s *Store) ListKeys() ([]APIKey, error) {
 
 	var keys []APIKey
 	for rows.Next() {
-		var k APIKey
+		var apiKey APIKey
 		var revoked int
-		if err := rows.Scan(&k.ID, &k.Name, &k.KeyPrefix, &k.RateLimit, &k.CreatedAt, &revoked); err != nil {
+		if err := rows.Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyPrefix, &apiKey.RateLimit, &apiKey.CreatedAt, &revoked); err != nil {
 			return nil, err
 		}
-		k.Revoked = revoked != 0
-		keys = append(keys, k)
+		apiKey.Revoked = revoked != 0
+		keys = append(keys, apiKey)
 	}
 	return keys, rows.Err()
 }
@@ -171,8 +171,8 @@ func (s *Store) RevokeKey(id int64) error {
 	if err != nil {
 		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
+	rowsAffected, _ := res.RowsAffected()
+	if rowsAffected == 0 {
 		return fmt.Errorf("key not found")
 	}
 	return nil
@@ -216,12 +216,12 @@ func (s *Store) GetUsageStats(keyID *int64, since *time.Time) ([]UsageStat, erro
 
 	var stats []UsageStat
 	for rows.Next() {
-		var st UsageStat
-		if err := rows.Scan(&st.APIKeyID, &st.KeyName, &st.Model, &st.TotalRequests,
-			&st.TotalPrompt, &st.TotalCompletion, &st.TotalTokens, &st.Status); err != nil {
+		var usageStat UsageStat
+		if err := rows.Scan(&usageStat.APIKeyID, &usageStat.KeyName, &usageStat.Model, &usageStat.TotalRequests,
+			&usageStat.TotalPrompt, &usageStat.TotalCompletion, &usageStat.TotalTokens, &usageStat.Status); err != nil {
 			return nil, err
 		}
-		stats = append(stats, st)
+		stats = append(stats, usageStat)
 	}
 	return stats, rows.Err()
 }


### PR DESCRIPTION
## Summary
- Replaces single-letter and abbreviated variable names with descriptive alternatives across all 5 Go packages
- `s` → `dataStore`, `h` → `handler`, `k` → `apiKey`, `b` → `tokenBucket`, `l` → `limiter`
- `rp` → `reverseProxy`, `f` → `flusher`, `st` → `usageStat`, `n` → `rowsAffected`
- `rlMu/rlTokens/rlLast` → `rateLimitMu/rateLimitTokens/rateLimitLastTime`
- Pure renames — no logic changes (81 insertions, 81 deletions)

## Test plan
- [ ] CI build passes (`go build ./...`)
- [ ] CI lint passes (`go vet`, `gofmt`)
- [ ] Verify no behavioral changes via manual smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)