### PR TITLE
BE PR 5: admin config + health endpoints

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -35,6 +36,11 @@ var (
 	buildTime = "unknown"
 )
 
+// usageChannelCapacity is the buffered size of the async usage-log channel.
+// Reported by /api/admin/config and used as the saturation threshold by both
+// the readiness probe and /api/admin/health.
+const usageChannelCapacity = 1000
+
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -62,8 +68,10 @@ func main() {
 	}
 	defer db.Close()
 
+	startTime := time.Now()
+
 	// Async usage logging channel
-	usageCh := make(chan store.UsageEntry, 1000)
+	usageCh := make(chan store.UsageEntry, usageChannelCapacity)
 
 	// Start async usage writer
 	writerCtx, writerCancel := context.WithCancel(context.Background())
@@ -137,12 +145,33 @@ func main() {
 	creditGate := credits.CreditGate(db, m)
 	rateLimitMiddleware := ratelimit.Middleware(limiter, m)
 	cors := middleware.CORS(cfg.CORSOrigins)
-	adminHandler := admin.NewHandler(db, cfg.AdminKey, usageCh)
-	bootstrapHandler := bootstrap.New(db, cfg.AdminBootstrapToken)
-	userHandler := user.NewHandler(db, cfg.DefaultCreditGrant)
 
 	hc := health.NewChecker(db, cfg.OllamaURL, func() int { return len(usageCh) }, cap(usageCh))
 	hc.SetOllamaGauge(m.OllamaUp)
+
+	configSnapshot := admin.ConfigSnapshot{
+		OllamaURL:               cfg.OllamaURL,
+		Port:                    cfg.Port,
+		LogLevel:                cfg.LogLevel,
+		MaxRequestBodyBytes:     cfg.MaxRequestBody,
+		DefaultCreditGrant:      cfg.DefaultCreditGrant,
+		CORSOrigins:             cfg.CORSOrigins,
+		AdminRateLimitPerMinute: admin.AdminKeyRateLimitPerMinute,
+		UsageChannelCapacity:    usageChannelCapacity,
+		AdminSessionDurationHrs: int(user.AdminSessionDuration / time.Hour),
+		UserSessionDurationHrs:  int(user.UserSessionDuration / time.Hour),
+		Version:                 version,
+		BuildTime:               buildTime,
+		GoVersion:               runtime.Version(),
+	}
+
+	adminHandler := admin.NewHandler(db, cfg.AdminKey, usageCh, admin.Options{
+		Snapshot:  configSnapshot,
+		Checker:   hc,
+		StartTime: startTime,
+	})
+	bootstrapHandler := bootstrap.New(db, cfg.AdminBootstrapToken)
+	userHandler := user.NewHandler(db, cfg.DefaultCreditGrant)
 
 	mux := http.NewServeMux()
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -15,10 +15,16 @@ import (
 	"time"
 
 	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/health"
 	"github.com/krishna/local-ai-proxy/internal/proxy"
 	"github.com/krishna/local-ai-proxy/internal/ratelimit"
 	"github.com/krishna/local-ai-proxy/internal/store"
 )
+
+// AdminKeyRateLimitPerMinute is the shared bucket size for X-Admin-Key requests.
+// Exposed so the /admin/config snapshot can report it without duplicating the
+// magic number.
+const AdminKeyRateLimitPerMinute = 10
 
 type handler struct {
 	store    *store.Store
@@ -32,6 +38,21 @@ type handler struct {
 
 	// Bearer session rate limiter: 300 req/min, one bucket per session (keyed by token hash).
 	sessionLimiter *sessionLimiter
+
+	// BE 5: dependencies for /admin/config + /admin/health. Zero values are
+	// safe — getConfig emits zeroed fields, getHealth reports zero uptime
+	// and an empty checks map.
+	configSnapshot ConfigSnapshot
+	healthChecker  *health.Checker
+	startTime      time.Time
+}
+
+// Options carries optional dependencies wired by main. Tests that don't touch
+// /admin/config or /admin/health may pass a zero-value Options.
+type Options struct {
+	Snapshot  ConfigSnapshot
+	Checker   *health.Checker
+	StartTime time.Time
 }
 
 type adminSessionCtxKey struct{}
@@ -65,14 +86,17 @@ type keyResponse struct {
 	Revoked   bool      `json:"revoked"`
 }
 
-func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.UsageEntry) http.Handler {
+func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.UsageEntry, opts Options) http.Handler {
 	handler := &handler{
 		store:             dataStore,
 		adminKey:          adminKey,
 		usageCh:           usageCh,
-		rateLimitTokens:   10,
+		rateLimitTokens:   AdminKeyRateLimitPerMinute,
 		rateLimitLastTime: time.Now(),
 		sessionLimiter:    newSessionLimiter(),
+		configSnapshot:    opts.Snapshot,
+		healthChecker:     opts.Checker,
+		startTime:         opts.StartTime,
 	}
 
 	mux := http.NewServeMux()
@@ -114,6 +138,10 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 
 	// Session limits
 	mux.HandleFunc("PUT /api/admin/keys/{id}/session-limit", handler.setSessionLimit)
+
+	// Config + health (BE 5)
+	mux.HandleFunc("GET /api/admin/config", handler.getConfig)
+	mux.HandleFunc("GET /api/admin/health", handler.getHealth)
 
 	return handler.authMiddleware(mux)
 }
@@ -203,7 +231,7 @@ func (h *handler) adminAllow() bool {
 
 	now := time.Now()
 	elapsed := now.Sub(h.rateLimitLastTime).Seconds()
-	h.rateLimitTokens = min(10, h.rateLimitTokens+elapsed*(10.0/60.0))
+	h.rateLimitTokens = min(float64(AdminKeyRateLimitPerMinute), h.rateLimitTokens+elapsed*(float64(AdminKeyRateLimitPerMinute)/60.0))
 	h.rateLimitLastTime = now
 
 	if h.rateLimitTokens >= 1 {

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -57,7 +57,7 @@ func setupAdminTest(t *testing.T) (http.Handler, *store.Store) {
 	})
 
 	usageCh := make(chan store.UsageEntry, 100)
-	h := NewHandler(s, testAdminKey, usageCh)
+	h := NewHandler(s, testAdminKey, usageCh, Options{})
 	return h, s
 }
 

--- a/internal/admin/config_health.go
+++ b/internal/admin/config_health.go
@@ -1,0 +1,68 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/health"
+)
+
+// ConfigSnapshot is the whitelisted view of runtime configuration exposed
+// at GET /api/admin/config. Secrets (admin_key, database_url,
+// admin_bootstrap_token) are deliberately absent — adding fields here is the
+// only way they reach the wire.
+type ConfigSnapshot struct {
+	OllamaURL                string  `json:"ollama_url"`
+	Port                     string  `json:"port"`
+	LogLevel                 string  `json:"log_level"`
+	MaxRequestBodyBytes      int64   `json:"max_request_body_bytes"`
+	DefaultCreditGrant       float64 `json:"default_credit_grant"`
+	CORSOrigins              string  `json:"cors_origins"`
+	AdminRateLimitPerMinute  int     `json:"admin_rate_limit_per_minute"`
+	UsageChannelCapacity     int     `json:"usage_channel_capacity"`
+	AdminSessionDurationHrs  int     `json:"admin_session_duration_hours"`
+	UserSessionDurationHrs   int     `json:"user_session_duration_hours"`
+	Version                  string  `json:"version"`
+	BuildTime                string  `json:"build_time"`
+	GoVersion                string  `json:"go_version"`
+}
+
+func (h *handler) getConfig(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(h.configSnapshot)
+}
+
+func (h *handler) getHealth(w http.ResponseWriter, r *http.Request) {
+	var (
+		allOK  = true
+		checks map[string]health.CheckResult
+	)
+	if h.healthChecker != nil {
+		allOK, checks = h.healthChecker.RunChecks(r.Context())
+	}
+	if checks == nil {
+		checks = map[string]health.CheckResult{}
+	}
+
+	status := "ok"
+	httpStatus := http.StatusOK
+	if !allOK {
+		status = "degraded"
+		httpStatus = http.StatusServiceUnavailable
+	}
+
+	uptime := int64(0)
+	if !h.startTime.IsZero() {
+		uptime = int64(time.Since(h.startTime).Seconds())
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":         status,
+		"checks":         checks,
+		"uptime_seconds": uptime,
+		"version":        h.configSnapshot.Version,
+	})
+}

