### PR TITLE
Fix CD: emit valid multi-document YAML when applying k8s manifests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,11 +89,13 @@ jobs:
               --dry-run=client -o yaml | sudo kubectl apply -f -"
 
           # Apply manifests by piping the runner's checked-out files over stdin
-          # (they no longer live on the dev server). Then pin the freshly pushed
+          # (they no longer live on the dev server). Glob only the files that
+          # exist and prefix each with a `---` document separator so the stream
+          # is valid multi-document YAML. A plain `cat` of the files concatenates
+          # them into a single document (duplicate top-level keys, last wins) so
+          # kubectl applies only the final manifest. Then pin the freshly pushed
           # image and wait for the rollout.
-          cat deploy/k8s/namespace.yaml deploy/k8s/pvc.yaml \
-              deploy/k8s/service.yaml deploy/k8s/ingress.yaml \
-              deploy/k8s/deployment.yaml \
+          for f in deploy/k8s/*.yaml; do printf '%s\n' '---'; cat "$f"; done \
             | $SSH "export KUBECONFIG=/home/sk/.kube/config && sudo kubectl apply -f -"
 
           $SSH "export KUBECONFIG=/home/sk/.kube/config && \


### PR DESCRIPTION
## Problem

The **Deploy to k3s** step piped concatenated manifests into `kubectl apply -f -` with no `---` separators:

```sh
cat deploy/k8s/namespace.yaml deploy/k8s/pvc.yaml \
    deploy/k8s/service.yaml deploy/k8s/ingress.yaml \
    deploy/k8s/deployment.yaml \
  | $SSH "... kubectl apply -f -"
```

Without separators the files parse as a **single** YAML document — duplicate top-level keys, last wins — so kubectl applied only the final manifest (the Deployment) and silently dropped **namespace/service/ingress** on every deploy. The list also referenced `deploy/k8s/pvc.yaml`, which doesn't exist, so each run printed `cat: deploy/k8s/pvc.yaml: No such file or directory`.

## Fix

Replace the `cat` pipeline with a loop that globs only files that exist and prefixes each with a `---` document separator, producing a valid multi-document stream:

```sh
for f in deploy/k8s/*.yaml; do printf '%s\n' '---'; cat "$f"; done \
  | $SSH "... kubectl apply -f -"
```

Now all four manifests (namespace, service, ingress, deployment) are applied. Secret creation, `set image`, and rollout status are unchanged. The k8s namespace already exists on the cluster, so glob/apply order is a non-issue. Re-applying the current manifests is a no-op against the live `ai.skpodduturi.dev` ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzZJYRDjuQfGQ5MjZMSNNR