### PR TITLE
BE PR 7: envelope default flip on admin list endpoints

### DIFF
--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -185,8 +185,8 @@ func TestAdmin_ListKeys(t *testing.T) {
 	createRec := httptest.NewRecorder()
 	h.ServeHTTP(createRec, createReq)
 
-	// List keys
-	req := httptest.NewRequest(http.MethodGet, "/api/admin/keys", nil)
+	// List keys (envelope=0 → raw array for this legacy-shape assertion)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/keys?envelope=0", nil)
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	rec := httptest.NewRecorder()
 
@@ -290,8 +290,8 @@ func TestAdmin_GetUsage(t *testing.T) {
 		Status:           "completed",
 	})
 
-	// Get usage
-	req := httptest.NewRequest(http.MethodGet, "/api/admin/usage", nil)
+	// Get usage (envelope=0 → raw array for this legacy-shape assertion)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/usage?envelope=0", nil)
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	rec := httptest.NewRecorder()
 
@@ -406,7 +406,7 @@ func TestAdmin_ListUsers(t *testing.T) {
 	_, _ = s.CreateUser("admin-list1@example.com", "hash", "User One")
 	_, _ = s.CreateUser("admin-list2@example.com", "hash", "User Two")
 
-	req := httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users?envelope=0", nil)
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)

