### PR TITLE
Fix CD: build image in CI and pull from GHCR

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,11 +17,46 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Compute image metadata
+        id: meta
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          echo "short_sha=${HEAD_SHA:0:12}" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      # Build the image on the clean runner (the exact tested SHA) and push to
+      # GHCR. Replaces the old "scp source to the dev server and build there"
+      # flow, where `scp` never deleted removed files.
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.short_sha }}
+            ghcr.io/${{ github.repository }}:latest
+          build-args: |
+            GIT_SHA=${{ steps.meta.outputs.short_sha }}
+            BUILD_TIME=${{ steps.meta.outputs.build_time }}
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3
@@ -36,42 +71,31 @@ jobs:
           ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
           ADMIN_BOOTSTRAP_TOKEN: ${{ secrets.ADMIN_BOOTSTRAP_TOKEN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+          IMAGE: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.short_sha }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
-          SHORT_SHA="${IMAGE_TAG:0:12}"
-          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          DEV=sk@100.108.60.90
+          SSH="ssh -o StrictHostKeyChecking=no $DEV"
 
-          # Copy source to server and build Docker image there
-          scp -o StrictHostKeyChecking=no -r cmd/ internal/ deploy/ go.mod sk@100.108.60.90:~/local-ai-proxy/
-
-          # Create/update k8s secret from repo secrets (runs locally via kubectl over SSH)
-          ssh -o StrictHostKeyChecking=no sk@100.108.60.90 "export KUBECONFIG=/home/sk/.kube/config && \
+          # Create/update k8s secret from repo secrets.
+          $SSH "export KUBECONFIG=/home/sk/.kube/config && \
             sudo kubectl -n local-ai create secret generic proxy-secret \
               --from-literal=ADMIN_KEY='${ADMIN_KEY}' \
               --from-literal=ADMIN_BOOTSTRAP_TOKEN='${ADMIN_BOOTSTRAP_TOKEN}' \
               --from-literal=DATABASE_URL='${DATABASE_URL}' \
               --dry-run=client -o yaml | sudo kubectl apply -f -"
 
-          # Inline the version metadata so the remote shell sees concrete values.
-          ssh -o StrictHostKeyChecking=no sk@100.108.60.90 \
-            "export KUBECONFIG=/home/sk/.kube/config && \
-             cd ~/local-ai-proxy && \
-             sudo docker build \
-               --build-arg GIT_SHA='${SHORT_SHA}' \
-               --build-arg BUILD_TIME='${BUILD_TIME}' \
-               -f deploy/Dockerfile \
-               -t local-ai-proxy:${SHORT_SHA} \
-               -t local-ai-proxy:latest \
-               . && \
-             sudo docker save local-ai-proxy:${SHORT_SHA} local-ai-proxy:latest | sudo k3s ctr images import - && \
-             sudo kubectl apply -f deploy/k8s/namespace.yaml && \
-             sudo kubectl apply -f deploy/k8s/pvc.yaml && \
-             sudo kubectl apply -f deploy/k8s/service.yaml && \
-             sudo kubectl apply -f deploy/k8s/ingress.yaml && \
-             sudo kubectl apply -f deploy/k8s/deployment.yaml && \
-             sudo kubectl -n local-ai set image deployment/ai-proxy ai-proxy=local-ai-proxy:${SHORT_SHA} && \
-             sudo kubectl -n local-ai rollout status deployment/ai-proxy --timeout=120s"
+          # Apply manifests by piping the runner's checked-out files over stdin
+          # (they no longer live on the dev server). Then pin the freshly pushed
+          # image and wait for the rollout.
+          cat deploy/k8s/namespace.yaml deploy/k8s/pvc.yaml \
+              deploy/k8s/service.yaml deploy/k8s/ingress.yaml \
+              deploy/k8s/deployment.yaml \
+            | $SSH "export KUBECONFIG=/home/sk/.kube/config && sudo kubectl apply -f -"
+
+          $SSH "export KUBECONFIG=/home/sk/.kube/config && \
+            sudo kubectl -n local-ai set image deployment/ai-proxy ai-proxy='${IMAGE}' && \
+            sudo kubectl -n local-ai rollout status deployment/ai-proxy --timeout=120s"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
         - name: ai-proxy
-          image: local-ai-proxy:latest
-          imagePullPolicy: Never
+          image: ghcr.io/skrx7392/local-ai-proxy:latest
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
## Why

Companion to skrx7392/local-ai-proxy-admin-frontend#52. Both repos share the same deploy pattern: `scp -r` source to the dev server and `docker build` there. `scp` never deletes removed files, so a file dropped from the repo can linger on the server and get baked into the image. In the admin-frontend that produced a shadowed route serving a stale page; the backend hasn't manifested it yet but has the same latent bug (and also wasn't copying `go.sum`).

## Fix

Build the image on the clean CI runner and push to **GHCR**; k3s pulls it. The runner checkout is exactly the tested SHA with no accreting state.

- **cd.yml**: add `packages: write`; build + push `ghcr.io/<repo>:<sha>` via `docker/build-push-action`; drop `scp`, on-server `docker build`, and `k3s ctr images import`. SSH now only applies manifests (piped over stdin) and rolls out. Building from the full checkout also fixes `go.sum` not being copied.
- **deployment.yaml**: `image` → `ghcr.io/skrx7392/local-ai-proxy`, `imagePullPolicy: Never` → `IfNotPresent`.
- **Dockerfile**: unchanged (already accepts `GIT_SHA`/`BUILD_TIME`).

GHCR package is **public** — no `imagePullSecret` needed. May need a one-time visibility flip to Public after the first push.

## Verification

After merge → CD pushes `ghcr.io/skrx7392/local-ai-proxy:<sha>`; verify `ai-proxy` rolls out healthy and the admin **Config** page Build version reflects the new SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)