### PR TITLE
BE PR 3: admin detail + mutation endpoints

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -85,8 +85,17 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 	mux.HandleFunc("GET /api/admin/usage/by-user", handler.getUsageByUser)
 	mux.HandleFunc("GET /api/admin/usage/timeseries", handler.getUsageTimeseries)
 	mux.HandleFunc("GET /api/admin/users", handler.listUsers)
+	mux.HandleFunc("GET /api/admin/users/{id}", handler.getUser)
 	mux.HandleFunc("PUT /api/admin/users/{id}/activate", handler.activateUser)
 	mux.HandleFunc("PUT /api/admin/users/{id}/deactivate", handler.deactivateUser)
+	mux.HandleFunc("PUT /api/admin/users/{id}/role", handler.updateUserRole)
+
+	// Key detail + mutations (BE 3)
+	mux.HandleFunc("GET /api/admin/keys/{id}", handler.getKey)
+	mux.HandleFunc("PUT /api/admin/keys/{id}/rate-limit", handler.updateKeyRateLimit)
+
+	// Registrations audit feed (BE 3)
+	mux.HandleFunc("GET /api/admin/registrations", handler.listRegistrations)
 
 	// Credit management
 	mux.HandleFunc("GET /api/admin/accounts", handler.listAccounts)
@@ -765,4 +774,244 @@ func min(a, b float64) float64 {
 		return a
 	}
 	return b
