### PR TITLE
Reject non-positive rate_limit on PUT /admin/keys/{id}/rate-limit

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -919,10 +919,11 @@ func (h *handler) updateKeyRateLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Pointer so we can distinguish "omitted" from "explicit 0". Omitted is
-	// rejected (we can't default silently — callers who meant to set 60 should
-	// say so); explicit 0 or negative is mapped to the default (same semantics
-	// as createKey / createAccountKey).
+	// Pointer so we can distinguish "omitted" from "explicit 0". Unlike
+	// createKey — which maps <=0 to 60 for back-compat with clients that
+	// simply omit the field — an explicit update is required to name a
+	// positive integer (PLAN.md §PR 0 note on PR 3). We still reuse the
+	// cap helper for the upper bound.
 	var req struct {
 		RateLimit *int `json:"rate_limit"`
 	}
@@ -932,6 +933,10 @@ func (h *handler) updateKeyRateLimit(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.RateLimit == nil {
 		proxy.WriteError(w, r, http.StatusBadRequest, "missing_rate_limit", "invalid_request_error", "rate_limit is required")
+		return
+	}
+	if *req.RateLimit <= 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_rate_limit", "invalid_request_error", "rate_limit must be a positive integer")
 		return
 	}
 	rateLimit, err := ratelimit.ApplyConfigDefaultsAndCap(*req.RateLimit)

--- a/internal/admin/detail_mutations_test.go
+++ b/internal/admin/detail_mutations_test.go
@@ -250,7 +250,10 @@ func TestAdmin_UpdateKeyRateLimit_CapEnforced(t *testing.T) {
 	}
 }
 
-func TestAdmin_UpdateKeyRateLimit_ZeroAppliesDefault(t *testing.T) {
+func TestAdmin_UpdateKeyRateLimit_RejectsZero(t *testing.T) {
+	// Explicit updates must name a positive integer — unlike createKey, which
+	// treats 0 as "omitted → default 60" for back-compat. See PLAN.md §PR 0
+	// note on PR 3.
 	h, s := setupAdminTest(t)
 	kid, _ := s.CreateKey("zero-key", "hash-zro", "sk-zro", 120)
 
@@ -261,12 +264,32 @@ func TestAdmin_UpdateKeyRateLimit_ZeroAppliesDefault(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for explicit rate_limit=0, got %d: %s", rec.Code, rec.Body.String())
 	}
 	k, _ := s.GetKeyByID(kid)
-	if k.RateLimit != 60 {
-		t.Errorf("expected default rate_limit=60, got %d", k.RateLimit)
+	if k.RateLimit != 120 {
+		t.Errorf("expected rate_limit unchanged=120, got %d", k.RateLimit)
+	}
+}
+
+func TestAdmin_UpdateKeyRateLimit_RejectsNegative(t *testing.T) {
+	h, s := setupAdminTest(t)
+	kid, _ := s.CreateKey("neg-key", "hash-neg", "sk-neg", 90)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/keys/"+strconv.FormatInt(kid, 10)+"/rate-limit",
+		bytes.NewBufferString(`{"rate_limit":-5}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for negative rate_limit, got %d: %s", rec.Code, rec.Body.String())
+	}
+	k, _ := s.GetKeyByID(kid)
+	if k.RateLimit != 90 {
+		t.Errorf("expected rate_limit unchanged=90, got %d", k.RateLimit)
 	}
 }
 


### PR DESCRIPTION
## Summary
Follow-up to PR #26 (BE PR 3). The rate-limit-reject fix commit got dropped in the squash-merge, so `main` still silently rewrites explicit `<= 0` updates to `60`. This reapplies the fix.

Per PLAN.md §PR 0 note on PR 3: explicit updates to `PUT /admin/keys/{id}/rate-limit` must name a positive integer — unlike `createKey`, which preserves `<=0 → 60` for back-compat with clients that omit the field. Handler now returns 400 `invalid_rate_limit` before calling the cap helper; stored value is unchanged.

## Test plan
- [x] `TestAdmin_UpdateKeyRateLimit_RejectsZero` + `RejectsNegative` (replace `ZeroAppliesDefault`)
- [x] Rate-limit test group: 6 pass locally against postgres:16
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)