--- a/internal/admin/coverage_test.go
+++ b/internal/admin/coverage_test.go
@@ -25,7 +25,7 @@ func TestAdmin_ListAccounts(t *testing.T) {
 	_ = s.InitCreditBalance(accountID)
 	_ = s.AddCredits(accountID, 25.5, "seed")
 
-	req := httptest.NewRequest(http.MethodGet, "/api/admin/accounts", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/accounts?envelope=0", nil)
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -267,7 +267,7 @@ func TestAdmin_ListRegistrationTokens(t *testing.T) {
 		t.Fatalf("seed failed: %d", rec.Code)
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/api/admin/registration-tokens", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/registration-tokens?envelope=0", nil)
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -343,7 +343,7 @@ func TestAdmin_UpsertListDeletePricing(t *testing.T) {
 		t.Fatalf("upsert: expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/api/admin/pricing", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/pricing?envelope=0", nil)
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, req)

--- a/internal/admin/list_envelope_test.go
+++ b/internal/admin/list_envelope_test.go
@@ -61,11 +61,11 @@ func TestListKeys_LegacyShape_NoEnvelopeMetadata(t *testing.T) {
 	h, s := setupAdminTest(t)
 	seedThreeKeys(t, s)
 
-	rec := doAdminGET(t, h, "/api/admin/keys")
+	rec := doAdminGET(t, h, "/api/admin/keys?envelope=0")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
-	// Legacy: must decode as a raw array. Any pagination key is a regression.
+	// Legacy (envelope=0): must decode as a raw array. Any pagination key is a regression.
 	var arr []keyResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &arr); err != nil {
 		t.Fatalf("legacy shape must be a raw array: %v", err)
@@ -80,11 +80,12 @@ func TestListKeys_LegacyShape_NoEnvelopeMetadata(t *testing.T) {
 
 func TestListKeys_LegacyShape_WithIsActiveFilter_NoPagination(t *testing.T) {
 	// is_active on /keys means "not revoked". Filters apply in legacy mode;
-	// only the envelope wrapper is gated behind envelope=1.
+	// envelope=0 is the post-BE-7 opt-out for ad-hoc scripts that still expect
+	// a raw array.
 	h, s := setupAdminTest(t)
 	seedThreeKeys(t, s)
 
-	rec := doAdminGET(t, h, "/api/admin/keys?is_active=true")
+	rec := doAdminGET(t, h, "/api/admin/keys?envelope=0&is_active=true")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -144,6 +145,27 @@ func TestListKeys_Envelope_LimitOffset(t *testing.T) {
 	}
 }
 
+// TestListKeys_DefaultIsEnvelope_BE7 locks in the BE 7 contract flip: with
+// no `envelope` query param, the response MUST be the `{data, pagination}`
+// envelope, not the legacy raw array. If this test ever starts passing with
+// a raw array again, BE 7 has regressed.
+func TestListKeys_DefaultIsEnvelope_BE7(t *testing.T) {
+	h, s := setupAdminTest(t)
+	seedThreeKeys(t, s)
+
+	rec := doAdminGET(t, h, "/api/admin/keys")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	data, pag := decodeEnvelope[[]keyResponse](t, rec.Body.Bytes())
+	if pag == nil {
+		t.Fatal("default response must include pagination envelope (BE 7)")
+	}
+	if len(data) != 3 {
+		t.Errorf("len(data)=%d, want 3", len(data))
+	}
+}
+
 func TestListKeys_InvalidEnvelope_400(t *testing.T) {
 	h, _ := setupAdminTest(t)
 	rec := doAdminGET(t, h, "/api/admin/keys?envelope=true")
@@ -190,7 +212,7 @@ func TestListUsers_LegacyShape(t *testing.T) {
 	seedUserWithRoleAndActive(t, s, "u1@example.com", "U1", "user", true)
 	seedUserWithRoleAndActive(t, s, "u2@example.com", "U2", "admin", true)
 
-	rec := doAdminGET(t, h, "/api/admin/users")
+	rec := doAdminGET(t, h, "/api/admin/users?envelope=0")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -275,7 +297,7 @@ func TestListAccounts_LegacyShape(t *testing.T) {
 	if _, err := s.CreateAccount("acc-b", "service"); err != nil {
 		t.Fatalf("CreateAccount: %v", err)
 	}
-	rec := doAdminGET(t, h, "/api/admin/accounts")
+	rec := doAdminGET(t, h, "/api/admin/accounts?envelope=0")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -340,7 +362,7 @@ func TestListPricing_LegacyShape(t *testing.T) {
 	_ = s.UpsertPricing("m1", 0.001, 0.002, 500)
 	_ = s.UpsertPricing("m2", 0.003, 0.004, 500)
 
-	rec := doAdminGET(t, h, "/api/admin/pricing")
+	rec := doAdminGET(t, h, "/api/admin/pricing?envelope=0")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -400,7 +422,7 @@ func TestListRegistrationTokens_LegacyShape(t *testing.T) {
 	_, _ = s.CreateRegistrationToken("t1", "reg-hash-1", 10, 1, nil)
 	_, _ = s.CreateRegistrationToken("t2", "reg-hash-2", 10, 1, nil)
 
-	rec := doAdminGET(t, h, "/api/admin/registration-tokens")
+	rec := doAdminGET(t, h, "/api/admin/registration-tokens?envelope=0")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -442,9 +464,9 @@ func TestGetUsage_LegacyShape_PreservesExistingParams(t *testing.T) {
 		DurationMs: 100, Status: "completed",
 	})
 
-	// No envelope param → legacy raw array shape, existing key_id filter
-	// still honored.
-	rec := doAdminGET(t, h, fmt.Sprintf("/api/admin/usage?key_id=%d", id))
+	// envelope=0 → legacy raw array shape (post-BE-7 opt-out), existing
+	// key_id filter still honored.
+	rec := doAdminGET(t, h, fmt.Sprintf("/api/admin/usage?envelope=0&key_id=%d", id))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}

--- a/internal/admin/list_filters.go
+++ b/internal/admin/list_filters.go
@@ -5,18 +5,18 @@ import (
 	"strconv"
 )
 
-// wantEnvelope reports whether the caller asked for the `{data, pagination}`
-// envelope via `?envelope=1`. Any other non-empty value besides "0" is a
-// validation error so typos like `envelope=true` don't silently fall through
-// to the legacy raw-array path. The returned code/message feed directly into
-// proxy.WriteError when err is non-nil.
+// wantEnvelope reports whether the response should use the `{data, pagination}`
+// envelope. As of BE 7 envelope is the default; callers can opt out with
+// `?envelope=0` for one deprecation release as a safety valve for ad-hoc
+// `X-Admin-Key` scripts. Any other non-empty value is a validation error so
+// typos like `envelope=true` don't silently fall through.
 func wantEnvelope(r *http.Request) (bool, string, string, error) {
 	raw := r.URL.Query().Get("envelope")
 	switch raw {
-	case "", "0":
-		return false, "", "", nil
-	case "1":
+	case "", "1":
 		return true, "", "", nil
+	case "0":
+		return false, "", "", nil
 	default:
 		return false, "invalid_envelope", "envelope must be 0 or 1", strconv.ErrSyntax
 	}

--- a/internal/admin/list_filters_test.go
+++ b/internal/admin/list_filters_test.go
@@ -12,7 +12,7 @@ func TestWantEnvelope(t *testing.T) {
 		wantErr bool
 		code    string
 	}{
-		{"", false, false, ""},
+		{"", true, false, ""},
 		{"envelope=0", false, false, ""},
 		{"envelope=1", true, false, ""},
 		{"envelope=true", false, true, "invalid_envelope"},

--- a/internal/admin/usage_analytics_http_test.go
+++ b/internal/admin/usage_analytics_http_test.go
@@ -410,13 +410,13 @@ func TestUsageEndpoints_InvalidAdminKey(t *testing.T) {
 // --- legacy /api/admin/usage regression ------------------------------------
 
 func TestLegacyUsageEndpoint_StillReturnsBareArray(t *testing.T) {
-	// BE 2 must not disturb the existing /api/admin/usage shape. BE 4 flips
-	// it to enveloped on opt-in; BE 7 makes envelope the default. Until then,
-	// the response body must remain a plain JSON array (no "data" wrapper).
+	// BE 7 made envelope the default on /api/admin/usage. The legacy raw-array
+	// shape is still reachable via ?envelope=0 for one deprecation cycle so
+	// ad-hoc X-Admin-Key scripts aren't broken mid-cycle.
 	h, s := setupAdminTest(t)
 	seedUsageFixtureHTTP(t, s)
 
-	rec := doAdmin(t, h, "/api/admin/usage")
+	rec := doAdmin(t, h, "/api/admin/usage?envelope=0")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}


### PR DESCRIPTION
## Summary
- Flip `wantEnvelope` so the default for all admin list endpoints (`/keys`, `/users`, `/accounts`, `/pricing`, `/registration-tokens`, `/usage`) is the `{data, pagination}` envelope.
- Preserve `?envelope=0` as a legacy-shape safety valve for ad-hoc X-Admin-Key scripts during one deprecation cycle.
- Add `TestListKeys_DefaultIsEnvelope_BE7` to lock in the new contract.
- Pin every existing `*_LegacyShape` test (and the `/usage` legacy regression test) to `?envelope=0` so they continue to exercise the opt-out path.

## Why
Per PLAN.md (admin-frontend) §PR 7. FE PR D landed envelope-required client code; shipping BE 7 now aligns the default with the only active consumer (the admin UI, via the BFF). No prod bake required — single-operator project, rollback risk is low.

## Compat / rollout
- Explicit `?envelope=1` continues to work (unchanged).
- New explicit `?envelope=0` returns the legacy raw array.
- No HTTP or schema changes beyond the default flip.
- FE already sends `envelope=1` explicitly → transparent to the UI.
- Any external ad-hoc scripts using raw arrays need to either adopt the envelope or append `?envelope=0` during the deprecation window.

## Test plan
- [ ] CI green (`build-and-test`, `lint`)
- [ ] `TestWantEnvelope` passes with new defaults
- [ ] `TestListKeys_DefaultIsEnvelope_BE7` confirms envelope on unqualified request
- [ ] All `*_LegacyShape` tests exercise `?envelope=0`
- [ ] Manual: `curl -H \"X-Admin-Key: ...\" https://.../api/admin/keys` returns envelope shape post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)