+}
+
+// --- BE 3: detail + mutations -------------------------------------------------
+
+type userDetailDTO struct {
+	ID        int64  `json:"id"`
+	Email     string `json:"email"`
+	Name      string `json:"name"`
+	Role      string `json:"role"`
+	IsActive  bool   `json:"is_active"`
+	AccountID *int64 `json:"account_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func toUserDetailDTO(u *store.User) userDetailDTO {
+	return userDetailDTO{
+		ID:        u.ID,
+		Email:     u.Email,
+		Name:      u.Name,
+		Role:      u.Role,
+		IsActive:  u.IsActive,
+		AccountID: u.AccountID,
+		CreatedAt: u.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: u.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+func (h *handler) getUser(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid user ID")
+		return
+	}
+
+	u, err := h.store.GetUserByID(id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "get user error", "error", err, "user_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to get user")
+		return
+	}
+	if u == nil {
+		proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "User not found")
+		return
+	}
+
+	writeEnvelope(w, toUserDetailDTO(u), nil)
+}
+
+func (h *handler) updateUserRole(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid user ID")
+		return
+	}
+
+	var req struct {
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_json", "invalid_request_error", "Invalid JSON body")
+		return
+	}
+
+	if err := h.store.UpdateUserRoleGuarded(id, req.Role); err != nil {
+		switch {
+		case errors.Is(err, store.ErrInvalidRole):
+			proxy.WriteError(w, r, http.StatusBadRequest, "invalid_role", "invalid_request_error", "role must be 'admin' or 'user'")
+			return
+		case errors.Is(err, store.ErrUserNotFound):
+			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "User not found")
+			return
+		case errors.Is(err, store.ErrLastActiveAdmin):
+			proxy.WriteError(w, r, http.StatusConflict, "last_admin", "invalid_request_error", "Cannot remove the last active admin")
+			return
+		}
+		slog.ErrorContext(r.Context(), "update user role error", "error", err, "user_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to update user role")
+		return
+	}
+
+	u, err := h.store.GetUserByID(id)
+	if err != nil || u == nil {
+		// Extremely unlikely — the row existed inside the guardrail tx.
+		slog.ErrorContext(r.Context(), "reload user after role change", "error", err, "user_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to reload user")
+		return
+	}
+	writeEnvelope(w, toUserDetailDTO(u), nil)
+}
+
+type keyDetailDTO struct {
+	ID                int64  `json:"id"`
+	Name              string `json:"name"`
+	KeyPrefix         string `json:"key_prefix"`
+	RateLimit         int    `json:"rate_limit"`
+	Revoked           bool   `json:"revoked"`
+	UserID            *int64 `json:"user_id"`
+	AccountID         *int64 `json:"account_id"`
+	SessionTokenLimit *int   `json:"session_token_limit"`
+	CreatedAt         string `json:"created_at"`
+}
+
+func toKeyDetailDTO(k *store.APIKey) keyDetailDTO {
+	return keyDetailDTO{
+		ID:                k.ID,
+		Name:              k.Name,
+		KeyPrefix:         k.KeyPrefix,
+		RateLimit:         k.RateLimit,
+		Revoked:           k.Revoked,
+		UserID:            k.UserID,
+		AccountID:         k.AccountID,
+		SessionTokenLimit: k.SessionTokenLimit,
+		CreatedAt:         k.CreatedAt.Format(time.RFC3339),
+	}
+}
+
+func (h *handler) getKey(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid key ID")
+		return
+	}
+
+	k, err := h.store.GetKeyByID(id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "get key error", "error", err, "key_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to get key")
+		return
+	}
+	if k == nil {
+		proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Key not found")
+		return
+	}
+
+	writeEnvelope(w, toKeyDetailDTO(k), nil)
+}
+
+func (h *handler) updateKeyRateLimit(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid key ID")
+		return
+	}
+
+	// Pointer so we can distinguish "omitted" from "explicit 0". Omitted is
+	// rejected (we can't default silently — callers who meant to set 60 should
+	// say so); explicit 0 or negative is mapped to the default (same semantics
+	// as createKey / createAccountKey).
+	var req struct {
+		RateLimit *int `json:"rate_limit"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_json", "invalid_request_error", "Invalid JSON body")
+		return
+	}
+	if req.RateLimit == nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "missing_rate_limit", "invalid_request_error", "rate_limit is required")
+		return
+	}
+	rateLimit, err := ratelimit.ApplyConfigDefaultsAndCap(*req.RateLimit)
+	if err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "rate_limit_too_high", "invalid_request_error", "rate_limit must be <= 10000")
+		return
+	}
+
+	if err := h.store.UpdateKeyRateLimit(id, rateLimit); err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Key not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "update key rate_limit error", "error", err, "key_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to update key")
+		return
+	}
+
+	k, err := h.store.GetKeyByID(id)
+	if err != nil || k == nil {
+		slog.ErrorContext(r.Context(), "reload key after update", "error", err, "key_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to reload key")
+		return
+	}
+	writeEnvelope(w, toKeyDetailDTO(k), nil)
+}
+
+type registrationEventDTO struct {
+	ID                  int64     `json:"id"`
+	Kind                string    `json:"kind"`
+	Source              string    `json:"source"`
+	UserID              *int64    `json:"user_id"`
+	UserEmail           *string   `json:"user_email"`
+	UserName            *string   `json:"user_name"`
+	AccountID           *int64    `json:"account_id"`
+	AccountName         *string   `json:"account_name"`
+	AccountType         *string   `json:"account_type"`
+	RegistrationTokenID *int64    `json:"registration_token_id"`
+	Metadata            any       `json:"metadata"`
+	CreatedAt           time.Time `json:"created_at"`
+}
+
+func (h *handler) listRegistrations(w http.ResponseWriter, r *http.Request) {
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
+	events, total, err := h.store.ListRegistrationEvents(limit, offset)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "list registrations error", "error", err)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to list registrations")
+		return
+	}
+
+	dtos := make([]registrationEventDTO, len(events))
+	for i, e := range events {
+		var md any
+		if len(e.Metadata) > 0 {
+			// Best-effort decode so clients get structured JSON rather than a
+			// base64-encoded byte slice. On failure, surface the raw text.
+			if err := json.Unmarshal(e.Metadata, &md); err != nil {
+				md = string(e.Metadata)
+			}
+		}
+		dtos[i] = registrationEventDTO{
+			ID:                  e.ID,
+			Kind:                e.Kind,
+			Source:              e.Source,
+			UserID:              e.UserID,
+			UserEmail:           e.UserEmail,
+			UserName:            e.UserName,
+			AccountID:           e.AccountID,
+			AccountName:         e.AccountName,
+			AccountType:         e.AccountType,
+			RegistrationTokenID: e.RegistrationTokenID,
+			Metadata:            md,
+			CreatedAt:           e.CreatedAt,
+		}
+	}
+	writeEnvelope(w, dtos, &Pagination{Limit: limit, Offset: offset, Total: total})
 }