--- a/internal/admin/config_health.go
+++ b/internal/admin/config_health.go
@@ -13,19 +13,19 @@ import (
 // admin_bootstrap_token) are deliberately absent — adding fields here is the
 // only way they reach the wire.
 type ConfigSnapshot struct {
-	OllamaURL                string  `json:"ollama_url"`
-	Port                     string  `json:"port"`
-	LogLevel                 string  `json:"log_level"`
-	MaxRequestBodyBytes      int64   `json:"max_request_body_bytes"`
-	DefaultCreditGrant       float64 `json:"default_credit_grant"`
-	CORSOrigins              string  `json:"cors_origins"`
-	AdminRateLimitPerMinute  int     `json:"admin_rate_limit_per_minute"`
-	UsageChannelCapacity     int     `json:"usage_channel_capacity"`
-	AdminSessionDurationHrs  int     `json:"admin_session_duration_hours"`
-	UserSessionDurationHrs   int     `json:"user_session_duration_hours"`
-	Version                  string  `json:"version"`
-	BuildTime                string  `json:"build_time"`
-	GoVersion                string  `json:"go_version"`
+	OllamaURL               string  `json:"ollama_url"`
+	Port                    string  `json:"port"`
+	LogLevel                string  `json:"log_level"`
+	MaxRequestBodyBytes     int64   `json:"max_request_body_bytes"`
+	DefaultCreditGrant      float64 `json:"default_credit_grant"`
+	CORSOrigins             string  `json:"cors_origins"`
+	AdminRateLimitPerMinute int     `json:"admin_rate_limit_per_minute"`
+	UsageChannelCapacity    int     `json:"usage_channel_capacity"`
+	AdminSessionDurationHrs int     `json:"admin_session_duration_hours"`
+	UserSessionDurationHrs  int     `json:"user_session_duration_hours"`
+	Version                 string  `json:"version"`
+	BuildTime               string  `json:"build_time"`
+	GoVersion               string  `json:"go_version"`
 }
 
 func (h *handler) getConfig(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/config_health_test.go
+++ b/internal/admin/config_health_test.go
@@ -1,0 +1,238 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/krishna/local-ai-proxy/internal/health"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// setupAdminWithObservability mirrors setupAdminTest but threads in the BE 5
+// dependencies. usageDepth/usageCap let a test force the usage_writer probe
+// into the "full" state.
+func setupAdminWithObservability(
+	t *testing.T,
+	snap ConfigSnapshot,
+	startTime time.Time,
+	ollamaURL string,
+	usageDepth, usageCap int,
+) http.Handler {
+	t.Helper()
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("DATABASE_URL not set, skipping admin integration test")
+	}
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	wipe := func(p *pgxpool.Pool) {
+		c := context.Background()
+		_, _ = p.Exec(c, "DELETE FROM registration_events")
+		_, _ = p.Exec(c, "DELETE FROM credit_holds")
+		_, _ = p.Exec(c, "DELETE FROM credit_transactions")
+		_, _ = p.Exec(c, "DELETE FROM account_usage_stats")
+		_, _ = p.Exec(c, "DELETE FROM credit_balances")
+		_, _ = p.Exec(c, "DELETE FROM credit_pricing")
+		_, _ = p.Exec(c, "DELETE FROM registration_tokens")
+		_, _ = p.Exec(c, "DELETE FROM usage_logs")
+		_, _ = p.Exec(c, "DELETE FROM user_sessions")
+		_, _ = p.Exec(c, "DELETE FROM api_keys")
+		_, _ = p.Exec(c, "DELETE FROM users")
+		_, _ = p.Exec(c, "DELETE FROM accounts")
+	}
+	wipe(s.Pool())
+	t.Cleanup(func() {
+		wipe(s.Pool())
+		s.Close()
+	})
+
+	usageCh := make(chan store.UsageEntry, 100)
+	checker := health.NewChecker(s, ollamaURL, func() int { return usageDepth }, usageCap)
+
+	return NewHandler(s, testAdminKey, usageCh, Options{
+		Snapshot:  snap,
+		Checker:   checker,
+		StartTime: startTime,
+	})
+}
+
+func defaultSnap() ConfigSnapshot {
+	return ConfigSnapshot{
+		OllamaURL:               "http://ollama.local:11434",
+		Port:                    "8080",
+		LogLevel:                "info",
+		MaxRequestBodyBytes:     52428800,
+		DefaultCreditGrant:      1.5,
+		CORSOrigins:             "*",
+		AdminRateLimitPerMinute: 10,
+		UsageChannelCapacity:    1000,
+		AdminSessionDurationHrs: 6,
+		UserSessionDurationHrs:  168,
+		Version:                 "test-version",
+		BuildTime:               "2026-04-14T00:00:00Z",
+		GoVersion:               runtime.Version(),
+	}
+}
+
+// stubOllama returns a 200-OK HEAD-friendly server so the ollama check stays
+// green during config/health tests. Callers Close() it via t.Cleanup.
+func stubOllama(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestConfig_RequiresAuth(t *testing.T) {
+	snap := defaultSnap()
+	h := setupAdminWithObservability(t, snap, time.Now(), stubOllama(t), 0, 1000)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/config", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without admin key, got %d", rec.Code)
+	}
+}
+
+func TestConfig_ReturnsWhitelistedFields(t *testing.T) {
+	snap := defaultSnap()
+	h := setupAdminWithObservability(t, snap, time.Now(), stubOllama(t), 0, 1000)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/config", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+
+	expected := map[string]any{
+		"ollama_url":                   snap.OllamaURL,
+		"port":                         snap.Port,
+		"log_level":                    snap.LogLevel,
+		"max_request_body_bytes":       float64(snap.MaxRequestBodyBytes),
+		"default_credit_grant":         snap.DefaultCreditGrant,
+		"cors_origins":                 snap.CORSOrigins,
+		"admin_rate_limit_per_minute":  float64(snap.AdminRateLimitPerMinute),
+		"usage_channel_capacity":       float64(snap.UsageChannelCapacity),
+		"admin_session_duration_hours": float64(snap.AdminSessionDurationHrs),
+		"user_session_duration_hours":  float64(snap.UserSessionDurationHrs),
+		"version":                      snap.Version,
+		"build_time":                   snap.BuildTime,
+		"go_version":                   snap.GoVersion,
+	}
+	for k, want := range expected {
+		got, ok := body[k]
+		if !ok {
+			t.Errorf("missing field %q", k)
+			continue
+		}
+		if got != want {
+			t.Errorf("field %q: want %v (%T), got %v (%T)", k, want, want, got, got)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"admin_key", "AdminKey",
+		"database_url", "DatabaseURL",
+		"admin_bootstrap_token", "AdminBootstrapToken",
+	} {
+		if _, present := body[forbidden]; present {
+			t.Errorf("secret field %q must not be exposed", forbidden)
+		}
+	}
+}
+
+func TestHealth_RequiresAuth(t *testing.T) {
+	h := setupAdminWithObservability(t, defaultSnap(), time.Now(), stubOllama(t), 0, 1000)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/health", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without admin key, got %d", rec.Code)
+	}
+}
+
+func TestHealth_HappyPath(t *testing.T) {
+	snap := defaultSnap()
+	h := setupAdminWithObservability(t, snap, time.Now().Add(-90*time.Second), stubOllama(t), 0, 1000)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/health", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+
+	if body["status"] != "ok" {
+		t.Errorf("status: want ok, got %v", body["status"])
+	}
+	if v, ok := body["version"].(string); !ok || v != snap.Version {
+		t.Errorf("version: want %q, got %v", snap.Version, body["version"])
+	}
+	if v, ok := body["uptime_seconds"].(float64); !ok || v < 90 {
+		t.Errorf("uptime_seconds: want >= 90, got %v", body["uptime_seconds"])
+	}
+
+	checks, ok := body["checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("checks: expected object, got %T", body["checks"])
+	}
+	for _, k := range []string{"db", "ollama", "usage_writer"} {
+		c, ok := checks[k].(map[string]any)
+		if !ok {
+			t.Errorf("missing check %q", k)
+			continue
+		}
+		if c["status"] != "ok" {
+			t.Errorf("check %q: want status ok, got %v", k, c["status"])
+		}
+	}
+
+	// Pool stats stay in Prometheus per locked decision #7.
+	for _, forbidden := range []string{"pool", "db_pool_total", "db_pool_idle", "db_pool_acquired"} {
+		if _, present := body[forbidden]; present {
+			t.Errorf("pool stats key %q must not appear in /admin/health (Prometheus only)", forbidden)
+		}
+	}
+}
+
+func TestHealth_DegradedWhenUsageWriterFull(t *testing.T) {
+	h := setupAdminWithObservability(t, defaultSnap(), time.Now(), stubOllama(t), 1000, 1000)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/health", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when usage channel full, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["status"] != "degraded" {
+		t.Errorf("status: want degraded, got %v", body["status"])
+	}
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -44,7 +44,9 @@ func (c *Checker) LiveHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`{"status":"ok"}`))
 }
 
