### PR TITLE
Migrate gateway to ai.skpodduturi.dev (Cloudflare DNS-01)

### DIFF
--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -4,17 +4,17 @@ metadata:
   name: ai-proxy-ingress
   namespace: local-ai
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
     # Disable response buffering for SSE streaming
     traefik.ingress.kubernetes.io/buffering-retries: "0"
 spec:
   ingressClassName: traefik
   tls:
     - hosts:
-        - ai.kinvee.in
-      secretName: ai-proxy-tls
+        - ai.skpodduturi.dev
+      secretName: ai-proxy-skpodduturi-tls
   rules:
-    - host: ai.kinvee.in
+    - host: ai.skpodduturi.dev
       http:
         paths:
           - path: /api


### PR DESCRIPTION
Ingress -> ai.skpodduturi.dev on the letsencrypt-cloudflare DNS-01 issuer (new TLS secret ai-proxy-skpodduturi-tls). Part of the kinvee.in -> skpodduturi.dev migration. A-record already created grey-cloud + tracked by the Cloudflare DDNS updater. No code change; CORS_ORIGINS=* unchanged. Deploys via the now-fixed (#34) CD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)