--- a/internal/admin/detail_mutations_test.go
+++ b/internal/admin/detail_mutations_test.go
@@ -1,0 +1,406 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// envelopeData decodes the JSON envelope and returns the `data` field.
+func envelopeData(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var env struct {
+		Data       map[string]any `json:"data"`
+		Pagination map[string]any `json:"pagination,omitempty"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v (body=%s)", err, string(body))
+	}
+	return env.Data
+}
+
+func envelopeList(t *testing.T, body []byte) ([]map[string]any, map[string]any) {
+	t.Helper()
+	var env struct {
+		Data       []map[string]any `json:"data"`
+		Pagination map[string]any   `json:"pagination,omitempty"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("unmarshal envelope list: %v (body=%s)", err, string(body))
+	}
+	return env.Data, env.Pagination
+}
+
+// --- GET /api/admin/users/{id} -----------------------------------------------
+
+func TestAdmin_GetUser_OK(t *testing.T) {
+	h, s := setupAdminTest(t)
+	uid, _ := s.CreateUser("detail@example.com", "hash", "Detail")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users/"+strconv.FormatInt(uid, 10), nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data := envelopeData(t, rec.Body.Bytes())
+	if int64(data["id"].(float64)) != uid {
+		t.Errorf("expected id=%d, got %v", uid, data["id"])
+	}
+	if data["email"] != "detail@example.com" {
+		t.Errorf("expected email, got %v", data["email"])
+	}
+}
+
+func TestAdmin_GetUser_NotFound(t *testing.T) {
+	h, _ := setupAdminTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users/99999", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestAdmin_GetUser_InvalidID(t *testing.T) {
+	h, _ := setupAdminTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users/abc", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+// --- PUT /api/admin/users/{id}/role ------------------------------------------
+
+func TestAdmin_UpdateUserRole_Promote(t *testing.T) {
+	h, s := setupAdminTest(t)
+	uid, _ := s.CreateUser("promote@example.com", "hash", "Promote")
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+strconv.FormatInt(uid, 10)+"/role",
+		bytes.NewBufferString(`{"role":"admin"}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data := envelopeData(t, rec.Body.Bytes())
+	if data["role"] != "admin" {
+		t.Errorf("expected role=admin in response, got %v", data["role"])
+	}
+	u, _ := s.GetUserByID(uid)
+	if u.Role != "admin" {
+		t.Errorf("expected DB role=admin, got %q", u.Role)
+	}
+}
+
+func TestAdmin_UpdateUserRole_DemoteLastAdmin_409(t *testing.T) {
+	h, s := setupAdminTest(t)
+	onlyAdmin := seedAdmin(t, s, "only@example.com")
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+strconv.FormatInt(onlyAdmin, 10)+"/role",
+		bytes.NewBufferString(`{"role":"user"}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var errResp map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &errResp)
+	errObj, _ := errResp["error"].(map[string]any)
+	if code, _ := errObj["code"].(string); code != "last_admin" {
+		t.Errorf("expected code 'last_admin', got %v", errObj["code"])
+	}
+}
+
+func TestAdmin_UpdateUserRole_InvalidRole_400(t *testing.T) {
+	h, s := setupAdminTest(t)
+	uid, _ := s.CreateUser("bad@example.com", "h", "Bad")
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+strconv.FormatInt(uid, 10)+"/role",
+		bytes.NewBufferString(`{"role":"superadmin"}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdmin_UpdateUserRole_NotFound(t *testing.T) {
+	h, _ := setupAdminTest(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/99999/role",
+		bytes.NewBufferString(`{"role":"admin"}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// --- GET /api/admin/keys/{id} -------------------------------------------------
+
+func TestAdmin_GetKey_OK(t *testing.T) {
+	h, s := setupAdminTest(t)
+	kid, _ := s.CreateKey("detail-key", "hash-get", "sk-gk", 60)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/keys/"+strconv.FormatInt(kid, 10), nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data := envelopeData(t, rec.Body.Bytes())
+	if int64(data["id"].(float64)) != kid {
+		t.Errorf("expected id=%d, got %v", kid, data["id"])
+	}
+	// Raw key hash must NOT be exposed — only prefix.
+	if _, present := data["key_hash"]; present {
+		t.Error("key_hash leaked to client")
+	}
+	if data["key_prefix"] != "sk-gk" {
+		t.Errorf("expected key_prefix=sk-gk, got %v", data["key_prefix"])
+	}
+}
+
+func TestAdmin_GetKey_NotFound(t *testing.T) {
+	h, _ := setupAdminTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/keys/99999", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// --- PUT /api/admin/keys/{id}/rate-limit --------------------------------------
+
+func TestAdmin_UpdateKeyRateLimit_OK(t *testing.T) {
+	h, s := setupAdminTest(t)
+	kid, _ := s.CreateKey("rl-key", "hash-rl", "sk-rl", 60)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/keys/"+strconv.FormatInt(kid, 10)+"/rate-limit",
+		bytes.NewBufferString(`{"rate_limit":500}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data := envelopeData(t, rec.Body.Bytes())
+	if int(data["rate_limit"].(float64)) != 500 {
+		t.Errorf("expected rate_limit=500, got %v", data["rate_limit"])
+	}
+	k, _ := s.GetKeyByID(kid)
+	if k.RateLimit != 500 {
+		t.Errorf("DB rate_limit: expected 500, got %d", k.RateLimit)
+	}
+}
+
+func TestAdmin_UpdateKeyRateLimit_CapEnforced(t *testing.T) {
+	h, s := setupAdminTest(t)
+	kid, _ := s.CreateKey("cap-key", "hash-cap", "sk-cap", 60)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/keys/"+strconv.FormatInt(kid, 10)+"/rate-limit",
+		bytes.NewBufferString(`{"rate_limit":20000}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for cap violation, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Original rate_limit must remain unchanged.
+	k, _ := s.GetKeyByID(kid)
+	if k.RateLimit != 60 {
+		t.Errorf("expected rate_limit unchanged=60, got %d", k.RateLimit)
+	}
+}
+
+func TestAdmin_UpdateKeyRateLimit_ZeroAppliesDefault(t *testing.T) {
+	h, s := setupAdminTest(t)
+	kid, _ := s.CreateKey("zero-key", "hash-zro", "sk-zro", 120)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/keys/"+strconv.FormatInt(kid, 10)+"/rate-limit",
+		bytes.NewBufferString(`{"rate_limit":0}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	k, _ := s.GetKeyByID(kid)
+	if k.RateLimit != 60 {
+		t.Errorf("expected default rate_limit=60, got %d", k.RateLimit)
+	}
+}
+
+func TestAdmin_UpdateKeyRateLimit_MissingField(t *testing.T) {
+	h, s := setupAdminTest(t)
+	kid, _ := s.CreateKey("miss-key", "hash-mis", "sk-mis", 60)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/keys/"+strconv.FormatInt(kid, 10)+"/rate-limit",
+		bytes.NewBufferString(`{}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing field, got %d", rec.Code)
+	}
+}
+
+func TestAdmin_UpdateKeyRateLimit_NotFound(t *testing.T) {
+	h, _ := setupAdminTest(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/keys/99999/rate-limit",
+		bytes.NewBufferString(`{"rate_limit":60}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// --- GET /api/admin/registrations ---------------------------------------------
+
+func TestAdmin_ListRegistrations_ReturnsEnvelope(t *testing.T) {
+	h, s := setupAdminTest(t)
+
+	if _, _, err := s.RegisterUser("reg1@example.com", "h", "Reg1"); err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	if _, _, err := s.RegisterUser("reg2@example.com", "h", "Reg2"); err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/registrations", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data, pag := envelopeList(t, rec.Body.Bytes())
+	if len(data) < 2 {
+		t.Errorf("expected >=2 events, got %d", len(data))
+	}
+	if pag == nil {
+		t.Fatal("expected pagination block")
+	}
+	if int(pag["total"].(float64)) < 2 {
+		t.Errorf("expected total>=2, got %v", pag["total"])
+	}
+	// Newest first — data[0] should be reg2.
+	if data[0]["user_email"] != "reg2@example.com" {
+		t.Errorf("expected newest first (reg2), got %v", data[0]["user_email"])
+	}
+}
+
+func TestAdmin_ListRegistrations_Pagination(t *testing.T) {
+	h, s := setupAdminTest(t)
+
+	for i := 0; i < 4; i++ {
+		email := string(rune('a'+i)) + "@pag.test"
+		if _, _, err := s.RegisterUser(email, "h", "U"); err != nil {
+			t.Fatalf("RegisterUser: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/registrations?limit=2&offset=0", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	data, pag := envelopeList(t, rec.Body.Bytes())
+	if len(data) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(data))
+	}
+	if int(pag["total"].(float64)) != 4 {
+		t.Errorf("expected total=4, got %v", pag["total"])
+	}
+	if int(pag["limit"].(float64)) != 2 {
+		t.Errorf("expected limit=2, got %v", pag["limit"])
+	}
+}
+
+// --- Ensure adjacent routes still work (no routing conflict from {id}) --------
+
+func TestAdmin_UserDetail_DoesNotShadowActivate(t *testing.T) {
+	h, s := setupAdminTest(t)
+	uid, _ := s.CreateUser("shadow@example.com", "h", "Shadow")
+	if err := s.SetUserActive(uid, false); err != nil {
+		t.Fatalf("SetUserActive: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/users/"+strconv.FormatInt(uid, 10)+"/activate", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected activate to still return 200, got %d", rec.Code)
+	}
+}
+
+// --- Session auth for new endpoints -------------------------------------------
+
+func TestAdmin_GetUser_SessionAuth(t *testing.T) {
+	h, s := setupAdminTest(t)
+
+	token := createSession(t, s, "detail-sess", "admin", time.Hour, true)
+	target, _ := s.CreateUser("target@example.com", "h", "Target")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users/"+strconv.FormatInt(target, 10), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 via session auth, got %d: %s", rec.Code, rec.Body.String())
+	}
+	_ = envelopeData(t, rec.Body.Bytes())
+}

--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -268,6 +268,68 @@ func (s *Store) GetUsageTimeseries(f UsageFilter, interval string) ([]Timeseries
 	return out, rows.Err()
 }
 
+// RegistrationEvent is one row of the admin /registrations feed. Enriched
+// with user email/name and account name/type via LEFT JOIN so the admin UI
+// can render owner info without extra round trips.
+type RegistrationEvent struct {
+	ID                  int64
+	Kind                string
+	Source              string
+	UserID              *int64
+	UserEmail           *string
+	UserName            *string
+	AccountID           *int64
+	AccountName         *string
+	AccountType         *string
+	RegistrationTokenID *int64
+	Metadata            []byte // raw JSONB, may be nil
+	CreatedAt           time.Time
+}
+
+// ListRegistrationEvents returns a page of registration_events rows ordered
+// newest-first, enriched with the related user + account fields. Returns
+// (rows, total, err) where total is the pre-slice count for pagination.
+func (s *Store) ListRegistrationEvents(limit, offset int) ([]RegistrationEvent, int, error) {
+	ctx := context.Background()
+
+	var total int
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM registration_events`).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count registration_events: %w", err)
+	}
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT e.id, e.kind, e.source,
+		        e.user_id, u.email, u.name,
+		        e.account_id, a.name, a.type,
+		        e.registration_token_id, e.metadata, e.created_at
+		 FROM registration_events e
+		 LEFT JOIN users u    ON u.id = e.user_id
+		 LEFT JOIN accounts a ON a.id = e.account_id
+		 ORDER BY e.created_at DESC, e.id DESC
+		 LIMIT $1 OFFSET $2`,
+		limit, offset,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list registration_events: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]RegistrationEvent, 0)
+	for rows.Next() {
+		var ev RegistrationEvent
+		if err := rows.Scan(
+			&ev.ID, &ev.Kind, &ev.Source,
+			&ev.UserID, &ev.UserEmail, &ev.UserName,
+			&ev.AccountID, &ev.AccountName, &ev.AccountType,
+			&ev.RegistrationTokenID, &ev.Metadata, &ev.CreatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan registration_event: %w", err)
+		}
+		out = append(out, ev)
+	}
+	return out, total, rows.Err()
+}
+
 // BackfillRegistrationEvents inserts a registration_events row with
 // source='backfill' for every existing users/accounts row that is not yet
 // tracked. Idempotent: uses WHERE NOT EXISTS guards.

--- a/internal/store/detail_mutations_test.go
+++ b/internal/store/detail_mutations_test.go
@@ -1,0 +1,298 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestGetKeyByID_ReturnsKey(t *testing.T) {
+	s := setupTestStore(t)
+
+	id, err := s.CreateKey("detail-key", "hash-det", "sk-dt", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	got, err := s.GetKeyByID(id)
+	if err != nil {
+		t.Fatalf("GetKeyByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected key, got nil")
+	}
+	if got.ID != id || got.Name != "detail-key" || got.RateLimit != 60 {
+		t.Errorf("unexpected key: %+v", got)
+	}
+}
+
+func TestGetKeyByID_ReturnsRevokedKey(t *testing.T) {
+	s := setupTestStore(t)
+
+	id, _ := s.CreateKey("rev-key", "hash-rv", "sk-rv", 30)
+	if err := s.RevokeKey(id); err != nil {
+		t.Fatalf("RevokeKey: %v", err)
+	}
+
+	got, err := s.GetKeyByID(id)
+	if err != nil {
+		t.Fatalf("GetKeyByID: %v", err)
+	}
+	if got == nil || !got.Revoked {
+		t.Errorf("expected revoked key, got %+v", got)
+	}
+}
+
+func TestGetKeyByID_NotFound(t *testing.T) {
+	s := setupTestStore(t)
+	got, err := s.GetKeyByID(99999)
+	if err != nil {
+		t.Fatalf("GetKeyByID: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing key, got %+v", got)
+	}
+}
+
+func TestUpdateKeyRateLimit_Updates(t *testing.T) {
+	s := setupTestStore(t)
+
+	id, _ := s.CreateKey("rl-key", "hash-rl", "sk-rl", 60)
+	if err := s.UpdateKeyRateLimit(id, 500); err != nil {
+		t.Fatalf("UpdateKeyRateLimit: %v", err)
+	}
+
+	got, _ := s.GetKeyByID(id)
+	if got.RateLimit != 500 {
+		t.Errorf("expected rate_limit=500, got %d", got.RateLimit)
+	}
+}
+
+func TestUpdateKeyRateLimit_NotFound(t *testing.T) {
+	s := setupTestStore(t)
+	err := s.UpdateKeyRateLimit(99999, 100)
+	if !errors.Is(err, ErrKeyNotFound) {
+		t.Errorf("expected ErrKeyNotFound, got %v", err)
+	}
+}
+
+func TestUpdateUserRoleGuarded_PromoteUser(t *testing.T) {
+	s := setupTestStore(t)
+
+	uid, err := s.CreateUser("promote@example.com", "h", "Promote")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := s.UpdateUserRoleGuarded(uid, "admin"); err != nil {
+		t.Fatalf("UpdateUserRoleGuarded: %v", err)
+	}
+	u, _ := s.GetUserByID(uid)
+	if u.Role != "admin" {
+		t.Errorf("expected role=admin, got %q", u.Role)
+	}
+}
+
+func TestUpdateUserRoleGuarded_DemoteLastAdmin_ReturnsErr(t *testing.T) {
+	s := setupTestStore(t)
+
+	uid, err := s.CreateAdminBootstrap("only@example.com", "h", "Only")
+	if err != nil {
+		t.Fatalf("CreateAdminBootstrap: %v", err)
+	}
+
+	err = s.UpdateUserRoleGuarded(uid, "user")
+	if !errors.Is(err, ErrLastActiveAdmin) {
+		t.Errorf("expected ErrLastActiveAdmin, got %v", err)
+	}
+	u, _ := s.GetUserByID(uid)
+	if u.Role != "admin" {
+		t.Errorf("role must remain admin after rejection, got %q", u.Role)
+	}
+}
+
+func TestUpdateUserRoleGuarded_DemoteSecondAdmin_OK(t *testing.T) {
+	s := setupTestStore(t)
+
+	_, err := s.CreateAdminBootstrap("keep@example.com", "h", "Keep")
+	if err != nil {
+		t.Fatalf("CreateAdminBootstrap keep: %v", err)
+	}
+	victim, err := s.CreateAdminBootstrap("victim@example.com", "h", "Victim")
+	if err != nil {
+		t.Fatalf("CreateAdminBootstrap victim: %v", err)
+	}
+
+	if err := s.UpdateUserRoleGuarded(victim, "user"); err != nil {
+		t.Fatalf("UpdateUserRoleGuarded: %v", err)
+	}
+	u, _ := s.GetUserByID(victim)
+	if u.Role != "user" {
+		t.Errorf("expected role=user, got %q", u.Role)
+	}
+}
+
+func TestUpdateUserRoleGuarded_InactiveAdmin_DemoteOK(t *testing.T) {
+	// Inactive admins don't count toward the active-admin total, so demoting
+	// one is allowed even if it's the "only admin by role".
+	s := setupTestStore(t)
+
+	_, _ = s.CreateAdminBootstrap("active@example.com", "h", "Active")
+	sleeper, _ := s.CreateAdminBootstrap("sleeper@example.com", "h", "Sleeper")
+	if err := s.SetUserActive(sleeper, false); err != nil {
+		t.Fatalf("SetUserActive: %v", err)
+	}
+
+	if err := s.UpdateUserRoleGuarded(sleeper, "user"); err != nil {
+		t.Fatalf("expected demote of inactive admin to succeed, got %v", err)
+	}
+}
+
+func TestUpdateUserRoleGuarded_InvalidRole(t *testing.T) {
+	s := setupTestStore(t)
+	uid, _ := s.CreateUser("bad@example.com", "h", "Bad")
+	err := s.UpdateUserRoleGuarded(uid, "superadmin")
+	if !errors.Is(err, ErrInvalidRole) {
+		t.Errorf("expected ErrInvalidRole, got %v", err)
+	}
+}
+
+func TestUpdateUserRoleGuarded_NotFound(t *testing.T) {
+	s := setupTestStore(t)
+	err := s.UpdateUserRoleGuarded(99999, "admin")
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Errorf("expected ErrUserNotFound, got %v", err)
+	}
+}
+
+func TestUpdateUserRoleGuarded_Noop(t *testing.T) {
+	// Setting the same role should succeed as a noop (no guardrail trip).
+	s := setupTestStore(t)
+	uid, _ := s.CreateAdminBootstrap("noop@example.com", "h", "Noop")
+	if err := s.UpdateUserRoleGuarded(uid, "admin"); err != nil {
+		t.Errorf("noop role change should succeed, got %v", err)
+	}
+}
+
+func TestUpdateUserRoleGuarded_ConcurrentRaceSerializes(t *testing.T) {
+	// Two concurrent demotions from admin→user, when only two active admins
+	// exist, must serialize on the advisory lock. Exactly one should win.
+	s := setupTestStore(t)
+
+	adminA, err := s.CreateAdminBootstrap("race-a@example.com", "h", "A")
+	if err != nil {
+		t.Fatalf("CreateAdminBootstrap A: %v", err)
+	}
+	adminB, err := s.CreateAdminBootstrap("race-b@example.com", "h", "B")
+	if err != nil {
+		t.Fatalf("CreateAdminBootstrap B: %v", err)
+	}
+
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		errs []error
+	)
+	for _, id := range []int64{adminA, adminB} {
+		wg.Add(1)
+		go func(uid int64) {
+			defer wg.Done()
+			e := s.UpdateUserRoleGuarded(uid, "user")
+			mu.Lock()
+			errs = append(errs, e)
+			mu.Unlock()
+		}(id)
+	}
+	wg.Wait()
+
+	var successes, conflicts int
+	for _, e := range errs {
+		switch {
+		case e == nil:
+			successes++
+		case errors.Is(e, ErrLastActiveAdmin):
+			conflicts++
+		default:
+			t.Errorf("unexpected error: %v", e)
+		}
+	}
+	if successes != 1 {
+		t.Errorf("expected 1 success, got %d (errs=%v)", successes, errs)
+	}
+	if conflicts != 1 {
+		t.Errorf("expected 1 last_admin conflict, got %d (errs=%v)", conflicts, errs)
+	}
+
+	// Exactly one admin still present.
+	ctx := context.Background()
+	var count int
+	_ = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM users WHERE role='admin' AND is_active=TRUE`,
+	).Scan(&count)
+	if count != 1 {
+		t.Errorf("expected 1 remaining active admin, got %d", count)
+	}
+}
+
+func TestListRegistrationEvents_ReturnsRowsNewestFirst(t *testing.T) {
+	s := setupTestStore(t)
+
+	// Create two users via RegisterUser (public_signup) — produces two events.
+	accountA, userA, err := s.RegisterUser("a@example.com", "h", "A")
+	if err != nil {
+		t.Fatalf("RegisterUser A: %v", err)
+	}
+	_, userB, err := s.RegisterUser("b@example.com", "h", "B")
+	if err != nil {
+		t.Fatalf("RegisterUser B: %v", err)
+	}
+
+	events, total, err := s.ListRegistrationEvents(50, 0)
+	if err != nil {
+		t.Fatalf("ListRegistrationEvents: %v", err)
+	}
+	if total < 2 {
+		t.Fatalf("expected at least 2 events, got total=%d", total)
+	}
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 event rows, got %d", len(events))
+	}
+	// Most recent first.
+	if events[0].UserID == nil || *events[0].UserID != userB {
+		t.Errorf("expected first row to be userB (%d), got %+v", userB, events[0].UserID)
+	}
+	if events[1].UserID == nil || *events[1].UserID != userA {
+		t.Errorf("expected second row to be userA (%d), got %+v", userA, events[1].UserID)
+	}
+	// Enriched fields present.
+	if events[0].UserEmail == nil || *events[0].UserEmail != "b@example.com" {
+		t.Errorf("expected user email 'b@example.com', got %+v", events[0].UserEmail)
+	}
+	if events[1].AccountID == nil || *events[1].AccountID != accountA {
+		t.Errorf("expected account for user A = %d, got %+v", accountA, events[1].AccountID)
+	}
+}
+
+func TestListRegistrationEvents_Pagination(t *testing.T) {
+	s := setupTestStore(t)
+
+	for i := 0; i < 5; i++ {
+		email := string(rune('a'+i)) + "@pag.test"
+		if _, _, err := s.RegisterUser(email, "h", "U"); err != nil {
+			t.Fatalf("RegisterUser: %v", err)
+		}
+	}
+
+	page1, total, _ := s.ListRegistrationEvents(2, 0)
+	if total != 5 {
+		t.Errorf("expected total=5, got %d", total)
+	}
+	if len(page1) != 2 {
+		t.Errorf("expected 2 rows on page1, got %d", len(page1))
+	}
+
+	page3, _, _ := s.ListRegistrationEvents(2, 4)
+	if len(page3) != 1 {
+		t.Errorf("expected 1 row on page3 (offset=4 total=5), got %d", len(page3))
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -25,6 +25,14 @@ var ErrLastActiveAdmin = errors.New("cannot remove the last active admin")
 // does not exist.
 var ErrUserNotFound = errors.New("user not found")
 
+// ErrKeyNotFound is returned by key-mutation helpers when the target row
+// does not exist.
+var ErrKeyNotFound = errors.New("key not found")
+
+// ErrInvalidRole is returned by UpdateUserRoleGuarded when the caller
+// supplies a role outside the allowed set.
+var ErrInvalidRole = errors.New("invalid role")
+
 // pgUniqueViolation is the Postgres SQLSTATE code for unique constraint
 // violations. Used to distinguish "email already taken" from other errors.
 const pgUniqueViolation = "23505"
@@ -325,6 +333,43 @@ func (s *Store) ListKeys() ([]APIKey, error) {
 	return keys, rows.Err()
 }
 
+// GetKeyByID looks up an API key by ID, including revoked keys so admin UI
+// can display their history.
+func (s *Store) GetKeyByID(id int64) (*APIKey, error) {
+	var apiKey APIKey
+	err := s.pool.QueryRow(
+		context.Background(),
+		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit
+		 FROM api_keys WHERE id = $1`, id,
+	).Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyHash, &apiKey.KeyPrefix, &apiKey.RateLimit,
+		&apiKey.CreatedAt, &apiKey.Revoked, &apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &apiKey, nil
+}
+
+// UpdateKeyRateLimit sets a new rate_limit on an existing key. The caller is
+// responsible for applying ratelimit.ApplyConfigDefaultsAndCap — this method
+// writes whatever value it's given.
+func (s *Store) UpdateKeyRateLimit(id int64, rateLimit int) error {
+	ct, err := s.pool.Exec(
+		context.Background(),
+		`UPDATE api_keys SET rate_limit = $1 WHERE id = $2`,
+		rateLimit, id,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return ErrKeyNotFound
+	}
+	return nil
+}
+
 // RevokeKey soft-deletes a key by setting revoked = TRUE.
 func (s *Store) RevokeKey(id int64) error {
 	ct, err := s.pool.Exec(context.Background(), `UPDATE api_keys SET revoked = TRUE WHERE id = $1`, id)
@@ -514,6 +559,71 @@ func (s *Store) DeactivateUserGuarded(id int64) error {
 		`UPDATE users SET is_active = FALSE, updated_at = NOW() WHERE id = $1`, id,
 	); err != nil {
 		return fmt.Errorf("deactivate: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// UpdateUserRoleGuarded changes a user's role with the same advisory-lock
+// protection as DeactivateUserGuarded. Demoting the last active admin is
+// rejected with ErrLastActiveAdmin; unknown roles are rejected with
+// ErrInvalidRole.
+func (s *Store) UpdateUserRoleGuarded(id int64, newRole string) error {
+	if newRole != "admin" && newRole != "user" {
+		return ErrInvalidRole
+	}
+
+	ctx := context.Background()
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext('admin_mutations'))`); err != nil {
+		return fmt.Errorf("advisory lock: %w", err)
+	}
+
+	var currentRole string
+	var currentActive bool
+	err = tx.QueryRow(ctx,
+		`SELECT role, is_active FROM users WHERE id = $1 FOR UPDATE`, id,
+	).Scan(&currentRole, &currentActive)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrUserNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("load user: %w", err)
+	}
+
+	// Noop — avoids a pointless UPDATE and always-safe outcome.
+	if currentRole == newRole {
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("commit: %w", err)
+		}
+		return nil
+	}
+
+	// Only demotion from an active admin can breach the last-admin invariant.
+	if currentRole == "admin" && currentActive && newRole != "admin" {
+		var activeAdmins int
+		if err := tx.QueryRow(ctx,
+			`SELECT COUNT(*) FROM users WHERE role = 'admin' AND is_active = TRUE`,
+		).Scan(&activeAdmins); err != nil {
+			return fmt.Errorf("count active admins: %w", err)
+		}
+		if activeAdmins <= 1 {
+			return ErrLastActiveAdmin
+		}
+	}
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE users SET role = $1, updated_at = NOW() WHERE id = $2`, newRole, id,
+	); err != nil {
+		return fmt.Errorf("update role: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {


### PR DESCRIPTION
## Summary
- Adds 5 admin endpoints per PLAN.md §Backend PR Sequence row 3:
  `GET /api/admin/users/{id}`, `PUT …/role`, `GET /api/admin/keys/{id}`,
  `PUT …/rate-limit`, `GET /api/admin/registrations`.
- Role change is guarded by the same advisory-lock pattern used in PR 0's
  deactivation (refuses demoting the last active admin → 409 `last_admin`).
- Rate-limit update reuses the PR 0 cap helper (`ApplyConfigDefaultsAndCap`)
  so validation matches the create path — reject >10000, default ≤0 → 60.
- Registrations feed reads `registration_events` (created PR 0, backfilled
  PR 1) with user/account LEFT JOIN enrichment and `{limit, offset, total}`
  pagination.
- All new endpoints return the BE 2 envelope (`{data, pagination?}`).

## Store additions
- `GetKeyByID`, `UpdateKeyRateLimit` (`ErrKeyNotFound`)
- `UpdateUserRoleGuarded` (`ErrInvalidRole`, `ErrLastActiveAdmin`, `ErrUserNotFound`)
- `ListRegistrationEvents(limit, offset) → (rows, total, err)` with `RegistrationEvent` DTO

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] Full suite `go test -race -count=1 -p 1` → 501 tests pass in 15 packages
- [x] Coverage 84.2% (threshold 60%)
- [ ] CI green on GitHub Actions (postgres:16 service)
- [ ] Manual smoke: hit each endpoint via `X-Admin-Key` and via Bearer session

## Notes for the reviewer
- Routing: Go 1.22+ `mux.HandleFunc("GET /api/admin/users/{id}", …)` coexists
  with the existing `…/{id}/activate|deactivate|role` patterns — no shadowing
  (covered by `TestAdmin_UserDetail_DoesNotShadowActivate`).
- `updateKeyRateLimit` uses a `*int` JSON field to distinguish "omitted" (400)
  from explicit `0` (→ default 60, same as createKey semantics).
- `RegistrationEvent.Metadata` is stored as JSONB; the handler best-effort
  decodes it so clients see structured JSON, not base64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)