### PR TITLE
BE PR 4: Opt-in pagination rollout on admin list endpoints

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -260,6 +260,22 @@ func (h *handler) createKey(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) listKeys(w http.ResponseWriter, r *http.Request) {
+	envelope, ecode, emsg, eerr := wantEnvelope(r)
+	if eerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, ecode, "invalid_request_error", emsg)
+		return
+	}
+	isActive, acode, amsg, aerr := parseIsActiveFilter(r)
+	if aerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, acode, "invalid_request_error", amsg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
 	keys, err := h.store.ListKeys()
 	if err != nil {
 		slog.ErrorContext(r.Context(), "list keys error", "error", err)
@@ -267,16 +283,27 @@ func (h *handler) listKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := make([]keyResponse, len(keys))
-	for i, apiKey := range keys {
-		resp[i] = keyResponse{
+	// is_active on keys maps to the inverse of Revoked: an active key is one
+	// that hasn't been revoked. No dedicated "enabled" column exists.
+	resp := make([]keyResponse, 0, len(keys))
+	for _, apiKey := range keys {
+		if isActive != nil && *isActive == apiKey.Revoked {
+			continue
+		}
+		resp = append(resp, keyResponse{
 			ID:        apiKey.ID,
 			Name:      apiKey.Name,
 			KeyPrefix: apiKey.KeyPrefix,
 			RateLimit: apiKey.RateLimit,
 			CreatedAt: apiKey.CreatedAt,
 			Revoked:   apiKey.Revoked,
-		}
+		})
+	}
+
+	if envelope {
+		page, pag := sliceWindow(resp, limit, offset)
+		writeEnvelope(w, page, pag)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -306,6 +333,17 @@ func (h *handler) revokeKey(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) getUsage(w http.ResponseWriter, r *http.Request) {
+	envelope, ecode, emsg, eerr := wantEnvelope(r)
+	if eerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, ecode, "invalid_request_error", emsg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
 	var keyID *int64
 	var since *time.Time
 
@@ -338,11 +376,38 @@ func (h *handler) getUsage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if envelope {
+		page, pag := sliceWindow(stats, limit, offset)
+		writeEnvelope(w, page, pag)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(stats)
 }
 
 func (h *handler) listUsers(w http.ResponseWriter, r *http.Request) {
+	envelope, ecode, emsg, eerr := wantEnvelope(r)
+	if eerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, ecode, "invalid_request_error", emsg)
+		return
+	}
+	role, rcode, rmsg, rerr := parseRoleFilter(r)
+	if rerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, rcode, "invalid_request_error", rmsg)
+		return
+	}
+	isActive, acode, amsg, aerr := parseIsActiveFilter(r)
+	if aerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, acode, "invalid_request_error", amsg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
 	users, err := h.store.ListUsers()
 	if err != nil {
 		slog.ErrorContext(r.Context(), "list users error", "error", err)
@@ -359,16 +424,28 @@ func (h *handler) listUsers(w http.ResponseWriter, r *http.Request) {
 		CreatedAt string `json:"created_at"`
 	}
 
-	resp := make([]userResponse, len(users))
-	for i, u := range users {
-		resp[i] = userResponse{
+	resp := make([]userResponse, 0, len(users))
+	for _, u := range users {
+		if role != "" && u.Role != role {
+			continue
+		}
+		if isActive != nil && u.IsActive != *isActive {
+			continue
+		}
+		resp = append(resp, userResponse{
 			ID:        u.ID,
 			Email:     u.Email,
 			Name:      u.Name,
 			Role:      u.Role,
 			IsActive:  u.IsActive,
 			CreatedAt: u.CreatedAt.Format(time.RFC3339),
-		}
+		})
+	}
+
+	if envelope {
+		page, pag := sliceWindow(resp, limit, offset)
+		writeEnvelope(w, page, pag)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -427,6 +504,27 @@ func (h *handler) deactivateUser(w http.ResponseWriter, r *http.Request) {
 // --- Credit management ---
 
 func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
+	envelope, ecode, emsg, eerr := wantEnvelope(r)
+	if eerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, ecode, "invalid_request_error", emsg)
+		return
+	}
+	accType, tcode, tmsg, terr := parseAccountTypeFilter(r)
+	if terr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, tcode, "invalid_request_error", tmsg)
+		return
+	}
+	isActive, acode, amsg, aerr := parseIsActiveFilter(r)
+	if aerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, acode, "invalid_request_error", amsg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
 	accounts, err := h.store.ListAccountsWithBalances()
 	if err != nil {
 		slog.ErrorContext(r.Context(), "list accounts error", "error", err)
@@ -445,9 +543,15 @@ func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 		CreatedAt string  `json:"created_at"`
 	}
 
-	resp := make([]accountResponse, len(accounts))
-	for i, a := range accounts {
-		resp[i] = accountResponse{
+	resp := make([]accountResponse, 0, len(accounts))
+	for _, a := range accounts {
+		if accType != "" && a.Type != accType {
+			continue
+		}
+		if isActive != nil && a.IsActive != *isActive {
+			continue
+		}
+		resp = append(resp, accountResponse{
 			ID:        a.ID,
 			Name:      a.Name,
 			Type:      a.Type,
@@ -456,7 +560,13 @@ func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 			Reserved:  a.Reserved,
 			Available: a.Balance - a.Reserved,
 			CreatedAt: a.CreatedAt.Format(time.RFC3339),
-		}
+		})
+	}
+
+	if envelope {
+		page, pag := sliceWindow(resp, limit, offset)
+		writeEnvelope(w, page, pag)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -609,6 +719,22 @@ func (h *handler) createRegistrationToken(w http.ResponseWriter, r *http.Request
 }
 
 func (h *handler) listRegistrationTokens(w http.ResponseWriter, r *http.Request) {
+	envelope, ecode, emsg, eerr := wantEnvelope(r)
+	if eerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, ecode, "invalid_request_error", emsg)
+		return
+	}
+	isActive, acode, amsg, aerr := parseIsActiveFilter(r)
+	if aerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, acode, "invalid_request_error", amsg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
 	tokens, err := h.store.ListRegistrationTokens()
 	if err != nil {
 		slog.ErrorContext(r.Context(), "list registration tokens error", "error", err)
@@ -627,8 +753,12 @@ func (h *handler) listRegistrationTokens(w http.ResponseWriter, r *http.Request)
 		Revoked     bool    `json:"revoked"`
 	}
 
-	resp := make([]tokenResponse, len(tokens))
-	for i, t := range tokens {
+	// is_active on registration tokens maps to the inverse of Revoked.
+	resp := make([]tokenResponse, 0, len(tokens))
+	for _, t := range tokens {
+		if isActive != nil && *isActive == t.Revoked {
+			continue
+		}
 		tr := tokenResponse{
 			ID:          t.ID,
 			Name:        t.Name,
@@ -642,7 +772,13 @@ func (h *handler) listRegistrationTokens(w http.ResponseWriter, r *http.Request)
 			s := t.ExpiresAt.Format(time.RFC3339)
 			tr.ExpiresAt = &s
 		}
-		resp[i] = tr
+		resp = append(resp, tr)
+	}
+
+	if envelope {
+		page, pag := sliceWindow(resp, limit, offset)
+		writeEnvelope(w, page, pag)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -673,10 +809,30 @@ func (h *handler) revokeRegistrationToken(w http.ResponseWriter, r *http.Request
 // --- Pricing ---
 
 func (h *handler) listPricing(w http.ResponseWriter, r *http.Request) {
+	envelope, ecode, emsg, eerr := wantEnvelope(r)
+	if eerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, ecode, "invalid_request_error", emsg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
+	// ListActivePricing already returns only active rows, so is_active has no
+	// endpoint-specific meaning here and is not accepted. Pricing gets
+	// envelope + pagination only.
 	pricing, err := h.store.ListActivePricing()
 	if err != nil {
 		slog.ErrorContext(r.Context(), "list pricing error", "error", err)
 		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to list pricing")
+		return
+	}
+
+	if envelope {
+		page, pag := sliceWindow(pricing, limit, offset)
+		writeEnvelope(w, page, pag)
 		return
 	}
 

--- a/internal/admin/list_envelope_test.go
+++ b/internal/admin/list_envelope_test.go
@@ -1,0 +1,475 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// ---- Shared helpers -------------------------------------------------------
+
+func doAdminGET(t *testing.T, h http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// decodeEnvelope expects a `{data, pagination}` shape; caller supplies the
+// concrete data slice type via the generic parameter.
+func decodeEnvelope[T any](t *testing.T, body []byte) (T, *Pagination) {
+	t.Helper()
+	var env struct {
+		Data       T           `json:"data"`
+		Pagination *Pagination `json:"pagination"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decodeEnvelope: %v\nbody: %s", err, string(body))
+	}
+	return env.Data, env.Pagination
+}
+
+// ---- /api/admin/keys ------------------------------------------------------
+
+func seedThreeKeys(t *testing.T, s *store.Store) (activeIDs []int64, revokedID int64) {
+	t.Helper()
+	for i := 0; i < 3; i++ {
+		id, err := s.CreateKey(fmt.Sprintf("k%d", i), fmt.Sprintf("hash-%d", i), fmt.Sprintf("sk-k%d", i), 60)
+		if err != nil {
+			t.Fatalf("CreateKey: %v", err)
+		}
+		if i == 2 {
+			if err := s.RevokeKey(id); err != nil {
+				t.Fatalf("RevokeKey: %v", err)
+			}
+			revokedID = id
+		} else {
+			activeIDs = append(activeIDs, id)
+		}
+	}
+	return
+}
+
+func TestListKeys_LegacyShape_NoEnvelopeMetadata(t *testing.T) {
+	h, s := setupAdminTest(t)
+	seedThreeKeys(t, s)
+
+	rec := doAdminGET(t, h, "/api/admin/keys")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	// Legacy: must decode as a raw array. Any pagination key is a regression.
+	var arr []keyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &arr); err != nil {
+		t.Fatalf("legacy shape must be a raw array: %v", err)
+	}
+	if len(arr) != 3 {
+		t.Errorf("len=%d, want 3", len(arr))
+	}
+	if contains(rec.Body.String(), `"pagination"`) {
+		t.Error("legacy response must not include pagination key")
+	}
+}
+
+func TestListKeys_LegacyShape_WithIsActiveFilter_NoPagination(t *testing.T) {
+	// is_active on /keys means "not revoked". Filters apply in legacy mode;
+	// only the envelope wrapper is gated behind envelope=1.
+	h, s := setupAdminTest(t)
+	seedThreeKeys(t, s)
+
+	rec := doAdminGET(t, h, "/api/admin/keys?is_active=true")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var arr []keyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &arr); err != nil {
+		t.Fatalf("legacy shape must be a raw array: %v", err)
+	}
+	if len(arr) != 2 {
+		t.Errorf("len=%d, want 2 active keys", len(arr))
+	}
+	for _, k := range arr {
+		if k.Revoked {
+			t.Errorf("expected only non-revoked keys, got revoked %d", k.ID)
+		}
+	}
+}
+
+func TestListKeys_Envelope_PaginationTotalIsFilteredCount(t *testing.T) {
+	h, s := setupAdminTest(t)
+	seedThreeKeys(t, s)
+
+	// Revoked-only: filtered list has 1 row. pagination.total must reflect
+	// that, not the 3-row pre-filter list.
+	rec := doAdminGET(t, h, "/api/admin/keys?envelope=1&is_active=false")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]keyResponse](t, rec.Body.Bytes())
+	if pag == nil {
+		t.Fatal("envelope=1 must include pagination")
+	}
+	if pag.Total != 1 {
+		t.Errorf("pagination.total = %d, want 1 (filtered count)", pag.Total)
+	}
+	if len(data) != 1 {
+		t.Errorf("len(data) = %d, want 1", len(data))
+	}
+}
+
+func TestListKeys_Envelope_LimitOffset(t *testing.T) {
+	h, s := setupAdminTest(t)
+	for i := 0; i < 5; i++ {
+		if _, err := s.CreateKey(fmt.Sprintf("pg%d", i), fmt.Sprintf("pg-hash-%d", i), fmt.Sprintf("sk-pg%d", i), 60); err != nil {
+			t.Fatalf("CreateKey: %v", err)
+		}
+	}
+	rec := doAdminGET(t, h, "/api/admin/keys?envelope=1&limit=2&offset=2")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]keyResponse](t, rec.Body.Bytes())
+	if pag == nil || pag.Total != 5 || pag.Limit != 2 || pag.Offset != 2 {
+		t.Errorf("pagination=%+v, want {limit:2,offset:2,total:5}", pag)
+	}
+	if len(data) != 2 {
+		t.Errorf("len(data) = %d, want 2", len(data))
+	}
+}
+
+func TestListKeys_InvalidEnvelope_400(t *testing.T) {
+	h, _ := setupAdminTest(t)
+	rec := doAdminGET(t, h, "/api/admin/keys?envelope=true")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", rec.Code)
+	}
+}
+
+func TestListKeys_InvalidIsActive_400(t *testing.T) {
+	h, _ := setupAdminTest(t)
+	rec := doAdminGET(t, h, "/api/admin/keys?is_active=1")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", rec.Code)
+	}
+}
+
+// ---- /api/admin/users -----------------------------------------------------
+
+// seedUserWithRoleAndActive bypasses the handler layer to stamp role/is_active
+// directly so tests can produce a known distribution without exercising the
+// bootstrap/guardrail endpoints.
+func seedUserWithRoleAndActive(t *testing.T, s *store.Store, email, name, role string, active bool) int64 {
+	t.Helper()
+	id, err := s.CreateUser(email, "hash-"+email, name)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if role == "admin" {
+		if _, err := s.Pool().Exec(context.Background(),
+			`UPDATE users SET role='admin' WHERE id=$1`, id); err != nil {
+			t.Fatalf("set role: %v", err)
+		}
+	}
+	if !active {
+		if err := s.SetUserActive(id, false); err != nil {
+			t.Fatalf("SetUserActive: %v", err)
+		}
+	}
+	return id
+}
+
+func TestListUsers_LegacyShape(t *testing.T) {
+	h, s := setupAdminTest(t)
+	seedUserWithRoleAndActive(t, s, "u1@example.com", "U1", "user", true)
+	seedUserWithRoleAndActive(t, s, "u2@example.com", "U2", "admin", true)
+
+	rec := doAdminGET(t, h, "/api/admin/users")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if contains(rec.Body.String(), `"pagination"`) {
+		t.Error("legacy response must not include pagination key")
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &arr); err != nil {
+		t.Fatalf("expected array, got %v", err)
+	}
+	if len(arr) != 2 {
+		t.Errorf("len=%d, want 2", len(arr))
+	}
+}
+
+func TestListUsers_Envelope_RoleFilter(t *testing.T) {
+	h, s := setupAdminTest(t)
+	seedUserWithRoleAndActive(t, s, "u1@example.com", "U1", "user", true)
+	seedUserWithRoleAndActive(t, s, "a1@example.com", "A1", "admin", true)
+	seedUserWithRoleAndActive(t, s, "a2@example.com", "A2", "admin", true)
+
+	rec := doAdminGET(t, h, "/api/admin/users?envelope=1&role=admin")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]map[string]any](t, rec.Body.Bytes())
+	if pag == nil || pag.Total != 2 {
+		t.Errorf("pagination = %+v, want total=2 (filtered count)", pag)
+	}
+	if len(data) != 2 {
+		t.Errorf("len(data) = %d, want 2", len(data))
+	}
+	for _, u := range data {
+		if u["role"] != "admin" {
+			t.Errorf("got role=%v in admin-filtered list", u["role"])
+		}
+	}
+}
+
+func TestListUsers_Envelope_IsActiveFilter(t *testing.T) {
+	h, s := setupAdminTest(t)
+	seedUserWithRoleAndActive(t, s, "a1@example.com", "A1", "admin", true)
+	seedUserWithRoleAndActive(t, s, "u1@example.com", "U1", "user", true)
+	seedUserWithRoleAndActive(t, s, "u2@example.com", "U2", "user", false)
+
+	rec := doAdminGET(t, h, "/api/admin/users?envelope=1&is_active=false")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]map[string]any](t, rec.Body.Bytes())
+	if pag == nil || pag.Total != 1 {
+		t.Errorf("pagination = %+v, want total=1", pag)
+	}
+	if len(data) != 1 || data[0]["email"] != "u2@example.com" {
+		t.Errorf("unexpected data=%+v", data)
+	}
+}
+
+func TestListUsers_InvalidRole_400(t *testing.T) {
+	h, _ := setupAdminTest(t)
+	rec := doAdminGET(t, h, "/api/admin/users?role=superadmin")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", rec.Code)
+	}
+}
+
+func TestListUsers_InvalidLimit_400(t *testing.T) {
+	h, _ := setupAdminTest(t)
+	rec := doAdminGET(t, h, "/api/admin/users?limit=-5")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", rec.Code)
+	}
+}
+
+// ---- /api/admin/accounts --------------------------------------------------
+
+func TestListAccounts_LegacyShape(t *testing.T) {
+	h, s := setupAdminTest(t)
+	if _, err := s.CreateAccount("acc-a", "personal"); err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if _, err := s.CreateAccount("acc-b", "service"); err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	rec := doAdminGET(t, h, "/api/admin/accounts")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if contains(rec.Body.String(), `"pagination"`) {
+		t.Error("legacy response must not include pagination key")
+	}
+}
+
+func TestListAccounts_Envelope_TypeFilter(t *testing.T) {
+	h, s := setupAdminTest(t)
+	_, _ = s.CreateAccount("p-1", "personal")
+	_, _ = s.CreateAccount("p-2", "personal")
+	_, _ = s.CreateAccount("s-1", "service")
+
+	rec := doAdminGET(t, h, "/api/admin/accounts?envelope=1&type=service")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]map[string]any](t, rec.Body.Bytes())
+	if pag == nil || pag.Total != 1 {
+		t.Errorf("pagination = %+v, want total=1", pag)
+	}
+	if len(data) != 1 || data[0]["type"] != "service" {
+		t.Errorf("unexpected data=%+v", data)
+	}
+}
+
+func TestListAccounts_Envelope_IsActiveFilter(t *testing.T) {
+	h, s := setupAdminTest(t)
+	a1, _ := s.CreateAccount("active-acc", "personal")
+	a2, _ := s.CreateAccount("inactive-acc", "personal")
+	_ = a1
+	if err := s.SetAccountActive(a2, false); err != nil {
+		t.Fatalf("SetAccountActive: %v", err)
+	}
+
+	rec := doAdminGET(t, h, "/api/admin/accounts?envelope=1&is_active=false")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]map[string]any](t, rec.Body.Bytes())
+	if pag == nil || pag.Total != 1 {
+		t.Errorf("pagination = %+v, want total=1", pag)
+	}
+	if len(data) != 1 || data[0]["name"] != "inactive-acc" {
+		t.Errorf("unexpected data=%+v", data)
+	}
+}
+
+func TestListAccounts_InvalidType_400(t *testing.T) {
+	h, _ := setupAdminTest(t)
+	rec := doAdminGET(t, h, "/api/admin/accounts?type=other")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", rec.Code)
+	}
+}
+
+// ---- /api/admin/pricing ---------------------------------------------------
+
+func TestListPricing_LegacyShape(t *testing.T) {
+	h, s := setupAdminTest(t)
+	_ = s.UpsertPricing("m1", 0.001, 0.002, 500)
+	_ = s.UpsertPricing("m2", 0.003, 0.004, 500)
+
+	rec := doAdminGET(t, h, "/api/admin/pricing")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if contains(rec.Body.String(), `"pagination"`) {
+		t.Error("legacy response must not include pagination key")
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &arr); err != nil {
+		t.Fatalf("legacy shape must be a raw array: %v", err)
+	}
+	if len(arr) < 2 {
+		t.Errorf("len=%d, want >=2", len(arr))
+	}
+}
+
+func TestListPricing_Envelope_Pagination(t *testing.T) {
+	h, s := setupAdminTest(t)
+	_ = s.UpsertPricing("m1", 0.001, 0.002, 500)
+	_ = s.UpsertPricing("m2", 0.003, 0.004, 500)
+	_ = s.UpsertPricing("m3", 0.005, 0.006, 500)
+
+	rec := doAdminGET(t, h, "/api/admin/pricing?envelope=1&limit=2&offset=0")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]map[string]any](t, rec.Body.Bytes())
+	if pag == nil || pag.Total != 3 || pag.Limit != 2 {
+		t.Errorf("pagination = %+v, want {limit:2, total:3}", pag)
+	}
+	if len(data) != 2 {
+		t.Errorf("len(data) = %d, want 2", len(data))
+	}
+}
+
+// ---- /api/admin/registration-tokens ---------------------------------------
+
+func TestListRegistrationTokens_LegacyShape(t *testing.T) {
+	h, s := setupAdminTest(t)
+	_, _ = s.CreateRegistrationToken("t1", "reg-hash-1", 10, 1, nil)
+	_, _ = s.CreateRegistrationToken("t2", "reg-hash-2", 10, 1, nil)
+
+	rec := doAdminGET(t, h, "/api/admin/registration-tokens")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if contains(rec.Body.String(), `"pagination"`) {
+		t.Error("legacy response must not include pagination key")
+	}
+}
+
+func TestListRegistrationTokens_Envelope_IsActiveFilter_MapsToRevoked(t *testing.T) {
+	// is_active on /registration-tokens maps to the inverse of Revoked.
+	h, s := setupAdminTest(t)
+	_, _ = s.CreateRegistrationToken("active-t", "reg-hash-active", 10, 1, nil)
+	revokedID, _ := s.CreateRegistrationToken("revoked-t", "reg-hash-revoked", 10, 1, nil)
+	if err := s.RevokeRegistrationToken(revokedID); err != nil {
+		t.Fatalf("RevokeRegistrationToken: %v", err)
+	}
+
+	rec := doAdminGET(t, h, "/api/admin/registration-tokens?envelope=1&is_active=true")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]map[string]any](t, rec.Body.Bytes())
+	if pag == nil || pag.Total != 1 {
+		t.Errorf("pagination = %+v, want total=1", pag)
+	}
+	if len(data) != 1 || data[0]["name"] != "active-t" {
+		t.Errorf("unexpected data=%+v", data)
+	}
+}
+
+// ---- /api/admin/usage -----------------------------------------------------
+
+func TestGetUsage_LegacyShape_PreservesExistingParams(t *testing.T) {
+	h, s := setupAdminTest(t)
+	id, _ := s.CreateKey("usage-key", "u-hash", "sk-use", 60)
+	_ = s.LogUsage(store.UsageEntry{
+		APIKeyID: id, Model: "llama3",
+		PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15,
+		DurationMs: 100, Status: "completed",
+	})
+
+	// No envelope param → legacy raw array shape, existing key_id filter
+	// still honored.
+	rec := doAdminGET(t, h, fmt.Sprintf("/api/admin/usage?key_id=%d", id))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if contains(rec.Body.String(), `"pagination"`) {
+		t.Error("legacy /usage response must not include pagination key")
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &arr); err != nil {
+		t.Fatalf("legacy shape must be a raw array: %v", err)
+	}
+	if len(arr) != 1 {
+		t.Errorf("len=%d, want 1", len(arr))
+	}
+}
+
+func TestGetUsage_Envelope_WrapsWithPagination(t *testing.T) {
+	h, s := setupAdminTest(t)
+	id, _ := s.CreateKey("usage-key", "u-hash", "sk-use", 60)
+	for i := 0; i < 3; i++ {
+		_ = s.LogUsage(store.UsageEntry{
+			APIKeyID: id, Model: fmt.Sprintf("model-%d", i),
+			PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15,
+			DurationMs: 100, Status: "completed",
+		})
+	}
+
+	rec := doAdminGET(t, h, fmt.Sprintf("/api/admin/usage?envelope=1&key_id=%d&limit=2&offset=0", id))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]map[string]any](t, rec.Body.Bytes())
+	if pag == nil || pag.Total != 3 || pag.Limit != 2 {
+		t.Errorf("pagination = %+v, want {limit:2, total:3}", pag)
+	}
+	if len(data) != 2 {
+		t.Errorf("len(data) = %d, want 2", len(data))
+	}
+}
+
+func TestGetUsage_InvalidEnvelope_400(t *testing.T) {
+	h, _ := setupAdminTest(t)
+	rec := doAdminGET(t, h, "/api/admin/usage?envelope=yes")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", rec.Code)
+	}
+}

--- a/internal/admin/list_filters.go
+++ b/internal/admin/list_filters.go
@@ -1,0 +1,70 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// wantEnvelope reports whether the caller asked for the `{data, pagination}`
+// envelope via `?envelope=1`. Any other non-empty value besides "0" is a
+// validation error so typos like `envelope=true` don't silently fall through
+// to the legacy raw-array path. The returned code/message feed directly into
+// proxy.WriteError when err is non-nil.
+func wantEnvelope(r *http.Request) (bool, string, string, error) {
+	raw := r.URL.Query().Get("envelope")
+	switch raw {
+	case "", "0":
+		return false, "", "", nil
+	case "1":
+		return true, "", "", nil
+	default:
+		return false, "invalid_envelope", "envelope must be 0 or 1", strconv.ErrSyntax
+	}
+}
+
+// parseIsActiveFilter parses `?is_active=true|false`. Empty string returns
+// nil (no filter). Any other value is a validation error — no "1"/"0"/"yes"
+// aliases so the contract stays tight.
+func parseIsActiveFilter(r *http.Request) (*bool, string, string, error) {
+	raw := r.URL.Query().Get("is_active")
+	if raw == "" {
+		return nil, "", "", nil
+	}
+	switch raw {
+	case "true":
+		v := true
+		return &v, "", "", nil
+	case "false":
+		v := false
+		return &v, "", "", nil
+	default:
+		return nil, "invalid_is_active", "is_active must be true or false", strconv.ErrSyntax
+	}
+}
+
+// parseRoleFilter parses `?role=admin|user`. Empty string returns "" (no
+// filter). Any other value is a validation error.
+func parseRoleFilter(r *http.Request) (string, string, string, error) {
+	raw := r.URL.Query().Get("role")
+	switch raw {
+	case "":
+		return "", "", "", nil
+	case "admin", "user":
+		return raw, "", "", nil
+	default:
+		return "", "invalid_role", "role must be 'admin' or 'user'", strconv.ErrSyntax
+	}
+}
+
+// parseAccountTypeFilter parses `?type=personal|service`. Empty returns "".
+func parseAccountTypeFilter(r *http.Request) (string, string, string, error) {
+	raw := r.URL.Query().Get("type")
+	switch raw {
+	case "":
+		return "", "", "", nil
+	case "personal", "service":
+		return raw, "", "", nil
+	default:
+		return "", "invalid_type", "type must be 'personal' or 'service'", strconv.ErrSyntax
+	}
+}

--- a/internal/admin/list_filters_test.go
+++ b/internal/admin/list_filters_test.go
@@ -1,0 +1,109 @@
+package admin
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWantEnvelope(t *testing.T) {
+	cases := []struct {
+		qs      string
+		want    bool
+		wantErr bool
+		code    string
+	}{
+		{"", false, false, ""},
+		{"envelope=0", false, false, ""},
+		{"envelope=1", true, false, ""},
+		{"envelope=true", false, true, "invalid_envelope"},
+		{"envelope=yes", false, true, "invalid_envelope"},
+		{"envelope=2", false, true, "invalid_envelope"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.qs, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/x?"+tc.qs, nil)
+			got, code, _, err := wantEnvelope(req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.qs)
+				}
+				if code != tc.code {
+					t.Errorf("code = %q, want %q", code, tc.code)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseIsActiveFilter(t *testing.T) {
+	cases := []struct {
+		qs      string
+		wantPtr bool
+		wantVal bool
+		wantErr bool
+	}{
+		{"", false, false, false},
+		{"is_active=true", true, true, false},
+		{"is_active=false", true, false, false},
+		{"is_active=1", false, false, true},
+		{"is_active=yes", false, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.qs, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/x?"+tc.qs, nil)
+			got, _, _, err := parseIsActiveFilter(req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.qs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantPtr {
+				if got == nil {
+					t.Fatal("expected non-nil pointer")
+				}
+				if *got != tc.wantVal {
+					t.Errorf("*got = %v, want %v", *got, tc.wantVal)
+				}
+			} else if got != nil {
+				t.Errorf("expected nil pointer, got %v", *got)
+			}
+		})
+	}
+}
+
+func TestParseRoleFilter(t *testing.T) {
+	for _, qs := range []string{"", "role=admin", "role=user"} {
+		req := httptest.NewRequest("GET", "/x?"+qs, nil)
+		if _, _, _, err := parseRoleFilter(req); err != nil {
+			t.Errorf("unexpected err for %q: %v", qs, err)
+		}
+	}
+	req := httptest.NewRequest("GET", "/x?role=superadmin", nil)
+	if _, code, _, err := parseRoleFilter(req); err == nil || code != "invalid_role" {
+		t.Errorf("expected invalid_role error, got code=%q err=%v", code, err)
+	}
+}
+
+func TestParseAccountTypeFilter(t *testing.T) {
+	for _, qs := range []string{"", "type=personal", "type=service"} {
+		req := httptest.NewRequest("GET", "/x?"+qs, nil)
+		if _, _, _, err := parseAccountTypeFilter(req); err != nil {
+			t.Errorf("unexpected err for %q: %v", qs, err)
+		}
+	}
+	req := httptest.NewRequest("GET", "/x?type=other", nil)
+	if _, code, _, err := parseAccountTypeFilter(req); err == nil || code != "invalid_type" {
+		t.Errorf("expected invalid_type error, got code=%q err=%v", code, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `?envelope=1` opt-in wrapper on list endpoints: `/api/admin/{keys,users,accounts,pricing,registration-tokens,usage}`. Legacy raw-array shape is preserved when the param is omitted or `envelope=0`.
- Adds strict filter parsing (400 on bad values): `role` on `/users`; `type` on `/accounts`; endpoint-specific `is_active` on `/users`, `/accounts`, `/keys` (→ `!revoked`), `/registration-tokens` (→ `!revoked`). No `q` (deferred per locked decision #6).
- Filters apply in both legacy and envelope modes; pagination metadata only appears with `envelope=1`. `pagination.total` reflects the post-filter count so "showing X–Y of N" is accurate.

In-memory filter + `sliceWindow` for v1; SQL push-down deferred. Helpers (`wantEnvelope`, `parseRoleFilter`, `parseAccountTypeFilter`, `parseIsActiveFilter`) live in `internal/admin/list_filters.go` with dedicated unit tests.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./internal/admin/... -count=1` → 204 pass
- [x] `go test ./... -count=1 -p=1` → 539 pass
- [x] Unit tests for each filter parser (valid/invalid/empty)
- [x] Integration tests per endpoint covering: legacy shape has no pagination key; envelope shape decodes; filters reduce `pagination.total`; limit/offset window; invalid `envelope`/`role`/`type`/`is_active`/`limit` return 400
- [x] `/usage` regression: existing `key_id`/`since` params still honored in both shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)