### PR TITLE
BE Follow-up 1: snake_case JSON tags on CreditPricing

### DIFF
--- a/internal/admin/list_envelope_test.go
+++ b/internal/admin/list_envelope_test.go
@@ -354,6 +354,7 @@ func TestListPricing_LegacyShape(t *testing.T) {
 	if len(arr) < 2 {
 		t.Errorf("len=%d, want >=2", len(arr))
 	}
+	assertPricingSnakeCaseKeys(t, arr[0])
 }
 
 func TestListPricing_Envelope_Pagination(t *testing.T) {
@@ -372,6 +373,23 @@ func TestListPricing_Envelope_Pagination(t *testing.T) {
 	}
 	if len(data) != 2 {
 		t.Errorf("len(data) = %d, want 2", len(data))
+	}
+	assertPricingSnakeCaseKeys(t, data[0])
+}
+
+func assertPricingSnakeCaseKeys(t *testing.T, row map[string]any) {
+	t.Helper()
+	want := []string{"id", "model_id", "prompt_rate", "completion_rate", "typical_completion", "effective_from", "active"}
+	for _, k := range want {
+		if _, ok := row[k]; !ok {
+			t.Errorf("missing snake_case key %q in pricing row: %+v", k, row)
+		}
+	}
+	forbidden := []string{"ID", "ModelID", "PromptRate", "CompletionRate", "TypicalCompletion", "EffectiveFrom", "Active"}
+	for _, k := range forbidden {
+		if _, ok := row[k]; ok {
+			t.Errorf("PascalCase key %q leaked into pricing wire shape: %+v", k, row)
+		}
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -132,13 +132,13 @@ type CreditHold struct {
 }
 
 type CreditPricing struct {
-	ID                int64
-	ModelID           string
-	PromptRate        float64
-	CompletionRate    float64
-	TypicalCompletion int
-	EffectiveFrom     time.Time
-	Active            bool
+	ID                int64     `json:"id"`
+	ModelID           string    `json:"model_id"`
+	PromptRate        float64   `json:"prompt_rate"`
+	CompletionRate    float64   `json:"completion_rate"`
+	TypicalCompletion int       `json:"typical_completion"`
+	EffectiveFrom     time.Time `json:"effective_from"`
+	Active            bool      `json:"active"`
 }
 
 type AccountUsageStats struct {


### PR DESCRIPTION
## Summary
- Add `json:\"…\"` tags to `store.CreditPricing` so `/api/admin/pricing` emits snake_case (`id`, `model_id`, `prompt_rate`, `completion_rate`, `typical_completion`, `effective_from`, `active`), matching every other admin list endpoint.
- Extend `TestListPricing_LegacyShape` and `TestListPricing_Envelope_Pagination` with a shared helper that asserts snake_case keys are present and no PascalCase keys leak.

## Why
Discovered during FE PR C. Frontend had to special-case `/admin/pricing` with a `PricingWireSchema` that parses PascalCase and `.transform()`s to snake_case — the only endpoint in the admin API requiring this. Tagging the struct lets the FE drop the wrapper.

## Rollout note
The live frontend currently expects PascalCase. This PR flips the wire shape, so it must ship in coordination with a FE cleanup PR that drops `PricingWireSchema`, or after a FE defensive-parse PR that tolerates both shapes. See `local-ai-proxy-admin-frontend/PLAN.md` § \"Backend Follow-ups\" for the two safe sequences.

## Test plan
- [ ] CI green (`build-and-test`, `lint`)
- [ ] `TestListPricing_LegacyShape` asserts snake_case keys
- [ ] `TestListPricing_Envelope_Pagination` asserts snake_case keys
- [ ] Manual: `curl /api/admin/pricing` on deploy returns snake_case keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)