-type checkResult struct {
+// CheckResult is one component's health snapshot. Exported so other packages
+// (e.g. internal/admin) can render it under their own response shape.
+type CheckResult struct {
 	Status    string `json:"status"`
 	LatencyMs *int64 `json:"latency_ms,omitempty"`
 	Error     string `json:"error,omitempty"`
@@ -52,28 +54,28 @@ type checkResult struct {
 	Capacity  *int   `json:"queue_capacity,omitempty"`
 }
 
-// ReadyHandler checks DB, Ollama, and usage writer health. Used for k8s readiness probes.
-func (c *Checker) ReadyHandler(w http.ResponseWriter, r *http.Request) {
-	checks := map[string]checkResult{}
-	allOK := true
+// RunChecks executes every configured probe and returns whether all passed
+// plus per-component results, keyed by the spec's component name (db, ollama,
+// usage_writer). Side-effect: updates the ollamaUp gauge when set.
+func (c *Checker) RunChecks(ctx context.Context) (allOK bool, checks map[string]CheckResult) {
+	checks = map[string]CheckResult{}
+	allOK = true
 
-	// DB check
 	if c.db != nil {
 		start := time.Now()
-		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
-		err := c.db.Ping(ctx)
+		pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		err := c.db.Ping(pingCtx)
 		cancel()
 		ms := time.Since(start).Milliseconds()
 
 		if err != nil {
 			allOK = false
-			checks["database"] = checkResult{Status: "error", LatencyMs: &ms, Error: err.Error()}
+			checks["db"] = CheckResult{Status: "error", LatencyMs: &ms, Error: err.Error()}
 		} else {
-			checks["database"] = checkResult{Status: "ok", LatencyMs: &ms}
+			checks["db"] = CheckResult{Status: "ok", LatencyMs: &ms}
 		}
 	}
 
-	// Ollama check
 	if c.ollamaURL != "" {
 		start := time.Now()
 		client := &http.Client{Timeout: 3 * time.Second}
@@ -82,30 +84,46 @@ func (c *Checker) ReadyHandler(w http.ResponseWriter, r *http.Request) {
 
 		if err != nil {
 			allOK = false
-			checks["ollama"] = checkResult{Status: "error", LatencyMs: &ms, Error: err.Error()}
+			checks["ollama"] = CheckResult{Status: "error", LatencyMs: &ms, Error: err.Error()}
 			if c.ollamaUp != nil {
 				c.ollamaUp.Set(0)
 			}
 		} else {
 			resp.Body.Close()
-			checks["ollama"] = checkResult{Status: "ok", LatencyMs: &ms}
+			checks["ollama"] = CheckResult{Status: "ok", LatencyMs: &ms}
 			if c.ollamaUp != nil {
 				c.ollamaUp.Set(1)
 			}
 		}
 	}
 
-	// Usage writer check
 	if c.usageChLen != nil {
 		depth := c.usageChLen()
-		cap := c.usageChCap
-		result := checkResult{Status: "ok", Depth: &depth, Capacity: &cap}
-		if depth >= cap {
+		capacity := c.usageChCap
+		result := CheckResult{Status: "ok", Depth: &depth, Capacity: &capacity}
+		if depth >= capacity {
 			allOK = false
 			result.Status = "error"
 			result.Error = "usage channel full"
 		}
 		checks["usage_writer"] = result
+	}
+
+	return allOK, checks
+}
+
+// ReadyHandler checks DB, Ollama, and usage writer health. Used for k8s readiness probes.
+// Renames the db key to "database" for compatibility with existing probe consumers.
+func (c *Checker) ReadyHandler(w http.ResponseWriter, r *http.Request) {
+	allOK, checks := c.RunChecks(r.Context())
+
+	legacy := make(map[string]CheckResult, len(checks))
+	for k, v := range checks {
+		if k == "db" {
+			legacy["database"] = v
+			continue
+		}
+		legacy[k] = v
 	}
 
 	status := "ready"
@@ -119,6 +137,6 @@ func (c *Checker) ReadyHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(httpStatus)
 	json.NewEncoder(w).Encode(map[string]any{
 		"status": status,
-		"checks": checks,
+		"checks": legacy,
 	})
 }


### PR DESCRIPTION
## Summary
- `GET /api/admin/config` — whitelisted config snapshot (no secrets).
- `GET /api/admin/health` — `{status, checks:{db,ollama,usage_writer}, uptime_seconds, version}`; 503 + `status=degraded` on any failing probe.
- Reuses the existing `health.Checker` via a new `RunChecks(ctx)` helper. K8s readiness probe shape unchanged (still emits `database`).

Per PLAN.md *Backend PR Sequence* row **5** and *Config Endpoint Whitelist (PR 5)*. Pool stats stay in Prometheus per locked decision #7 (lands in BE 6).

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` — 184 tests pass locally (admin integration tests SKIP without DATABASE_URL; CI runs them).
- [ ] CI green on `be-pr-5-config-health`.
- [ ] Manual: hit `/api/admin/config` with a valid admin key → confirm secrets absent.
- [ ] Manual: hit `/api/admin/health` with Ollama down → confirm 503 + `status=degraded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)