### PR TITLE
feat(backend): BE PR 1 — store layer + analytics + registration_events backfill + credits_charged plumbing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3
@@ -32,6 +34,7 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.DEV_SERVER_SSH_KEY }}
           ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
+          ADMIN_BOOTSTRAP_TOKEN: ${{ secrets.ADMIN_BOOTSTRAP_TOKEN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
         run: |
@@ -49,6 +52,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no sk@100.108.60.90 "export KUBECONFIG=/home/sk/.kube/config && \
             sudo kubectl -n local-ai create secret generic proxy-secret \
               --from-literal=ADMIN_KEY='${ADMIN_KEY}' \
+              --from-literal=ADMIN_BOOTSTRAP_TOKEN='${ADMIN_BOOTSTRAP_TOKEN}' \
               --from-literal=DATABASE_URL='${DATABASE_URL}' \
               --dry-run=client -o yaml | sudo kubectl apply -f -"
 
@@ -69,5 +73,5 @@ jobs:
              sudo kubectl apply -f deploy/k8s/service.yaml && \
              sudo kubectl apply -f deploy/k8s/ingress.yaml && \
              sudo kubectl apply -f deploy/k8s/deployment.yaml && \
-             sudo kubectl -n local-ai rollout restart deployment/ai-proxy && \
+             sudo kubectl -n local-ai set image deployment/ai-proxy ai-proxy=local-ai-proxy:${SHORT_SHA} && \
              sudo kubectl -n local-ai rollout status deployment/ai-proxy --timeout=120s"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,9 @@ jobs:
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
+          SHORT_SHA="${IMAGE_TAG:0:12}"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
           # Copy source to server and build Docker image there
           scp -o StrictHostKeyChecking=no -r cmd/ internal/ deploy/ go.mod sk@100.108.60.90:~/local-ai-proxy/
 
@@ -49,24 +52,22 @@ jobs:
               --from-literal=DATABASE_URL='${DATABASE_URL}' \
               --dry-run=client -o yaml | sudo kubectl apply -f -"
 
-          ssh -o StrictHostKeyChecking=no sk@100.108.60.90 << 'DEPLOY_EOF'
-            export KUBECONFIG=/home/sk/.kube/config
-            cd ~/local-ai-proxy
-
-            # Build Docker image
-            sudo docker build -f deploy/Dockerfile -t local-ai-proxy:latest .
-
-            # Import into k3s containerd
-            sudo docker save local-ai-proxy:latest | sudo k3s ctr images import -
-
-            # Apply k8s manifests
-            sudo kubectl apply -f deploy/k8s/namespace.yaml
-            sudo kubectl apply -f deploy/k8s/pvc.yaml
-            sudo kubectl apply -f deploy/k8s/service.yaml
-            sudo kubectl apply -f deploy/k8s/ingress.yaml
-            sudo kubectl apply -f deploy/k8s/deployment.yaml
-
-            # Restart to pick up new image
-            sudo kubectl -n local-ai rollout restart deployment/ai-proxy
-            sudo kubectl -n local-ai rollout status deployment/ai-proxy --timeout=120s
-          DEPLOY_EOF
+          # Inline the version metadata so the remote shell sees concrete values.
+          ssh -o StrictHostKeyChecking=no sk@100.108.60.90 \
+            "export KUBECONFIG=/home/sk/.kube/config && \
+             cd ~/local-ai-proxy && \
+             sudo docker build \
+               --build-arg GIT_SHA='${SHORT_SHA}' \
+               --build-arg BUILD_TIME='${BUILD_TIME}' \
+               -f deploy/Dockerfile \
+               -t local-ai-proxy:${SHORT_SHA} \
+               -t local-ai-proxy:latest \
+               . && \
+             sudo docker save local-ai-proxy:${SHORT_SHA} local-ai-proxy:latest | sudo k3s ctr images import - && \
+             sudo kubectl apply -f deploy/k8s/namespace.yaml && \
+             sudo kubectl apply -f deploy/k8s/pvc.yaml && \
+             sudo kubectl apply -f deploy/k8s/service.yaml && \
+             sudo kubectl apply -f deploy/k8s/ingress.yaml && \
+             sudo kubectl apply -f deploy/k8s/deployment.yaml && \
+             sudo kubectl -n local-ai rollout restart deployment/ai-proxy && \
+             sudo kubectl -n local-ai rollout status deployment/ai-proxy --timeout=120s"

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -26,6 +26,15 @@ import (
 	"github.com/krishna/local-ai-proxy/internal/user"
 )
 
+// Populated at build time via -ldflags "-X main.version=... -X main.buildTime=...".
+// See deploy/Dockerfile. Must be string-typed package-level vars for -X to
+// take effect; otherwise the flag is silently ignored and these stay at
+// their defaults.
+var (
+	version   = "dev"
+	buildTime = "unknown"
+)
+
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -101,6 +110,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Backfill registration_events for pre-existing users and service accounts
+	if err := db.BackfillRegistrationEvents(); err != nil {
+		slog.Error("backfill registration events error", "error", err)
+		os.Exit(1)
+	}
+
 	// Seed default model pricing (idempotent)
 	if err := credits.SeedDefaultPricing(db); err != nil {
 		slog.Error("seed pricing error", "error", err)
@@ -170,7 +185,7 @@ func main() {
 	defer stop()
 
 	go func() {
-		slog.Info("proxy listening", "port", cfg.Port)
+		slog.Info("proxy listening", "port", cfg.Port, "version", version, "build_time", buildTime)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)
 			os.Exit(1)

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,9 +1,13 @@
 FROM golang:1.26-alpine AS builder
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
 WORKDIR /src
 COPY go.mod ./
 COPY . .
 RUN go mod tidy
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /proxy ./cmd/proxy
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w -X main.version=${GIT_SHA} -X main.buildTime=${BUILD_TIME}" \
+    -o /proxy ./cmd/proxy
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -40,6 +40,12 @@ spec:
                 secretKeyRef:
                   name: proxy-secret
                   key: ADMIN_KEY
+            - name: ADMIN_BOOTSTRAP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-secret
+                  key: ADMIN_BOOTSTRAP_TOKEN
+                  optional: true
             - name: LOG_LEVEL
               value: "info"
           livenessProbe:

--- a/internal/admin/session_auth_test.go
+++ b/internal/admin/session_auth_test.go
@@ -153,28 +153,51 @@ func TestAdmin_BothHeaders_XAdminKeyWins(t *testing.T) {
 	}
 }
 
-func TestAdmin_Bearer_PerSessionRateLimit(t *testing.T) {
-	h, s := setupAdminTest(t)
+// TestSessionLimiter_PerSessionCap drives the limiter through its full
+// capacity + refill cycle against a fake clock. The previous HTTP
+// integration version of this test was flaky: it burst PerSessionRateLimit
+// requests and asserted the next one was rejected, but the 5 tok/sec
+// wall-clock refill meant a slow CI loop could accrue enough tokens to
+// let subsequent requests slip through. This version freezes the clock
+// so the assertion is exact.
+func TestSessionLimiter_PerSessionCap(t *testing.T) {
+	t0 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := t0
+	lim := &sessionLimiter{
+		buckets: make(map[string]*sessionBucket),
+		nowFn:   func() time.Time { return clock },
+	}
+	const key = "session-cap"
 
-	token := createSession(t, s, "ratelimit-admin@example.com", "admin", time.Hour, true)
-
-	// Per-session bucket is 300/min with a 5 tok/sec refill. Burst past the
-	// capacity and assert we see a 429 within a margin that tolerates the
-	// wall-clock refill that accumulates while the loop runs.
-	const maxAttempts = PerSessionRateLimit + 50
-	sawLimit := false
-	for i := 0; i < maxAttempts; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/api/admin/keys", nil)
-		req.Header.Set("Authorization", "Bearer "+token)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		if rec.Code == http.StatusTooManyRequests {
-			sawLimit = true
-			break
+	for i := 0; i < PerSessionRateLimit; i++ {
+		if !lim.Allow(key) {
+			t.Fatalf("request %d/%d should be allowed on a fresh bucket", i+1, PerSessionRateLimit)
 		}
 	}
-	if !sawLimit {
-		t.Errorf("expected 429 within %d requests, never rate-limited", maxAttempts)
+	if lim.Allow(key) {
+		t.Fatal("expected bucket to be exhausted after PerSessionRateLimit requests")
+	}
+
+	// Advance 12s → 60 tokens refilled (5 tok/sec). Exactly 60 must pass.
+	clock = t0.Add(12 * time.Second)
+	for i := 0; i < 60; i++ {
+		if !lim.Allow(key) {
+			t.Fatalf("after 12s refill, request %d/60 should be allowed", i+1)
+		}
+	}
+	if lim.Allow(key) {
+		t.Fatal("refilled tokens should be exhausted after 60 requests")
+	}
+
+	// Advance well past capacity-in-seconds → refill caps at PerSessionRateLimit.
+	clock = t0.Add(1 * time.Hour)
+	for i := 0; i < PerSessionRateLimit; i++ {
+		if !lim.Allow(key) {
+			t.Fatalf("after long refill (capped), request %d/%d should be allowed", i+1, PerSessionRateLimit)
+		}
+	}
+	if lim.Allow(key) {
+		t.Fatal("refill must cap at PerSessionRateLimit, not overflow")
 	}
 }
 

--- a/internal/admin/session_auth_test.go
+++ b/internal/admin/session_auth_test.go
@@ -158,24 +158,23 @@ func TestAdmin_Bearer_PerSessionRateLimit(t *testing.T) {
 
 	token := createSession(t, s, "ratelimit-admin@example.com", "admin", time.Hour, true)
 
-	// Per-session bucket is 300/min. Exhaust the bucket then confirm 429.
-	for i := 0; i < 300; i++ {
+	// Per-session bucket is 300/min with a 5 tok/sec refill. Burst past the
+	// capacity and assert we see a 429 within a margin that tolerates the
+	// wall-clock refill that accumulates while the loop runs.
+	const maxAttempts = PerSessionRateLimit + 50
+	sawLimit := false
+	for i := 0; i < maxAttempts; i++ {
 		req := httptest.NewRequest(http.MethodGet, "/api/admin/keys", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
 		if rec.Code == http.StatusTooManyRequests {
-			t.Fatalf("request %d should not be rate limited yet", i+1)
+			sawLimit = true
+			break
 		}
 	}
-
-	// The 301st should be rate-limited
-	req := httptest.NewRequest(http.MethodGet, "/api/admin/keys", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusTooManyRequests {
-		t.Errorf("expected 429 after exhausting per-session bucket, got %d", rec.Code)
+	if !sawLimit {
+		t.Errorf("expected 429 within %d requests, never rate-limited", maxAttempts)
 	}
 }
 

--- a/internal/admin/session_limiter.go
+++ b/internal/admin/session_limiter.go
@@ -26,9 +26,13 @@ type sessionBucket struct {
 
 // sessionLimiter manages one token bucket per active admin session,
 // keyed by the session's token hash. 300 req/min (5 tokens/sec refill).
+//
+// nowFn is the clock source (injected for deterministic tests); nil
+// means wall clock.
 type sessionLimiter struct {
 	mu      sync.Mutex
 	buckets map[string]*sessionBucket
+	nowFn   func() time.Time
 }
 
 func newSessionLimiter() *sessionLimiter {
@@ -43,8 +47,16 @@ func newSessionLimiter() *sessionLimiter {
 	return limiter
 }
 
+func (l *sessionLimiter) now() time.Time {
+	if l.nowFn != nil {
+		return l.nowFn()
+	}
+	return time.Now()
+}
+
 // Allow consumes one token for the given session hash. The bucket is
-// created on first use and refilled based on wall-clock elapsed time.
+// created on first use and refilled based on elapsed time from the
+// limiter's clock.
 func (l *sessionLimiter) Allow(tokenHash string) bool {
 	const (
 		capacity   = float64(PerSessionRateLimit)
@@ -54,7 +66,7 @@ func (l *sessionLimiter) Allow(tokenHash string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	now := time.Now()
+	now := l.now()
 	bucket, exists := l.buckets[tokenHash]
 	if !exists {
 		l.buckets[tokenHash] = &sessionBucket{
@@ -80,7 +92,7 @@ func (l *sessionLimiter) Allow(tokenHash string) bool {
 func (l *sessionLimiter) prune() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	cutoff := time.Now().Add(-sessionIdleCutoff)
+	cutoff := l.now().Add(-sessionIdleCutoff)
 	for hash, b := range l.buckets {
 		if b.lastAccess.Before(cutoff) {
 			delete(l.buckets, hash)

--- a/internal/credits/middleware_test.go
+++ b/internal/credits/middleware_test.go
@@ -22,9 +22,9 @@ func setupTestStore(t *testing.T) *store.Store {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	t.Cleanup(func() {
-		pool := s.Pool()
+	wipe := func() {
 		c := context.Background()
+		pool := s.Pool()
 		// DELETE rather than DROP so concurrent tests don't race on Postgres
 		// catalog locks during migrate.
 		_, _ = pool.Exec(c, "DELETE FROM registration_events")
@@ -39,22 +39,12 @@ func setupTestStore(t *testing.T) *store.Store {
 		_, _ = pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = pool.Exec(c, "DELETE FROM users")
 		_, _ = pool.Exec(c, "DELETE FROM accounts")
+	}
+	wipe()
+	t.Cleanup(func() {
+		wipe()
 		s.Close()
 	})
-
-	pool := s.Pool()
-	_, _ = pool.Exec(ctx, "DELETE FROM registration_events")
-	_, _ = pool.Exec(ctx, "DELETE FROM credit_holds")
-	_, _ = pool.Exec(ctx, "DELETE FROM credit_transactions")
-	_, _ = pool.Exec(ctx, "DELETE FROM account_usage_stats")
-	_, _ = pool.Exec(ctx, "DELETE FROM credit_balances")
-	_, _ = pool.Exec(ctx, "DELETE FROM credit_pricing")
-	_, _ = pool.Exec(ctx, "DELETE FROM registration_tokens")
-	_, _ = pool.Exec(ctx, "DELETE FROM usage_logs")
-	_, _ = pool.Exec(ctx, "DELETE FROM user_sessions")
-	_, _ = pool.Exec(ctx, "DELETE FROM api_keys")
-	_, _ = pool.Exec(ctx, "DELETE FROM users")
-	_, _ = pool.Exec(ctx, "DELETE FROM accounts")
 	return s
 }
 

--- a/internal/credits/sweeper_test.go
+++ b/internal/credits/sweeper_test.go
@@ -70,7 +70,7 @@ func TestStartSweeper_CleansUpOldHolds(t *testing.T) {
 	_ = db.AddCredits(accID, 1000, "grant")
 
 	holdID, _ := db.ReserveCredits(accID, 10)
-	_ = db.SettleHold(holdID, 5)
+	_, _ = db.SettleHold(holdID, 5)
 
 	// Backdate settled_at
 	pool := db.Pool()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -228,13 +228,13 @@ func (h *handler) handleNonStreaming(w http.ResponseWriter, r *http.Request, bod
 		}
 		if ctx.Err() != nil {
 			if key != nil {
-				h.logUsage(key, usageData{Model: model}, time.Since(start), "partial")
+				h.logUsage(key, usageData{Model: model}, time.Since(start), "partial", 0)
 			}
 			return
 		}
 		slog.ErrorContext(ctx, "upstream error", "error", err, "model", model)
 		if key != nil {
-			h.logUsage(key, usageData{Model: model}, time.Since(start), "error")
+			h.logUsage(key, usageData{Model: model}, time.Since(start), "error", 0)
 		}
 		writeError(w, r, http.StatusBadGateway, "upstream_error", "server_error", "Failed to connect to upstream model server")
 		return
@@ -249,7 +249,7 @@ func (h *handler) handleNonStreaming(w http.ResponseWriter, r *http.Request, bod
 		}
 		slog.ErrorContext(ctx, "read response error", "error", err, "model", model)
 		if key != nil {
-			h.logUsage(key, usageData{Model: model}, time.Since(start), "error")
+			h.logUsage(key, usageData{Model: model}, time.Since(start), "error", 0)
 		}
 		writeError(w, r, http.StatusBadGateway, "upstream_error", "server_error", "Failed to read upstream response")
 		return
@@ -266,18 +266,19 @@ func (h *handler) handleNonStreaming(w http.ResponseWriter, r *http.Request, bod
 	}
 
 	// Credit settlement
+	var actualCost float64
 	if creditEnabled {
 		if resp.StatusCode != http.StatusOK {
 			// Upstream error — release hold, no charge
 			h.db.ReleaseHold(holdID)
 		} else {
-			h.settleCredits(holdID, key, &ud, len(respBody), pricing)
+			actualCost = h.settleCredits(holdID, key, &ud, len(respBody), pricing)
 		}
 	}
 
 	// Log usage and record metrics
 	if key != nil {
-		h.logUsage(key, ud, time.Since(start), status)
+		h.logUsage(key, ud, time.Since(start), status, actualCost)
 	}
 	h.metrics.RecordTokens(model, ud.Usage.PromptTokens, ud.Usage.CompletionTokens)
 
@@ -325,13 +326,13 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 		}
 		if ctx.Err() != nil {
 			if key != nil {
-				h.logUsage(key, usageData{Model: model}, time.Since(start), "partial")
+				h.logUsage(key, usageData{Model: model}, time.Since(start), "partial", 0)
 			}
 			return
 		}
 		slog.ErrorContext(ctx, "upstream error", "error", err, "model", model, "stream", true)
 		if key != nil {
-			h.logUsage(key, usageData{Model: model}, time.Since(start), "error")
+			h.logUsage(key, usageData{Model: model}, time.Since(start), "error", 0)
 		}
 		writeError(w, r, http.StatusBadGateway, "upstream_error", "server_error", "Failed to connect to upstream model server")
 		return
@@ -353,7 +354,7 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 			h.db.ReleaseHold(holdID)
 		}
 		if key != nil {
-			h.logUsage(key, usageData{Model: model}, time.Since(start), "error")
+			h.logUsage(key, usageData{Model: model}, time.Since(start), "error", 0)
 		}
 		return
 	}
@@ -407,19 +408,22 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 	}
 
 	// Credit settlement
+	var actualCost float64
 	if creditEnabled {
-		h.settleStreamCredits(holdID, key, &ud, bytesWritten, status, pricing)
+		actualCost = h.settleStreamCredits(holdID, key, &ud, bytesWritten, status, pricing)
 	}
 
 	if key != nil {
-		h.logUsage(key, ud, time.Since(start), status)
+		h.logUsage(key, ud, time.Since(start), status, actualCost)
 	}
 	h.metrics.RecordTokens(model, ud.Usage.PromptTokens, ud.Usage.CompletionTokens)
 }
 
-// settleCredits handles credit settlement for non-streaming responses.
-// Called only for successful (200) upstream responses.
-func (h *handler) settleCredits(holdID int64, key *store.APIKey, ud *usageData, respBodyLen int, pricing *store.CreditPricing) {
+// settleCredits handles credit settlement for non-streaming responses and
+// returns the amount actually charged (0 when the hold had already been
+// released by the sweeper). Called only for successful (200) upstream
+// responses.
+func (h *handler) settleCredits(holdID int64, key *store.APIKey, ud *usageData, respBodyLen int, pricing *store.CreditPricing) float64 {
 	promptTokens := ud.Usage.PromptTokens
 	completionTokens := ud.Usage.CompletionTokens
 
@@ -429,8 +433,9 @@ func (h *handler) settleCredits(holdID int64, key *store.APIKey, ud *usageData, 
 		promptTokens = 0 // prompt cost was in the reserve estimate
 	}
 
-	actualCost := credits.EstimateCost(pricing, promptTokens, completionTokens)
-	if err := h.db.SettleHold(holdID, actualCost); err != nil {
+	estimatedCost := credits.EstimateCost(pricing, promptTokens, completionTokens)
+	charged, err := h.db.SettleHold(holdID, estimatedCost)
+	if err != nil {
 		slog.Error("settle hold error", "error", err, "hold_id", holdID)
 	}
 
@@ -440,13 +445,15 @@ func (h *handler) settleCredits(holdID int64, key *store.APIKey, ud *usageData, 
 			slog.Warn("update usage stats error", "error", err, "account_id", *key.AccountID, "model", ud.Model)
 		}
 	}
+	return charged
 }
 
-// settleStreamCredits handles credit settlement for streaming responses.
-func (h *handler) settleStreamCredits(holdID int64, key *store.APIKey, ud *usageData, bytesWritten int, status string, pricing *store.CreditPricing) {
+// settleStreamCredits handles credit settlement for streaming responses and
+// returns the amount actually charged.
+func (h *handler) settleStreamCredits(holdID int64, key *store.APIKey, ud *usageData, bytesWritten int, status string, pricing *store.CreditPricing) float64 {
 	if status == "error" && bytesWritten == 0 {
 		h.db.ReleaseHold(holdID)
-		return
+		return 0
 	}
 
 	promptTokens := ud.Usage.PromptTokens
@@ -458,8 +465,9 @@ func (h *handler) settleStreamCredits(holdID int64, key *store.APIKey, ud *usage
 		promptTokens = 0
 	}
 
-	actualCost := credits.EstimateCost(pricing, promptTokens, completionTokens)
-	if err := h.db.SettleHold(holdID, actualCost); err != nil {
+	estimatedCost := credits.EstimateCost(pricing, promptTokens, completionTokens)
+	charged, err := h.db.SettleHold(holdID, estimatedCost)
+	if err != nil {
 		slog.Error("settle hold error", "error", err, "hold_id", holdID, "stream", true)
 	}
 
@@ -468,9 +476,10 @@ func (h *handler) settleStreamCredits(holdID int64, key *store.APIKey, ud *usage
 			slog.Warn("update usage stats error", "error", err, "account_id", *key.AccountID, "model", ud.Model)
 		}
 	}
+	return charged
 }
 
-func (h *handler) logUsage(key *store.APIKey, ud usageData, duration time.Duration, status string) {
+func (h *handler) logUsage(key *store.APIKey, ud usageData, duration time.Duration, status string, creditsCharged float64) {
 	if key == nil {
 		return
 	}
@@ -482,6 +491,7 @@ func (h *handler) logUsage(key *store.APIKey, ud usageData, duration time.Durati
 		TotalTokens:      ud.Usage.TotalTokens,
 		DurationMs:       duration.Milliseconds(),
 		Status:           status,
+		CreditsCharged:   creditsCharged,
 	}
 	select {
 	case h.usageCh <- entry:

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -717,7 +717,7 @@ func TestLogUsage_NilKey(t *testing.T) {
 	h := &handler{usageCh: usageCh}
 
 	// Should not panic and should not send to channel
-	h.logUsage(nil, usageData{Model: "test"}, time.Second, "completed")
+	h.logUsage(nil, usageData{Model: "test"}, time.Second, "completed", 0)
 
 	select {
 	case entry := <-usageCh:
@@ -736,7 +736,7 @@ func TestLogUsage_ChannelFull(t *testing.T) {
 	key := testAPIKey()
 
 	// Should not block — entry is dropped silently
-	h.logUsage(key, usageData{Model: "test"}, time.Second, "completed")
+	h.logUsage(key, usageData{Model: "test"}, time.Second, "completed", 0)
 
 	// Drain the original entry
 	<-usageCh
@@ -760,7 +760,7 @@ func TestLogUsage_Success(t *testing.T) {
 	ud.Usage.CompletionTokens = 5
 	ud.Usage.TotalTokens = 15
 
-	h.logUsage(key, ud, 500*time.Millisecond, "completed")
+	h.logUsage(key, ud, 500*time.Millisecond, "completed", 0.12)
 
 	select {
 	case entry := <-usageCh:
@@ -784,6 +784,9 @@ func TestLogUsage_Success(t *testing.T) {
 		}
 		if entry.Status != "completed" {
 			t.Errorf("expected status 'completed', got %q", entry.Status)
+		}
+		if diff := entry.CreditsCharged - 0.12; diff < -0.0001 || diff > 0.0001 {
+			t.Errorf("expected credits_charged=0.12, got %f", entry.CreditsCharged)
 		}
 	case <-time.After(time.Second):
 		t.Error("timed out waiting for usage entry")
@@ -1063,6 +1066,59 @@ func TestCreditIntegration_SettlesAfterResponse(t *testing.T) {
 	}
 	if bal.Reserved != 0 {
 		t.Errorf("expected reserved 0 after settlement, got %f", bal.Reserved)
+	}
+
+	// The proxy must forward the settled cost to the async usage writer so
+	// the column `usage_logs.credits_charged` ends up non-zero.
+	select {
+	case entry := <-usageCh:
+		if entry.CreditsCharged <= 0 {
+			t.Errorf("expected CreditsCharged > 0 after successful settlement, got %f", entry.CreditsCharged)
+		}
+		// Cost must match balance delta.
+		cost := 1000 - bal.Balance
+		if diff := entry.CreditsCharged - cost; diff < -0.0001 || diff > 0.0001 {
+			t.Errorf("expected CreditsCharged=%f to match balance delta, got %f", cost, entry.CreditsCharged)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for usage entry after settlement")
+	}
+}
+
+func TestCreditIntegration_LegacyKeyLogsZeroCredits(t *testing.T) {
+	db := setupTestDB(t)
+
+	ollamaResp := map[string]any{
+		"id": "chatcmpl-legacy", "object": "chat.completion", "model": "llama3.1:8b",
+		"choices": []map[string]any{{"message": map[string]any{"role": "assistant", "content": "Hi"}}},
+		"usage":   map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+	}
+	upstream := mockOllamaChatNonStreaming(http.StatusOK, ollamaResp)
+	defer upstream.Close()
+
+	usageCh := make(chan store.UsageEntry, 10)
+	h := NewHandler(mustParseURL(t, upstream.URL), usageCh, 52428800, db, nil)
+
+	reqBody := `{"model":"llama3.1:8b","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	// Legacy admin key: no AccountID, so credit plumbing is bypassed.
+	key := &store.APIKey{ID: 1, Name: "legacy"}
+	req = addKeyToRequest(req, key)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+
+	select {
+	case entry := <-usageCh:
+		if entry.CreditsCharged != 0 {
+			t.Errorf("expected CreditsCharged=0 for legacy key, got %f", entry.CreditsCharged)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for usage entry")
 	}
 }
 

--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -1,0 +1,296 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// UsageFilter constrains the set of usage_logs rows aggregated by the
+// analytics methods. All fields are optional; zero-valued fields skip that
+// filter. Filters compose with AND semantics.
+type UsageFilter struct {
+	Since     *time.Time
+	Until     *time.Time
+	AccountID *int64
+	APIKeyID  *int64
+	UserID    *int64
+	Model     *string
+}
+
+// UsageSummary is the aggregated response for GetUsageSummary.
+type UsageSummary struct {
+	Requests         int
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+	Credits          float64
+	AvgDurationMs    float64
+	Errors           int
+}
+
+// ModelUsageRow is one row of GetUsageByModel.
+type ModelUsageRow struct {
+	Model         string
+	Requests      int
+	TotalTokens   int
+	Credits       float64
+	AvgDurationMs float64
+}
+
+// OwnerUsageRow is one row of GetUsageByUser. Either the user fields or the
+// account fields will be populated depending on whether the key was
+// user-owned, service-owned, or an unattributed admin key.
+type OwnerUsageRow struct {
+	UserID      *int64
+	Email       *string
+	Name        *string
+	AccountID   *int64
+	AccountName *string
+	AccountType *string
+	Requests    int
+	TotalTokens int
+	Credits     float64
+	KeyCount    int
+}
+
+// TimeseriesBucket is one bucket of GetUsageTimeseries.
+type TimeseriesBucket struct {
+	Bucket           time.Time
+	Requests         int
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+	Credits          float64
+	Errors           int
+}
+
+// buildUsageFilterClause appends WHERE conditions derived from f to the given
+// string builder, starting at argIdx. It returns the updated args slice and
+// the next argument index.
+func buildUsageFilterClause(sb *strings.Builder, args []any, f UsageFilter, argIdx int) ([]any, int) {
+	if f.Since != nil {
+		fmt.Fprintf(sb, " AND ul.created_at >= $%d", argIdx)
+		args = append(args, *f.Since)
+		argIdx++
+	}
+	if f.Until != nil {
+		fmt.Fprintf(sb, " AND ul.created_at < $%d", argIdx)
+		args = append(args, *f.Until)
+		argIdx++
+	}
+	if f.AccountID != nil {
+		fmt.Fprintf(sb, " AND k.account_id = $%d", argIdx)
+		args = append(args, *f.AccountID)
+		argIdx++
+	}
+	if f.APIKeyID != nil {
+		fmt.Fprintf(sb, " AND ul.api_key_id = $%d", argIdx)
+		args = append(args, *f.APIKeyID)
+		argIdx++
+	}
+	if f.UserID != nil {
+		fmt.Fprintf(sb, " AND k.user_id = $%d", argIdx)
+		args = append(args, *f.UserID)
+		argIdx++
+	}
+	if f.Model != nil {
+		fmt.Fprintf(sb, " AND ul.model = $%d", argIdx)
+		args = append(args, *f.Model)
+		argIdx++
+	}
+	return args, argIdx
+}
+
+// GetUsageSummary returns a single aggregated summary row for the window.
+func (s *Store) GetUsageSummary(f UsageFilter) (UsageSummary, error) {
+	var sb strings.Builder
+	sb.WriteString(
+		`SELECT
+		   COUNT(*),
+		   COALESCE(SUM(ul.prompt_tokens), 0),
+		   COALESCE(SUM(ul.completion_tokens), 0),
+		   COALESCE(SUM(ul.total_tokens), 0),
+		   COALESCE(SUM(ul.credits_charged), 0),
+		   COALESCE(AVG(ul.duration_ms), 0),
+		   COALESCE(SUM(CASE WHEN ul.status='error' THEN 1 ELSE 0 END), 0)
+		 FROM usage_logs ul
+		 JOIN api_keys k ON ul.api_key_id = k.id
+		 WHERE 1=1`)
+	args, _ := buildUsageFilterClause(&sb, nil, f, 1)
+
+	var summary UsageSummary
+	err := s.pool.QueryRow(context.Background(), sb.String(), args...).Scan(
+		&summary.Requests,
+		&summary.PromptTokens,
+		&summary.CompletionTokens,
+		&summary.TotalTokens,
+		&summary.Credits,
+		&summary.AvgDurationMs,
+		&summary.Errors,
+	)
+	if err != nil {
+		return UsageSummary{}, fmt.Errorf("usage summary: %w", err)
+	}
+	return summary, nil
+}
+
+// GetUsageByModel returns per-model aggregates, ordered by total_tokens desc.
+func (s *Store) GetUsageByModel(f UsageFilter) ([]ModelUsageRow, error) {
+	var sb strings.Builder
+	sb.WriteString(
+		`SELECT
+		   ul.model,
+		   COUNT(*),
+		   COALESCE(SUM(ul.total_tokens), 0),
+		   COALESCE(SUM(ul.credits_charged), 0),
+		   COALESCE(AVG(ul.duration_ms), 0)
+		 FROM usage_logs ul
+		 JOIN api_keys k ON ul.api_key_id = k.id
+		 WHERE 1=1`)
+	args, _ := buildUsageFilterClause(&sb, nil, f, 1)
+	sb.WriteString(` GROUP BY ul.model ORDER BY COALESCE(SUM(ul.total_tokens), 0) DESC`)
+
+	rows, err := s.pool.Query(context.Background(), sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage by model: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]ModelUsageRow, 0)
+	for rows.Next() {
+		var r ModelUsageRow
+		if err := rows.Scan(&r.Model, &r.Requests, &r.TotalTokens, &r.Credits, &r.AvgDurationMs); err != nil {
+			return nil, fmt.Errorf("scan model row: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GetUsageByUser returns per-owner aggregates, ordered by total_tokens desc.
+// "Owner" is the human user if the key has a user_id, otherwise the service
+// account if the key has only an account_id, otherwise neither (legacy
+// admin-created keys).
+func (s *Store) GetUsageByUser(f UsageFilter) ([]OwnerUsageRow, error) {
+	var sb strings.Builder
+	sb.WriteString(
+		`SELECT
+		   k.user_id,
+		   usr.email,
+		   usr.name,
+		   k.account_id,
+		   a.name,
+		   a.type,
+		   COUNT(*),
+		   COALESCE(SUM(ul.total_tokens), 0),
+		   COALESCE(SUM(ul.credits_charged), 0),
+		   COUNT(DISTINCT k.id)
+		 FROM usage_logs ul
+		 JOIN api_keys k ON ul.api_key_id = k.id
+		 LEFT JOIN users usr ON usr.id = k.user_id
+		 LEFT JOIN accounts a ON a.id = k.account_id
+		 WHERE 1=1`)
+	args, _ := buildUsageFilterClause(&sb, nil, f, 1)
+	sb.WriteString(
+		` GROUP BY k.user_id, usr.email, usr.name, k.account_id, a.name, a.type
+		  ORDER BY COALESCE(SUM(ul.total_tokens), 0) DESC`)
+
+	rows, err := s.pool.Query(context.Background(), sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage by user: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]OwnerUsageRow, 0)
+	for rows.Next() {
+		var r OwnerUsageRow
+		if err := rows.Scan(&r.UserID, &r.Email, &r.Name, &r.AccountID, &r.AccountName, &r.AccountType,
+			&r.Requests, &r.TotalTokens, &r.Credits, &r.KeyCount); err != nil {
+			return nil, fmt.Errorf("scan owner row: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GetUsageTimeseries returns time-bucketed aggregates. interval must be
+// "hour" or "day". Gap-filling is the caller's responsibility.
+func (s *Store) GetUsageTimeseries(f UsageFilter, interval string) ([]TimeseriesBucket, error) {
+	// Validate interval against a small allowlist — date_trunc accepts many
+	// values but handler contract is hour/day.
+	switch interval {
+	case "hour", "day":
+	default:
+		return nil, fmt.Errorf("invalid interval %q: must be 'hour' or 'day'", interval)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(
+		`SELECT
+		   date_trunc($1, ul.created_at),
+		   COUNT(*),
+		   COALESCE(SUM(ul.prompt_tokens), 0),
+		   COALESCE(SUM(ul.completion_tokens), 0),
+		   COALESCE(SUM(ul.total_tokens), 0),
+		   COALESCE(SUM(ul.credits_charged), 0),
+		   COALESCE(SUM(CASE WHEN ul.status='error' THEN 1 ELSE 0 END), 0)
+		 FROM usage_logs ul
+		 JOIN api_keys k ON ul.api_key_id = k.id
+		 WHERE 1=1`)
+
+	args := []any{interval}
+	args, _ = buildUsageFilterClause(&sb, args, f, 2)
+	sb.WriteString(` GROUP BY 1 ORDER BY 1`)
+
+	rows, err := s.pool.Query(context.Background(), sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage timeseries: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]TimeseriesBucket, 0)
+	for rows.Next() {
+		var b TimeseriesBucket
+		if err := rows.Scan(&b.Bucket, &b.Requests, &b.PromptTokens, &b.CompletionTokens,
+			&b.TotalTokens, &b.Credits, &b.Errors); err != nil {
+			return nil, fmt.Errorf("scan bucket: %w", err)
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// BackfillRegistrationEvents inserts a registration_events row with
+// source='backfill' for every existing users/accounts row that is not yet
+// tracked. Idempotent: uses WHERE NOT EXISTS guards.
+func (s *Store) BackfillRegistrationEvents() error {
+	ctx := context.Background()
+
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO registration_events (kind, account_id, user_id, source, created_at)
+		 SELECT 'user', u.account_id, u.id, 'backfill', u.created_at
+		 FROM users u
+		 WHERE NOT EXISTS (
+		   SELECT 1 FROM registration_events e
+		   WHERE e.user_id = u.id AND e.kind = 'user'
+		 )`,
+	); err != nil {
+		return fmt.Errorf("backfill user events: %w", err)
+	}
+
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO registration_events (kind, account_id, source, created_at)
+		 SELECT 'service', a.id, 'backfill', a.created_at
+		 FROM accounts a
+		 WHERE a.type = 'service'
+		   AND NOT EXISTS (
+		     SELECT 1 FROM registration_events e
+		     WHERE e.account_id = a.id AND e.kind = 'service'
+		   )`,
+	); err != nil {
+		return fmt.Errorf("backfill service events: %w", err)
+	}
+	return nil
+}

--- a/internal/store/analytics_test.go
+++ b/internal/store/analytics_test.go
@@ -1,0 +1,585 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// seedAnalyticsFixture creates a small, deterministic dataset for analytics
+// tests: two accounts (one personal with a user, one service), three keys,
+// two models, 9 usage rows across a 3-day window.
+type analyticsFixture struct {
+	personalAccountID int64
+	serviceAccountID  int64
+	userID            int64
+	userEmail         string
+	userName          string
+	keyUser           int64 // user-owned key
+	keyUser2          int64 // second user-owned key (personal account)
+	keyService        int64 // service-account key
+	t0                time.Time
+}
+
+func seedAnalyticsFixture(t *testing.T, s *Store) analyticsFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	personalAccountID, userID, err := s.RegisterUser("alice@example.com", "hash", "Alice")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+
+	svcAccountID, err := s.CreateAccount("svc-1", "service")
+	if err != nil {
+		t.Fatalf("CreateAccount service: %v", err)
+	}
+	if err := s.InitCreditBalance(svcAccountID); err != nil {
+		t.Fatalf("InitCreditBalance: %v", err)
+	}
+
+	keyUser, err := s.CreateKeyForAccount(userID, personalAccountID, "alice-primary", "hash-user-1", "sk-u1", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccount user: %v", err)
+	}
+	keyUser2, err := s.CreateKeyForAccount(userID, personalAccountID, "alice-secondary", "hash-user-2", "sk-u2", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccount user 2: %v", err)
+	}
+	keyService, err := s.CreateKeyForAccountOnly(svcAccountID, "svc-key", "hash-svc-1", "sk-sv1", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccountOnly: %v", err)
+	}
+
+	t0 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+
+	// Model A rows for user (various times, all success).
+	rows := []struct {
+		keyID  int64
+		model  string
+		prompt int
+		comp   int
+		total  int
+		dur    int64
+		credit float64
+		status string
+		offset time.Duration
+	}{
+		{keyUser, "llama3.1:8b", 100, 50, 150, 200, 0.30, "completed", 0 * time.Hour},
+		{keyUser, "llama3.1:8b", 200, 100, 300, 300, 0.60, "completed", 1 * time.Hour},
+		{keyUser, "gpt-4o-mini", 50, 25, 75, 150, 0.15, "completed", 2 * time.Hour},
+		{keyUser2, "llama3.1:8b", 80, 40, 120, 180, 0.24, "completed", 3 * time.Hour},
+		{keyUser2, "gpt-4o-mini", 30, 15, 45, 100, 0.09, "error", 4 * time.Hour},
+		{keyService, "llama3.1:8b", 500, 250, 750, 500, 1.50, "completed", 5 * time.Hour},
+		{keyService, "llama3.1:8b", 600, 300, 900, 600, 1.80, "completed", 25 * time.Hour},
+		{keyService, "gpt-4o-mini", 40, 20, 60, 120, 0.12, "completed", 26 * time.Hour},
+		{keyService, "gpt-4o-mini", 20, 10, 30, 80, 0.06, "error", 27 * time.Hour},
+	}
+
+	for _, r := range rows {
+		_, err := s.pool.Exec(ctx,
+			`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged, created_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			r.keyID, r.model, r.prompt, r.comp, r.total, r.dur, r.status, r.credit, t0.Add(r.offset),
+		)
+		if err != nil {
+			t.Fatalf("insert usage row: %v", err)
+		}
+	}
+
+	// Refresh planner statistics so EXPLAIN tests observe realistic row
+	// counts. Without ANALYZE, fresh PG reports 0 rows per table and picks
+	// whichever index happens to come first alphabetically.
+	if _, err := s.pool.Exec(ctx, "ANALYZE usage_logs, api_keys, users, accounts"); err != nil {
+		t.Fatalf("ANALYZE: %v", err)
+	}
+
+	return analyticsFixture{
+		personalAccountID: personalAccountID,
+		serviceAccountID:  svcAccountID,
+		userID:            userID,
+		userEmail:         "alice@example.com",
+		userName:          "Alice",
+		keyUser:           keyUser,
+		keyUser2:          keyUser2,
+		keyService:        keyService,
+		t0:                t0,
+	}
+}
+
+// seedAnalyticsFixtureLarge inflates the seeded dataset so the planner has
+// enough statistical signal to prefer the selectivity-appropriate indexes in
+// EXPLAIN tests. Called only by the EXPLAIN tests to keep unit-test fixture
+// runs fast.
+func seedAnalyticsFixtureLarge(t *testing.T, s *Store) analyticsFixture {
+	t.Helper()
+	fx := seedAnalyticsFixture(t, s)
+	ctx := context.Background()
+
+	// Insert 2000 rows with selective model/key distribution so the planner
+	// can distinguish between indexes on different columns.
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged, created_at)
+		 SELECT
+		   CASE WHEN i % 3 = 0 THEN $1::bigint WHEN i % 3 = 1 THEN $2::bigint ELSE $3::bigint END,
+		   'model-' || (i % 20),
+		   10, 5, 15, 100, 'completed', 0.01, NOW() - (i * INTERVAL '1 minute')
+		 FROM generate_series(1, 2000) AS i`,
+		fx.keyUser, fx.keyUser2, fx.keyService,
+	); err != nil {
+		t.Fatalf("seed extra rows: %v", err)
+	}
+
+	if _, err := s.pool.Exec(ctx, "ANALYZE usage_logs, api_keys, users, accounts"); err != nil {
+		t.Fatalf("ANALYZE: %v", err)
+	}
+	return fx
+}
+
+func TestGetUsageSummary_Empty(t *testing.T) {
+	s := setupTestStore(t)
+
+	summary, err := s.GetUsageSummary(UsageFilter{})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.Requests != 0 {
+		t.Errorf("expected 0 requests, got %d", summary.Requests)
+	}
+	if summary.TotalTokens != 0 {
+		t.Errorf("expected 0 total tokens, got %d", summary.TotalTokens)
+	}
+	if summary.Credits != 0 {
+		t.Errorf("expected 0 credits, got %f", summary.Credits)
+	}
+	if summary.Errors != 0 {
+		t.Errorf("expected 0 errors, got %d", summary.Errors)
+	}
+}
+
+func TestGetUsageSummary_NoFilter(t *testing.T) {
+	s := setupTestStore(t)
+	seedAnalyticsFixture(t, s)
+
+	summary, err := s.GetUsageSummary(UsageFilter{})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.Requests != 9 {
+		t.Errorf("expected 9 requests, got %d", summary.Requests)
+	}
+	wantTotal := 150 + 300 + 75 + 120 + 45 + 750 + 900 + 60 + 30
+	if summary.TotalTokens != wantTotal {
+		t.Errorf("expected total_tokens=%d, got %d", wantTotal, summary.TotalTokens)
+	}
+	wantPrompt := 100 + 200 + 50 + 80 + 30 + 500 + 600 + 40 + 20
+	if summary.PromptTokens != wantPrompt {
+		t.Errorf("expected prompt_tokens=%d, got %d", wantPrompt, summary.PromptTokens)
+	}
+	if summary.Errors != 2 {
+		t.Errorf("expected 2 errors, got %d", summary.Errors)
+	}
+	// Credits sum: 0.30+0.60+0.15+0.24+0.09+1.50+1.80+0.12+0.06 = 4.86
+	wantCredits := 4.86
+	if diff := summary.Credits - wantCredits; diff < -0.0001 || diff > 0.0001 {
+		t.Errorf("expected credits ~= %f, got %f", wantCredits, summary.Credits)
+	}
+}
+
+func TestGetUsageSummary_FilterByAccountID(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixture(t, s)
+
+	summary, err := s.GetUsageSummary(UsageFilter{AccountID: &fx.serviceAccountID})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.Requests != 4 {
+		t.Errorf("expected 4 service requests, got %d", summary.Requests)
+	}
+	if summary.Errors != 1 {
+		t.Errorf("expected 1 error in service rows, got %d", summary.Errors)
+	}
+}
+
+func TestGetUsageSummary_FilterByAPIKeyID(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixture(t, s)
+
+	summary, err := s.GetUsageSummary(UsageFilter{APIKeyID: &fx.keyUser})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.Requests != 3 {
+		t.Errorf("expected 3 rows for keyUser, got %d", summary.Requests)
+	}
+}
+
+func TestGetUsageSummary_FilterByUserID(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixture(t, s)
+
+	summary, err := s.GetUsageSummary(UsageFilter{UserID: &fx.userID})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.Requests != 5 {
+		t.Errorf("expected 5 rows for userID, got %d", summary.Requests)
+	}
+}
+
+func TestGetUsageSummary_FilterByModel(t *testing.T) {
+	s := setupTestStore(t)
+	seedAnalyticsFixture(t, s)
+
+	model := "gpt-4o-mini"
+	summary, err := s.GetUsageSummary(UsageFilter{Model: &model})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.Requests != 4 {
+		t.Errorf("expected 4 rows for gpt-4o-mini, got %d", summary.Requests)
+	}
+}
+
+func TestGetUsageSummary_FilterByTimeRange(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixture(t, s)
+
+	// Since covers rows at offsets 25, 26, 27 only (fx.t0 + 24h).
+	since := fx.t0.Add(24 * time.Hour)
+	summary, err := s.GetUsageSummary(UsageFilter{Since: &since})
+	if err != nil {
+		t.Fatalf("GetUsageSummary with since: %v", err)
+	}
+	if summary.Requests != 3 {
+		t.Errorf("expected 3 rows since t0+24h, got %d", summary.Requests)
+	}
+
+	// Until excludes later half (offsets 25, 26, 27).
+	until := fx.t0.Add(24 * time.Hour)
+	summary, err = s.GetUsageSummary(UsageFilter{Until: &until})
+	if err != nil {
+		t.Fatalf("GetUsageSummary with until: %v", err)
+	}
+	if summary.Requests != 6 {
+		t.Errorf("expected 6 rows until t0+24h, got %d", summary.Requests)
+	}
+}
+
+func TestGetUsageByModel_OrderedByTokensDesc(t *testing.T) {
+	s := setupTestStore(t)
+	seedAnalyticsFixture(t, s)
+
+	rows, err := s.GetUsageByModel(UsageFilter{})
+	if err != nil {
+		t.Fatalf("GetUsageByModel: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 model rows, got %d", len(rows))
+	}
+	// llama3.1:8b total = 150+300+120+750+900 = 2220
+	// gpt-4o-mini total = 75+45+60+30 = 210
+	if rows[0].Model != "llama3.1:8b" {
+		t.Errorf("expected first model 'llama3.1:8b', got %q", rows[0].Model)
+	}
+	if rows[0].TotalTokens != 2220 {
+		t.Errorf("expected total_tokens=2220, got %d", rows[0].TotalTokens)
+	}
+	if rows[1].Model != "gpt-4o-mini" {
+		t.Errorf("expected second model 'gpt-4o-mini', got %q", rows[1].Model)
+	}
+	if rows[1].TotalTokens != 210 {
+		t.Errorf("expected total_tokens=210, got %d", rows[1].TotalTokens)
+	}
+}
+
+func TestGetUsageByModel_FilterByAccountID(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixture(t, s)
+
+	rows, err := s.GetUsageByModel(UsageFilter{AccountID: &fx.serviceAccountID})
+	if err != nil {
+		t.Fatalf("GetUsageByModel: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	// service account only: llama = 750+900 = 1650, gpt = 60+30 = 90
+	if rows[0].Model != "llama3.1:8b" || rows[0].TotalTokens != 1650 {
+		t.Errorf("unexpected first row: %+v", rows[0])
+	}
+}
+
+func TestGetUsageByUser_ReturnsUserAndServiceRows(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixture(t, s)
+
+	rows, err := s.GetUsageByUser(UsageFilter{})
+	if err != nil {
+		t.Fatalf("GetUsageByUser: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 owner rows, got %d: %+v", len(rows), rows)
+	}
+
+	var userRow, svcRow *OwnerUsageRow
+	for i := range rows {
+		r := rows[i]
+		if r.UserID != nil {
+			userRow = &rows[i]
+		} else if r.AccountID != nil {
+			svcRow = &rows[i]
+		}
+	}
+	if userRow == nil {
+		t.Fatal("expected a user-owned row")
+	}
+	if svcRow == nil {
+		t.Fatal("expected a service-account row")
+	}
+	if userRow.Email == nil || *userRow.Email != fx.userEmail {
+		t.Errorf("expected email %q, got %v", fx.userEmail, userRow.Email)
+	}
+	// user has 5 rows across both keys totaling 150+300+75+120+45 = 690
+	if userRow.Requests != 5 {
+		t.Errorf("expected 5 user requests, got %d", userRow.Requests)
+	}
+	if userRow.TotalTokens != 690 {
+		t.Errorf("expected user total_tokens=690, got %d", userRow.TotalTokens)
+	}
+	// Expect 2 distinct keys for user
+	if userRow.KeyCount != 2 {
+		t.Errorf("expected user key_count=2, got %d", userRow.KeyCount)
+	}
+	// service account: 4 rows, total = 750+900+60+30 = 1740, 1 distinct key
+	if svcRow.Requests != 4 {
+		t.Errorf("expected 4 service requests, got %d", svcRow.Requests)
+	}
+	if svcRow.TotalTokens != 1740 {
+		t.Errorf("expected service total_tokens=1740, got %d", svcRow.TotalTokens)
+	}
+	if svcRow.KeyCount != 1 {
+		t.Errorf("expected service key_count=1, got %d", svcRow.KeyCount)
+	}
+}
+
+func TestGetUsageByUser_OrderedByTokensDesc(t *testing.T) {
+	s := setupTestStore(t)
+	seedAnalyticsFixture(t, s)
+
+	rows, err := s.GetUsageByUser(UsageFilter{})
+	if err != nil {
+		t.Fatalf("GetUsageByUser: %v", err)
+	}
+	// service account sum (1740) > user sum (690)
+	if rows[0].TotalTokens < rows[len(rows)-1].TotalTokens {
+		t.Errorf("expected rows ordered by total_tokens desc, got: %+v", rows)
+	}
+}
+
+func TestGetUsageByUser_UnattributedKey(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create an admin-created key with no user_id and no account_id.
+	keyID, err := s.CreateKey("admin-only-key", "hash-admin-only", "sk-adm", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	_, err = s.pool.Exec(ctx,
+		`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged)
+		 VALUES ($1, 'llama3.1:8b', 10, 5, 15, 50, 'completed', 0)`, keyID,
+	)
+	if err != nil {
+		t.Fatalf("insert usage row: %v", err)
+	}
+
+	rows, err := s.GetUsageByUser(UsageFilter{})
+	if err != nil {
+		t.Fatalf("GetUsageByUser: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].UserID != nil || rows[0].AccountID != nil {
+		t.Errorf("expected both user_id and account_id nil, got %+v", rows[0])
+	}
+}
+
+func TestGetUsageTimeseries_HourBuckets(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixture(t, s)
+
+	buckets, err := s.GetUsageTimeseries(UsageFilter{}, "hour")
+	if err != nil {
+		t.Fatalf("GetUsageTimeseries: %v", err)
+	}
+	// 9 distinct hours (0..5, 25..27) → 9 buckets
+	if len(buckets) != 9 {
+		t.Errorf("expected 9 hour buckets, got %d: %+v", len(buckets), buckets)
+	}
+	// Ordered ascending by bucket
+	for i := 1; i < len(buckets); i++ {
+		if !buckets[i].Bucket.After(buckets[i-1].Bucket) {
+			t.Errorf("buckets not ordered ascending at i=%d", i)
+		}
+	}
+	// Each hour has exactly one row here, so requests=1 per bucket.
+	for _, b := range buckets {
+		if b.Requests != 1 {
+			t.Errorf("expected 1 request per bucket, got %d at %v", b.Requests, b.Bucket)
+		}
+	}
+	// First bucket is at t0 (UTC-truncated). Credits 0.30.
+	if diff := buckets[0].Credits - 0.30; diff < -0.0001 || diff > 0.0001 {
+		t.Errorf("expected first bucket credits=0.30, got %f", buckets[0].Credits)
+	}
+	_ = fx
+}
+
+func TestGetUsageTimeseries_DayBuckets(t *testing.T) {
+	s := setupTestStore(t)
+	seedAnalyticsFixture(t, s)
+
+	buckets, err := s.GetUsageTimeseries(UsageFilter{}, "day")
+	if err != nil {
+		t.Fatalf("GetUsageTimeseries: %v", err)
+	}
+	// Rows span two UTC days (t0-t0+5h, t0+25h-t0+27h), which may collapse
+	// into 1 or 2 day buckets depending on t0 alignment. Require 1 or 2.
+	if len(buckets) < 1 || len(buckets) > 2 {
+		t.Errorf("expected 1-2 day buckets, got %d", len(buckets))
+	}
+}
+
+func TestGetUsageTimeseries_InvalidInterval(t *testing.T) {
+	s := setupTestStore(t)
+
+	_, err := s.GetUsageTimeseries(UsageFilter{}, "minute")
+	if err == nil {
+		t.Error("expected error for invalid interval, got nil")
+	}
+}
+
+func TestGetUsageTimeseries_WithFilters(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixture(t, s)
+
+	buckets, err := s.GetUsageTimeseries(UsageFilter{AccountID: &fx.serviceAccountID}, "hour")
+	if err != nil {
+		t.Fatalf("GetUsageTimeseries: %v", err)
+	}
+	total := 0
+	for _, b := range buckets {
+		total += b.Requests
+	}
+	if total != 4 {
+		t.Errorf("expected 4 service requests across buckets, got %d", total)
+	}
+}
+
+// --- EXPLAIN assertions ---
+
+func TestExplain_ByModel_UsesModelIndex(t *testing.T) {
+	s := setupTestStore(t)
+	seedAnalyticsFixtureLarge(t, s)
+	model := "model-1" // one of the 20 distinct models; 100 rows of 2000
+	if !planUsesIndex(t, s,
+		`SELECT ul.model, COUNT(*) FROM usage_logs ul JOIN api_keys k ON ul.api_key_id = k.id
+		 WHERE ul.model = $1 GROUP BY ul.model`,
+		[]any{model},
+		"idx_usage_logs_model_created",
+	) {
+		t.Error("expected plan to use idx_usage_logs_model_created for by-model with model filter")
+	}
+}
+
+func TestExplain_Summary_WithAccountFilter_UsesAccountIndex(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixtureLarge(t, s)
+	if !planUsesIndex(t, s,
+		`SELECT COUNT(*) FROM usage_logs ul JOIN api_keys k ON ul.api_key_id = k.id
+		 WHERE k.account_id = $1`,
+		[]any{fx.serviceAccountID},
+		"idx_api_keys_account_id",
+	) {
+		t.Error("expected plan to use idx_api_keys_account_id for summary with account_id")
+	}
+}
+
+func TestExplain_Summary_WithAPIKeyFilter_UsesKeyIndex(t *testing.T) {
+	s := setupTestStore(t)
+	fx := seedAnalyticsFixtureLarge(t, s)
+	// Either the single-column api_key_id index or the composite
+	// (api_key_id, created_at) index is acceptable — both satisfy the
+	// contract "don't seq-scan usage_logs to find rows for a single key".
+	// The planner picks whichever is cheaper for the current statistics.
+	query := `SELECT COUNT(*) FROM usage_logs ul JOIN api_keys k ON ul.api_key_id = k.id
+	          WHERE ul.api_key_id = $1`
+	args := []any{fx.keyUser}
+	if !(planUsesIndex(t, s, query, args, "idx_usage_logs_key_id") ||
+		planUsesIndex(t, s, query, args, "idx_usage_logs_key_created")) {
+		t.Error("expected plan to use an api_key_id-based index for summary with api_key_id")
+	}
+}
+
+// planUsesIndex runs EXPLAIN (FORMAT JSON) for the given query and searches
+// the resulting plan tree for the named index. Returns true if the index is
+// referenced anywhere in the plan. The planner session state (enable_seqscan
+// off) and the EXPLAIN itself must run on the same backend, so acquire a
+// dedicated connection for the whole check.
+func planUsesIndex(t *testing.T, s *Store, query string, args []any, indexName string) bool {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer conn.Release()
+
+	// Disable seqscan on this connection so the planner surfaces indexed
+	// access paths even on tiny test tables where a seq scan would cost
+	// less in the abstract.
+	if _, err := conn.Exec(ctx, "SET enable_seqscan = off"); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+
+	explainSQL := "EXPLAIN (FORMAT JSON) " + query
+	var raw []byte
+	if err := conn.QueryRow(ctx, explainSQL, args...).Scan(&raw); err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	// Reset so the connection isn't poisoned for the next user of the pool.
+	_, _ = conn.Exec(ctx, "RESET enable_seqscan")
+
+	var plans []map[string]any
+	if err := json.Unmarshal(raw, &plans); err != nil {
+		t.Fatalf("parse EXPLAIN output: %v", err)
+	}
+	for _, p := range plans {
+		if planContainsIndex(p["Plan"], indexName) {
+			return true
+		}
+	}
+	return false
+}
+
+func planContainsIndex(node any, indexName string) bool {
+	m, ok := node.(map[string]any)
+	if !ok {
+		return false
+	}
+	if s, ok := m["Index Name"].(string); ok && s == indexName {
+		return true
+	}
+	if children, ok := m["Plans"].([]any); ok {
+		for _, c := range children {
+			if planContainsIndex(c, indexName) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/store/credits.go
+++ b/internal/store/credits.go
@@ -143,13 +143,15 @@ func (s *Store) ReserveCredits(accountID int64, amount float64) (int64, error) {
 	return holdID, nil
 }
 
-// SettleHold settles a credit hold with the actual cost. Derives reserve amount from the hold row.
-// If the hold was already released by the sweeper, returns nil (no-op).
-func (s *Store) SettleHold(holdID int64, actualAmount float64) error {
+// SettleHold settles a credit hold with the actual cost and returns the cost
+// that was actually charged. When the hold was already released by the
+// sweeper, returns (0, nil) so callers can record "no cost charged" without
+// special-casing. Normal path returns (actualAmount, nil).
+func (s *Store) SettleHold(holdID int64, actualAmount float64) (float64, error) {
 	ctx := context.Background()
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return 0, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback(ctx)
 
@@ -162,11 +164,11 @@ func (s *Store) SettleHold(holdID int64, actualAmount float64) error {
 		 RETURNING account_id, amount`, holdID,
 	).Scan(&accountID, &holdAmount)
 	if err == pgx.ErrNoRows {
-		// Sweeper already released this hold — no-op
-		return nil
+		// Sweeper already released this hold — nothing charged.
+		return 0, nil
 	}
 	if err != nil {
-		return fmt.Errorf("update hold: %w", err)
+		return 0, fmt.Errorf("update hold: %w", err)
 	}
 
 	// Update balance: deduct actual cost, release reservation
@@ -178,7 +180,7 @@ func (s *Store) SettleHold(holdID int64, actualAmount float64) error {
 		 RETURNING balance`, actualAmount, holdAmount, accountID,
 	).Scan(&newBalance)
 	if err != nil {
-		return fmt.Errorf("update balance: %w", err)
+		return 0, fmt.Errorf("update balance: %w", err)
 	}
 
 	// Audit trail
@@ -188,10 +190,13 @@ func (s *Store) SettleHold(holdID int64, actualAmount float64) error {
 		accountID, -actualAmount, newBalance, holdID,
 	)
 	if err != nil {
-		return fmt.Errorf("insert transaction: %w", err)
+		return 0, fmt.Errorf("insert transaction: %w", err)
 	}
 
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+	return actualAmount, nil
 }
 
 // ReleaseHold releases a pending hold without charging. Used when requests fail with 0 bytes.
@@ -458,7 +463,9 @@ func (s *Store) RevokeRegistrationToken(id int64) error {
 }
 
 // RegisterServiceAccount atomically: validates+consumes token, creates service account,
-// inits credit balance, grants credits, creates API key. Returns (accountID, keyID, creditGrant, err).
+// inits credit balance, grants credits, creates API key, and records a
+// registration_events audit row with source='registration_token'.
+// Returns (accountID, keyID, creditGrant, err).
 func (s *Store) RegisterServiceAccount(tokenHash, name, keyHash, keyPrefix string, rateLimit int) (int64, int64, float64, error) {
 	ctx := context.Background()
 	tx, err := s.pool.Begin(ctx)
@@ -468,14 +475,15 @@ func (s *Store) RegisterServiceAccount(tokenHash, name, keyHash, keyPrefix strin
 	defer tx.Rollback(ctx)
 
 	// Atomically validate and consume the token
+	var tokenID int64
 	var creditGrant float64
 	err = tx.QueryRow(ctx,
 		`UPDATE registration_tokens
 		 SET uses = uses + 1
 		 WHERE token_hash = $1 AND NOT revoked AND uses < max_uses
 		   AND (expires_at IS NULL OR expires_at > NOW())
-		 RETURNING credit_grant`, tokenHash,
-	).Scan(&creditGrant)
+		 RETURNING id, credit_grant`, tokenHash,
+	).Scan(&tokenID, &creditGrant)
 	if err == pgx.ErrNoRows {
 		return 0, 0, 0, fmt.Errorf("invalid, expired, or exhausted registration token")
 	}
@@ -525,6 +533,14 @@ func (s *Store) RegisterServiceAccount(tokenHash, name, keyHash, keyPrefix strin
 	).Scan(&keyID)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("create key: %w", err)
+	}
+
+	if _, err = tx.Exec(ctx,
+		`INSERT INTO registration_events (kind, account_id, registration_token_id, source)
+		 VALUES ('service', $1, $2, 'registration_token')`,
+		accountID, tokenID,
+	); err != nil {
+		return 0, 0, 0, fmt.Errorf("record registration_event: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/store/credits_charged_test.go
+++ b/internal/store/credits_charged_test.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"testing"
+)
+
+func TestSettleHold_ReturnsActualCost(t *testing.T) {
+	s := setupTestStore(t)
+	accID, _ := s.CreateAccount("settle-actual-cost", "personal")
+	_ = s.InitCreditBalance(accID)
+	_ = s.AddCredits(accID, 100, "grant")
+
+	holdID, err := s.ReserveCredits(accID, 30)
+	if err != nil {
+		t.Fatalf("ReserveCredits: %v", err)
+	}
+
+	charged, err := s.SettleHold(holdID, 20)
+	if err != nil {
+		t.Fatalf("SettleHold: %v", err)
+	}
+	if !almostEqual(charged, 20) {
+		t.Errorf("expected charged=20, got %f", charged)
+	}
+}
+
+func TestSettleHold_AfterReleaseReturnsZero(t *testing.T) {
+	s := setupTestStore(t)
+	accID, _ := s.CreateAccount("settle-after-release", "personal")
+	_ = s.InitCreditBalance(accID)
+	_ = s.AddCredits(accID, 100, "grant")
+
+	holdID, _ := s.ReserveCredits(accID, 30)
+	_ = s.ReleaseHold(holdID)
+
+	charged, err := s.SettleHold(holdID, 20)
+	if err != nil {
+		t.Fatalf("SettleHold after release: %v", err)
+	}
+	if charged != 0 {
+		t.Errorf("expected 0 charged for already-released hold, got %f", charged)
+	}
+}

--- a/internal/store/credits_test.go
+++ b/internal/store/credits_test.go
@@ -227,7 +227,7 @@ func TestSettleHold(t *testing.T) {
 	holdID, _ := s.ReserveCredits(accID, 30)
 
 	// Actual cost was 20 (less than reserved 30)
-	if err := s.SettleHold(holdID, 20); err != nil {
+	if _, err := s.SettleHold(holdID, 20); err != nil {
 		t.Fatalf("SettleHold: %v", err)
 	}
 
@@ -266,7 +266,7 @@ func TestSettleHold_AfterSweeperReleased(t *testing.T) {
 	_ = s.ReleaseHold(holdID)
 
 	// Settle after release should be a no-op (not error)
-	if err := s.SettleHold(holdID, 20); err != nil {
+	if _, err := s.SettleHold(holdID, 20); err != nil {
 		t.Fatalf("SettleHold after release should be no-op, got: %v", err)
 	}
 
@@ -420,7 +420,7 @@ func TestCleanupSettledHolds(t *testing.T) {
 	_ = s.AddCredits(accID, 100, "grant")
 
 	holdID, _ := s.ReserveCredits(accID, 10)
-	_ = s.SettleHold(holdID, 5)
+	_, _ = s.SettleHold(holdID, 5)
 
 	// Backdate the settled_at
 	_, _ = s.pool.Exec(

--- a/internal/store/registration_events_test.go
+++ b/internal/store/registration_events_test.go
@@ -1,0 +1,240 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLogUsage_PersistsCreditsCharged(t *testing.T) {
+	s := setupTestStore(t)
+
+	id, err := s.CreateKey("credit-key", "hash-credit", "sk-cr", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	entry := UsageEntry{
+		APIKeyID:         id,
+		Model:            "llama3.1:8b",
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+		DurationMs:       200,
+		Status:           "completed",
+		CreditsCharged:   0.425,
+	}
+	if err := s.LogUsage(entry); err != nil {
+		t.Fatalf("LogUsage: %v", err)
+	}
+
+	var got float64
+	err = s.pool.QueryRow(context.Background(),
+		`SELECT credits_charged FROM usage_logs WHERE api_key_id = $1`, id,
+	).Scan(&got)
+	if err != nil {
+		t.Fatalf("query credits_charged: %v", err)
+	}
+	if diff := got - 0.425; diff < -0.0001 || diff > 0.0001 {
+		t.Errorf("expected credits_charged=0.425, got %f", got)
+	}
+}
+
+func TestLogUsage_DefaultZeroCredits(t *testing.T) {
+	s := setupTestStore(t)
+
+	id, _ := s.CreateKey("zero-credit", "hash-zero", "sk-zr", 60)
+
+	// Omit CreditsCharged → zero value
+	if err := s.LogUsage(UsageEntry{
+		APIKeyID:     id,
+		Model:        "llama3.1:8b",
+		TotalTokens:  1,
+		PromptTokens: 1,
+		Status:       "completed",
+	}); err != nil {
+		t.Fatalf("LogUsage: %v", err)
+	}
+
+	var got float64
+	_ = s.pool.QueryRow(context.Background(),
+		`SELECT credits_charged FROM usage_logs WHERE api_key_id = $1`, id,
+	).Scan(&got)
+	if got != 0 {
+		t.Errorf("expected 0 credits, got %f", got)
+	}
+}
+
+func TestBackfillRegistrationEvents_UsersAndServiceAccounts(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// Register a user (personal account + user row).
+	personalAccountID, userID, err := s.RegisterUser("b@example.com", "hash", "Bob")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	// Create a service account directly.
+	svcAccountID, err := s.CreateAccount("svc-backfill", "service")
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	// Wipe any registration_events rows from the live writers so the backfill
+	// is the only thing producing rows (PR 0 registration flow does not yet
+	// write events; if a future change wires it, this test still asserts
+	// backfill is idempotent below).
+	if _, err := s.pool.Exec(ctx, "DELETE FROM registration_events"); err != nil {
+		t.Fatalf("wipe: %v", err)
+	}
+
+	if err := s.BackfillRegistrationEvents(); err != nil {
+		t.Fatalf("BackfillRegistrationEvents: %v", err)
+	}
+
+	var userCount int
+	err = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM registration_events WHERE kind='user' AND user_id=$1 AND source='backfill'`,
+		userID,
+	).Scan(&userCount)
+	if err != nil {
+		t.Fatalf("count user events: %v", err)
+	}
+	if userCount != 1 {
+		t.Errorf("expected 1 backfill event for user, got %d", userCount)
+	}
+
+	var svcCount int
+	err = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM registration_events WHERE kind='service' AND account_id=$1 AND source='backfill'`,
+		svcAccountID,
+	).Scan(&svcCount)
+	if err != nil {
+		t.Fatalf("count service events: %v", err)
+	}
+	if svcCount != 1 {
+		t.Errorf("expected 1 backfill event for service account, got %d", svcCount)
+	}
+
+	// Idempotent: running again should not create duplicates.
+	if err := s.BackfillRegistrationEvents(); err != nil {
+		t.Fatalf("second BackfillRegistrationEvents: %v", err)
+	}
+	err = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM registration_events WHERE source='backfill'`,
+	).Scan(&userCount)
+	if err != nil {
+		t.Fatalf("count after second backfill: %v", err)
+	}
+	if userCount != 2 {
+		t.Errorf("expected exactly 2 backfill rows (user + service) after 2 runs, got %d", userCount)
+	}
+
+	// Personal accounts should NOT get a 'service' backfill row.
+	var personalSvcCount int
+	err = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM registration_events WHERE kind='service' AND account_id=$1`,
+		personalAccountID,
+	).Scan(&personalSvcCount)
+	if err != nil {
+		t.Fatalf("count personal-as-service: %v", err)
+	}
+	if personalSvcCount != 0 {
+		t.Errorf("expected 0 service backfill rows for personal account, got %d", personalSvcCount)
+	}
+}
+
+func TestBackfillRegistrationEvents_SkipsAlreadyRecorded(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// Pre-insert a registration_event from an admin bootstrap.
+	userID, err := s.CreateAdminBootstrap("pre@example.com", "hash", "Pre")
+	if err != nil {
+		t.Fatalf("CreateAdminBootstrap: %v", err)
+	}
+
+	if err := s.BackfillRegistrationEvents(); err != nil {
+		t.Fatalf("BackfillRegistrationEvents: %v", err)
+	}
+
+	var count int
+	err = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM registration_events WHERE user_id=$1`, userID,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 registration_event for user (bootstrap row retained, no backfill dup), got %d", count)
+	}
+
+	var src string
+	err = s.pool.QueryRow(ctx,
+		`SELECT source FROM registration_events WHERE user_id=$1`, userID,
+	).Scan(&src)
+	if err != nil {
+		t.Fatalf("source: %v", err)
+	}
+	if src != "admin_bootstrap" {
+		t.Errorf("expected existing source retained ('admin_bootstrap'), got %q", src)
+	}
+}
+
+// --- Registration-event writer tests on live paths ---
+
+func TestRegisterUser_WritesRegistrationEvent(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	accountID, userID, err := s.RegisterUser("live-signup@example.com", "hash", "Live")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+
+	var count int
+	err = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM registration_events
+		 WHERE kind='user' AND user_id=$1 AND account_id=$2 AND source='public_signup'`,
+		userID, accountID,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 registration_event for public_signup, got %d", count)
+	}
+}
+
+func TestRegisterServiceAccount_WritesRegistrationEvent(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create a registration token.
+	tokHash := "svc-reg-token-hash"
+	tokID, err := s.CreateRegistrationToken("svc-token", tokHash, 5.0, 1, nil)
+	if err != nil {
+		t.Fatalf("CreateRegistrationToken: %v", err)
+	}
+
+	accountID, _, _, err := s.RegisterServiceAccount(tokHash, "my-svc", "hash-svc-key", "sk-svx", 60)
+	if err != nil {
+		t.Fatalf("RegisterServiceAccount: %v", err)
+	}
+
+	var count int
+	var gotTokenID *int64
+	err = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*), MAX(registration_token_id) FROM registration_events
+		 WHERE kind='service' AND account_id=$1 AND source='registration_token'`,
+		accountID,
+	).Scan(&count, &gotTokenID)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 registration_event for service registration, got %d", count)
+	}
+	if gotTokenID == nil || *gotTokenID != tokID {
+		t.Errorf("expected registration_token_id=%d, got %v", tokID, gotTokenID)
+	}
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -172,3 +172,18 @@ CREATE TABLE IF NOT EXISTS registration_events (
 );
 CREATE INDEX IF NOT EXISTS idx_registration_events_created
     ON registration_events(created_at);
+
+-- Analytics indexes (PR 1)
+CREATE INDEX IF NOT EXISTS idx_usage_logs_model_created
+    ON usage_logs(model, created_at);
+CREATE INDEX IF NOT EXISTS idx_api_keys_account_id
+    ON api_keys(account_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_user_id
+    ON api_keys(user_id);
+
+-- Per-request credit cost on usage_logs (historical rows default 0).
+DO $$ BEGIN
+    ALTER TABLE usage_logs ADD COLUMN credits_charged DECIMAL(15,6) NOT NULL DEFAULT 0;
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -69,7 +69,8 @@ type UsageEntry struct {
 	CompletionTokens int
 	TotalTokens      int
 	DurationMs       int64
-	Status           string // completed | partial | error
+	Status           string  // completed | partial | error
+	CreditsCharged   float64 // 0 when no hold/pricing was active
 }
 
 type UsageStat struct {
@@ -328,10 +329,10 @@ func (s *Store) RevokeKey(id int64) error {
 func (s *Store) LogUsage(entry UsageEntry) error {
 	_, err := s.pool.Exec(
 		context.Background(),
-		`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 		entry.APIKeyID, entry.Model, entry.PromptTokens, entry.CompletionTokens,
-		entry.TotalTokens, entry.DurationMs, entry.Status,
+		entry.TotalTokens, entry.DurationMs, entry.Status, entry.CreditsCharged,
 	)
 	return err
 }
@@ -676,7 +677,9 @@ func (s *Store) CreateKeyForAccountOnly(accountID int64, name, keyHash, keyPrefi
 }
 
 // RegisterUser atomically creates a personal account and user in one transaction.
-// Returns (accountID, userID, err).
+// Returns (accountID, userID, err). Also records a registration_events audit
+// row with source='public_signup' so the admin registrations view reflects
+// self-serve signups without an additional code path.
 func (s *Store) RegisterUser(email, passwordHash, name string) (int64, int64, error) {
 	ctx := context.Background()
 	tx, err := s.pool.Begin(ctx)
@@ -707,6 +710,14 @@ func (s *Store) RegisterUser(email, passwordHash, name string) (int64, int64, er
 		`INSERT INTO credit_balances (account_id) VALUES ($1) ON CONFLICT DO NOTHING`, accountID)
 	if err != nil {
 		return 0, 0, fmt.Errorf("init credit balance: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO registration_events (kind, account_id, user_id, source)
+		 VALUES ('user', $1, $2, 'public_signup')`,
+		accountID, userID,
+	); err != nil {
+		return 0, 0, fmt.Errorf("record registration_event: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -23,6 +23,7 @@ func setupTestStore(t *testing.T) *Store {
 	wipe := func() {
 		c := context.Background()
 		// FK-aware order: delete referencing rows before referenced rows.
+		// DELETE (not DROP) avoids pg_catalog races on rapid DROP+CREATE cycles.
 		_, _ = s.pool.Exec(c, "DELETE FROM registration_events")
 		_, _ = s.pool.Exec(c, "DELETE FROM credit_holds")
 		_, _ = s.pool.Exec(c, "DELETE FROM credit_transactions")


### PR DESCRIPTION
## Summary

Implements Backend PR 1 of the Admin Expansion initiative. Branches from PR 0 (`be/pr-0-admin-session-auth`) and should be merged **after** PR 0 lands.

Scope (per PLAN.md):

- **Schema**: `idx_usage_logs_model_created`, `idx_api_keys_account_id`, `idx_api_keys_user_id`; `usage_logs.credits_charged DECIMAL(15,6) NOT NULL DEFAULT 0` via idempotent `DO $$ ... EXCEPTION WHEN duplicate_column`.
- **Store analytics**: `UsageFilter` plus `GetUsageSummary`, `GetUsageByModel`, `GetUsageByUser` (returns one row per owner: user, service account, or unattributed admin key), `GetUsageTimeseries` (hour/day buckets).
- **Credits plumbing** (locked decision #16): `SettleHold(holdID, actualCost) (float64, error)` — returns the amount actually charged (0 when hold was already released by the sweeper). Proxy `settleCredits` / `settleStreamCredits` now return `actualCost`; the outer handlers forward it through `logUsage` into `UsageEntry.CreditsCharged`. Legacy keys without pricing plumb 0.
- **Registration events**: `RegisterUser` writes `source='public_signup'` inside the same transaction as the user insert; `RegisterServiceAccount` writes `source='registration_token'` with the token id as reference. Historical users and service accounts get backfilled on startup via `BackfillRegistrationEvents` (idempotent via `WHERE NOT EXISTS`), wired next to the existing `BackfillAccounts` / `BackfillCreditBalances` calls in `cmd/proxy/main.go`.
- **ldflags wiring**: `version` / `buildTime` string vars in `cmd/proxy/main.go`, Dockerfile accepts `--build-arg GIT_SHA` and `--build-arg BUILD_TIME`, `cd.yml` passes both from the commit SHA and UTC timestamp. Prereq for the PR 5 `/admin/config` endpoint.

No HTTP changes in this PR — the new store methods are consumed by PR 2's handlers.

**Deferred**: nothing from the PR 1 plan. PR 2 will add the admin HTTP endpoints that call these store methods.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] Integration tests against postgres for every new method: empty, single row, filters (account_id, api_key_id, user_id, model, since, until), grouping, ordering, unattributed keys, timeseries intervals
- [x] EXPLAIN assertions (`idx_usage_logs_model_created` for model filter, `idx_api_keys_account_id` for account filter, an api_key_id-based index for api_key_id filter) — follow the "Deliberately NOT asserted" guidance from PLAN.md for broad filters
- [x] Proxy end-to-end: a successful chat completion plumbs the settled cost into `UsageEntry.CreditsCharged` on the async writer channel
- [x] Proxy legacy key: no AccountID → CreditsCharged is 0
- [x] `DATABASE_URL=... go test -count=1 -race -p 1 ./...` passes cleanly twice in a row
- [x] Coverage ≥ 60% (currently 67.7% via `go tool cover -func`)

Also switched `setupTestStore` / `setupTestDB` / `setupUserTest` / credits middleware helpers from DROP+CREATE to DELETE-only between tests, which eliminates a pre-existing pg_catalog race on rapid DROP+CREATE cycles. No CI behavior change (CI runs against a fresh DB), sizeable stability win for local runs.