### PR TITLE
feat(registry): in-memory routing core with immutable snapshots

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -156,11 +156,7 @@ func (r *Registry) SetNodeState(nodeID int64, health Health, models []string) {
 		return
 	}
 	e.health = health
-	if models == nil {
-		e.models = nil
-	} else {
-		e.models = append([]string(nil), models...)
-	}
+	e.models = cloneModels(models)
 	r.publishLocked()
 }
 
@@ -203,7 +199,7 @@ func (r *Registry) Snapshot() RegistrySnapshot {
 		out.Nodes[i] = NodeState{
 			Node:   ns.Node.clone(),
 			Health: ns.Health,
-			Models: append([]string(nil), ns.Models...),
+			Models: cloneModels(ns.Models),
 		}
 	}
 	for model, candidates := range s.models {
@@ -245,6 +241,18 @@ func (r *Registry) publishLocked() {
 	}
 
 	r.snap.Store(&snapshot{nodes: nodes, models: models})
+}
+
+// cloneModels copies a model list, preserving the nil-vs-empty distinction:
+// nil means "not yet discovered", a non-nil empty slice is a known-empty
+// list from a successful probe.
+func cloneModels(models []string) []string {
+	if models == nil {
+		return nil
+	}
+	out := make([]string, len(models))
+	copy(out, models)
+	return out
 }
 
 func sameURL(a, b *url.URL) bool {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,255 @@
+// Package registry is the in-memory routing core for distributed backend
+// nodes. It maps model names to healthy nodes and round-robins across
+// candidates. It has no HTTP or database dependencies: loaders (config file,
+// DB) declare nodes via SetNodes and the health poller reports probe results
+// via SetNodeState; the proxy consumes Resolve and Snapshot.
+//
+// Concurrency model (see docs/design/distributed-nodes.md, "Registry
+// concurrency"): routing state is published as an immutable snapshot swapped
+// via atomic.Pointer (copy-on-write). Writers rebuild a complete snapshot
+// under the registry mutex and publish it atomically; Resolve reads exactly
+// one snapshot per call and can never observe a torn mix of old and new
+// state. Round-robin counters live outside the snapshot in a mutex-guarded
+// map so republishes do not reset balancing; the map is pruned to routable
+// models on each republish and is never grown by lookups of unknown models.
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ErrModelUnavailable is returned by Resolve when no healthy node with a
+// known model list serves the requested model. Callers should map it to
+// 503 model_unavailable.
+var ErrModelUnavailable = errors.New("no healthy node serves this model")
+
+// Health is a node's probed health state. Unknown and unhealthy are both
+// non-routable; they are distinct for display (never probed vs failing).
+type Health string
+
+const (
+	HealthUnknown   Health = "unknown"
+	HealthHealthy   Health = "healthy"
+	HealthUnhealthy Health = "unhealthy"
+)
+
+// Node is the routing view of a backend node: everything the proxy needs to
+// forward a request.
+type Node struct {
+	ID         int64
+	Name       string
+	BaseURL    *url.URL
+	AuthHeader string        // Authorization value sent upstream; "" = none
+	Timeout    time.Duration // per-node request timeout; 0 = default
+}
+
+// clone returns a deep copy of n so registry state can never be mutated
+// through values handed to callers (url.URL is a mutable struct).
+func (n Node) clone() Node {
+	if n.BaseURL != nil {
+		u := *n.BaseURL
+		if n.BaseURL.User != nil {
+			user := *n.BaseURL.User
+			u.User = &user
+		}
+		n.BaseURL = &u
+	}
+	return n
+}
+
+// NodeState is a node plus its runtime state, as exposed by Snapshot.
+type NodeState struct {
+	Node   Node
+	Health Health
+	Models []string // last reported model list; nil = not yet discovered
+}
+
+// RegistrySnapshot is a self-consistent view of the registry: every node the
+// registry knows about (ascending by ID) and the model→nodes routing map.
+// Models contains only routable candidates: healthy nodes with a known model
+// list, ascending by ID. The returned value is a private copy; callers may
+// retain and mutate it freely.
+type RegistrySnapshot struct {
+	Nodes  []NodeState
+	Models map[string][]Node
+}
+
+// snapshot is the immutable published routing state. Once stored it is never
+// mutated; writers build a complete replacement and swap the pointer.
+type snapshot struct {
+	nodes  []NodeState       // ascending by Node.ID
+	models map[string][]Node // model -> routable candidates, ascending by Node.ID
+}
+
+// entry is the writer-side authoritative state for one node, guarded by
+// Registry.mu.
+type entry struct {
+	node   Node
+	health Health
+	models []string
+}
+
+// Registry routes models to healthy backend nodes.
+//
+// Resolve and Snapshot are safe for unbounded concurrent use; SetNodes and
+// SetNodeState may be called concurrently with them and with each other.
+type Registry struct {
+	snap atomic.Pointer[snapshot]
+
+	mu       sync.Mutex
+	entries  map[int64]*entry
+	counters map[string]uint64 // round-robin position per routable model
+}
+
+// New returns an empty registry: every Resolve fails with
+// ErrModelUnavailable until nodes are declared and reported healthy.
+func New() *Registry {
+	r := &Registry{
+		entries:  make(map[int64]*entry),
+		counters: make(map[string]uint64),
+	}
+	r.snap.Store(&snapshot{models: make(map[string][]Node)})
+	return r
+}
+
+// SetNodes replaces the full set of nodes the registry knows about (initial
+// load, config reload, admin add/update/disable). Runtime state carries over
+// for a node whose ID persists with an unchanged BaseURL; a node whose
+// BaseURL changed is effectively an unprobed backend, so its health resets
+// to unknown and its model list is cleared (no optimistic routing). If the
+// same ID appears more than once the last declaration wins. A new snapshot
+// is published before SetNodes returns.
+func (r *Registry) SetNodes(nodes []Node) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	next := make(map[int64]*entry, len(nodes))
+	for _, n := range nodes {
+		e := &entry{node: n.clone(), health: HealthUnknown}
+		if prev, ok := r.entries[n.ID]; ok && sameURL(prev.node.BaseURL, n.BaseURL) {
+			e.health = prev.health
+			e.models = prev.models
+		}
+		next[n.ID] = e
+	}
+	r.entries = next
+	r.publishLocked()
+}
+
+// SetNodeState records a probe result for one node and publishes a new
+// snapshot. models is the node's discovered (or static) model list; nil
+// means the list is unknown, which keeps the node non-routable even when
+// healthy. State reported for a node ID the registry does not know is
+// ignored (the poller may race a node removal).
+func (r *Registry) SetNodeState(nodeID int64, health Health, models []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e, ok := r.entries[nodeID]
+	if !ok {
+		return
+	}
+	e.health = health
+	if models == nil {
+		e.models = nil
+	} else {
+		e.models = append([]string(nil), models...)
+	}
+	r.publishLocked()
+}
+
+// Resolve returns a healthy node serving model, round-robining across
+// candidates on successive calls. It returns an error wrapping
+// ErrModelUnavailable when no healthy node with a known model list serves
+// the model. The returned Node is a private copy; mutating it (including
+// BaseURL) does not affect the registry.
+func (r *Registry) Resolve(model string) (Node, error) {
+	candidates := r.snap.Load().models[model]
+	if len(candidates) == 0 {
+		return Node{}, fmt.Errorf("model %q: %w", model, ErrModelUnavailable)
+	}
+
+	var idx int
+	if len(candidates) > 1 {
+		// The counter is only touched for models that are routable in the
+		// snapshot just read, so arbitrary client-supplied model names can
+		// never allocate counter state.
+		r.mu.Lock()
+		c := r.counters[model]
+		r.counters[model] = c + 1
+		r.mu.Unlock()
+		idx = int(c % uint64(len(candidates)))
+	}
+	return candidates[idx].clone(), nil
+}
+
+// Snapshot returns the current node states and model→nodes routing map, for
+// /v1/models, admin endpoints, and readiness. The result is a deep copy the
+// caller owns.
+func (r *Registry) Snapshot() RegistrySnapshot {
+	s := r.snap.Load()
+
+	out := RegistrySnapshot{
+		Nodes:  make([]NodeState, len(s.nodes)),
+		Models: make(map[string][]Node, len(s.models)),
+	}
+	for i, ns := range s.nodes {
+		out.Nodes[i] = NodeState{
+			Node:   ns.Node.clone(),
+			Health: ns.Health,
+			Models: append([]string(nil), ns.Models...),
+		}
+	}
+	for model, candidates := range s.models {
+		nodes := make([]Node, len(candidates))
+		for i, n := range candidates {
+			nodes[i] = n.clone()
+		}
+		out.Models[model] = nodes
+	}
+	return out
+}
+
+// publishLocked rebuilds the immutable snapshot from r.entries, prunes
+// round-robin counters for models that are no longer routable, and swaps the
+// snapshot pointer. Callers must hold r.mu.
+func (r *Registry) publishLocked() {
+	nodes := make([]NodeState, 0, len(r.entries))
+	models := make(map[string][]Node)
+	for _, e := range r.entries {
+		nodes = append(nodes, NodeState{Node: e.node, Health: e.health, Models: e.models})
+		if e.health != HealthHealthy || e.models == nil {
+			continue
+		}
+		for _, m := range e.models {
+			models[m] = append(models[m], e.node)
+		}
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Node.ID < nodes[j].Node.ID })
+	for _, candidates := range models {
+		sort.Slice(candidates, func(i, j int) bool { return candidates[i].ID < candidates[j].ID })
+	}
+
+	// Prune counters for models that disappeared from the routable map; the
+	// counter map stays bounded by the discovered catalog.
+	for model := range r.counters {
+		if _, ok := models[model]; !ok {
+			delete(r.counters, model)
+		}
+	}
+
+	r.snap.Store(&snapshot{nodes: nodes, models: models})
+}
+
+func sameURL(a, b *url.URL) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.String() == b.String()
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -282,6 +282,22 @@ func TestSetNodes_BaseURLChangeResetsHealth(t *testing.T) {
 	}
 }
 
+func TestSetNodeState_KnownEmptyModelListStaysNonNil(t *testing.T) {
+	// nil means "not yet discovered"; a successfully probed node serving
+	// zero models is a known-empty list and must stay distinguishable.
+	r := New()
+	r.SetNodes([]Node{testNode(t, 1, "idle", "http://idle:11434")})
+	r.SetNodeState(1, HealthHealthy, []string{})
+
+	snap := r.Snapshot()
+	if snap.Nodes[0].Models == nil {
+		t.Fatal("known-empty model list collapsed to nil (looks undiscovered)")
+	}
+	if len(snap.Nodes[0].Models) != 0 {
+		t.Fatalf("got models %v, want empty", snap.Nodes[0].Models)
+	}
+}
+
 func TestSetNodeState_UnknownNodeIgnored(t *testing.T) {
 	r := twoHealthyNodes(t)
 	r.SetNodeState(99, HealthHealthy, []string{"ghost-model"})

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,447 @@
+package registry
+
+import (
+	"errors"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+)
+
+func testNode(t *testing.T, id int64, name, rawURL string) Node {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawURL, err)
+	}
+	return Node{ID: id, Name: name, BaseURL: u}
+}
+
+// twoHealthyNodes builds a registry with nodes 1 and 2 both healthy and
+// serving "shared-model"; node 1 additionally serves "solo-model".
+func twoHealthyNodes(t *testing.T) *Registry {
+	t.Helper()
+	r := New()
+	r.SetNodes([]Node{
+		testNode(t, 1, "alpha", "http://alpha:11434"),
+		testNode(t, 2, "beta", "http://beta:11434"),
+	})
+	r.SetNodeState(1, HealthHealthy, []string{"shared-model", "solo-model"})
+	r.SetNodeState(2, HealthHealthy, []string{"shared-model"})
+	return r
+}
+
+func TestResolve_EmptyRegistry(t *testing.T) {
+	r := New()
+	_, err := r.Resolve("any-model")
+	if !errors.Is(err, ErrModelUnavailable) {
+		t.Fatalf("want ErrModelUnavailable, got %v", err)
+	}
+}
+
+func TestResolve_HealthyNodeHit(t *testing.T) {
+	r := New()
+	n := testNode(t, 7, "gpu-1", "http://gpu-1:11434")
+	n.AuthHeader = "Bearer secret"
+	n.Timeout = 900 * time.Second
+	r.SetNodes([]Node{n})
+	r.SetNodeState(7, HealthHealthy, []string{"llama3.2:3b"})
+
+	got, err := r.Resolve("llama3.2:3b")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.ID != 7 || got.Name != "gpu-1" {
+		t.Errorf("got node %d %q, want 7 %q", got.ID, got.Name, "gpu-1")
+	}
+	if got.BaseURL == nil || got.BaseURL.String() != "http://gpu-1:11434" {
+		t.Errorf("got BaseURL %v, want http://gpu-1:11434", got.BaseURL)
+	}
+	if got.AuthHeader != "Bearer secret" {
+		t.Errorf("got AuthHeader %q, want %q", got.AuthHeader, "Bearer secret")
+	}
+	if got.Timeout != 900*time.Second {
+		t.Errorf("got Timeout %v, want %v", got.Timeout, 900*time.Second)
+	}
+}
+
+func TestResolve_UnknownModel(t *testing.T) {
+	r := twoHealthyNodes(t)
+	_, err := r.Resolve("no-such-model")
+	if !errors.Is(err, ErrModelUnavailable) {
+		t.Fatalf("want ErrModelUnavailable, got %v", err)
+	}
+}
+
+func TestResolve_NonRoutableStates(t *testing.T) {
+	tests := []struct {
+		name   string
+		health Health
+		models []string
+	}{
+		{"unhealthy node with known models", HealthUnhealthy, []string{"m"}},
+		{"unknown-health node with known models", HealthUnknown, []string{"m"}},
+		{"healthy node with unknown model list", HealthHealthy, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := New()
+			r.SetNodes([]Node{testNode(t, 1, "n1", "http://n1:11434")})
+			r.SetNodeState(1, tt.health, tt.models)
+			_, err := r.Resolve("m")
+			if !errors.Is(err, ErrModelUnavailable) {
+				t.Fatalf("want ErrModelUnavailable, got %v", err)
+			}
+		})
+	}
+}
+
+func TestResolve_NeverProbedNodeNotRoutable(t *testing.T) {
+	// A node registered via SetNodes but never probed must not receive
+	// traffic (no optimistic routing).
+	r := New()
+	r.SetNodes([]Node{testNode(t, 1, "n1", "http://n1:11434")})
+	_, err := r.Resolve("m")
+	if !errors.Is(err, ErrModelUnavailable) {
+		t.Fatalf("want ErrModelUnavailable, got %v", err)
+	}
+}
+
+func TestResolve_RoundRobin(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	// Candidates are ordered by node ID, and the counter starts at zero,
+	// so the sequence over six calls is deterministic: 1,2,1,2,1,2.
+	want := []int64{1, 2, 1, 2, 1, 2}
+	var got []int64
+	for i := 0; i < 6; i++ {
+		n, err := r.Resolve("shared-model")
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		got = append(got, n.ID)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("round-robin sequence = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestResolve_RoundRobinSkipsUnhealthy(t *testing.T) {
+	r := twoHealthyNodes(t)
+	r.SetNodeState(1, HealthUnhealthy, []string{"shared-model", "solo-model"})
+
+	for i := 0; i < 4; i++ {
+		n, err := r.Resolve("shared-model")
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if n.ID != 2 {
+			t.Fatalf("call %d resolved node %d, want only healthy node 2", i, n.ID)
+		}
+	}
+}
+
+func TestResolve_CountersSurviveRepublish(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	// Advance the counter to 3: sequence 1, 2, 1.
+	for i, want := range []int64{1, 2, 1} {
+		n, err := r.Resolve("shared-model")
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if n.ID != want {
+			t.Fatalf("call %d resolved %d, want %d", i, n.ID, want)
+		}
+	}
+
+	// Republish the same state (as the poller does every cycle). If the
+	// counter were rebuilt with the snapshot, the next pick would restart
+	// at node 1 instead of continuing at node 2.
+	r.SetNodeState(1, HealthHealthy, []string{"shared-model", "solo-model"})
+	r.SetNodeState(2, HealthHealthy, []string{"shared-model"})
+
+	n, err := r.Resolve("shared-model")
+	if err != nil {
+		t.Fatalf("Resolve after republish: %v", err)
+	}
+	if n.ID != 2 {
+		t.Fatalf("resolved node %d after republish, want 2 (balancing continuity)", n.ID)
+	}
+}
+
+func TestCounterPrunedWhenModelDisappears(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	// Create counter state for shared-model (two candidates -> counter used).
+	if _, err := r.Resolve("shared-model"); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if _, err := r.Resolve("shared-model"); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	r.mu.Lock()
+	_, exists := r.counters["shared-model"]
+	r.mu.Unlock()
+	if !exists {
+		t.Fatal("expected a counter for shared-model after resolving it")
+	}
+
+	// Both nodes stop serving shared-model; the republish must prune its counter.
+	r.SetNodeState(1, HealthHealthy, []string{"solo-model"})
+	r.SetNodeState(2, HealthHealthy, []string{"other-model"})
+
+	r.mu.Lock()
+	_, exists = r.counters["shared-model"]
+	r.mu.Unlock()
+	if exists {
+		t.Fatal("counter for disappeared model was not pruned on republish")
+	}
+	if _, err := r.Resolve("shared-model"); !errors.Is(err, ErrModelUnavailable) {
+		t.Fatal("shared-model should no longer resolve")
+	}
+}
+
+func TestResolve_NoCounterGrowthForUnknownModels(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	// A flood of arbitrary client-supplied model names must not allocate
+	// counter state.
+	for i := 0; i < 1000; i++ {
+		model := "bogus-" + string(rune('a'+i%26)) + "-model"
+		if _, err := r.Resolve(model); !errors.Is(err, ErrModelUnavailable) {
+			t.Fatalf("want ErrModelUnavailable for %q, got %v", model, err)
+		}
+	}
+
+	r.mu.Lock()
+	size := len(r.counters)
+	for model := range r.counters {
+		if model != "shared-model" && model != "solo-model" {
+			t.Errorf("counter allocated for non-routable model %q", model)
+		}
+	}
+	r.mu.Unlock()
+	if size > 2 {
+		t.Fatalf("counter map grew to %d entries from unknown-model floods", size)
+	}
+}
+
+func TestSetNodes_RemovedNodeNotRoutable(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	// Drop node 1; solo-model loses its only server.
+	r.SetNodes([]Node{testNode(t, 2, "beta", "http://beta:11434")})
+
+	if _, err := r.Resolve("solo-model"); !errors.Is(err, ErrModelUnavailable) {
+		t.Fatalf("want ErrModelUnavailable for solo-model, got %v", err)
+	}
+	n, err := r.Resolve("shared-model")
+	if err != nil {
+		t.Fatalf("shared-model should still resolve via node 2: %v", err)
+	}
+	if n.ID != 2 {
+		t.Fatalf("resolved node %d, want 2", n.ID)
+	}
+}
+
+func TestSetNodes_PreservesRuntimeStateByID(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	// Re-declare the same nodes (e.g. config reload with a renamed node).
+	renamed := testNode(t, 1, "alpha-renamed", "http://alpha:11434")
+	r.SetNodes([]Node{renamed, testNode(t, 2, "beta", "http://beta:11434")})
+
+	n, err := r.Resolve("solo-model")
+	if err != nil {
+		t.Fatalf("health/models should survive SetNodes for unchanged BaseURL: %v", err)
+	}
+	if n.Name != "alpha-renamed" {
+		t.Errorf("got Name %q, want config update applied", n.Name)
+	}
+}
+
+func TestSetNodes_BaseURLChangeResetsHealth(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	// Node 1 moves to a new URL: it is effectively an unprobed backend, so
+	// its stale healthy state must not be trusted.
+	moved := testNode(t, 1, "alpha", "http://alpha-new:11434")
+	r.SetNodes([]Node{moved, testNode(t, 2, "beta", "http://beta:11434")})
+
+	if _, err := r.Resolve("solo-model"); !errors.Is(err, ErrModelUnavailable) {
+		t.Fatalf("want ErrModelUnavailable for node with changed BaseURL, got %v", err)
+	}
+	snap := r.Snapshot()
+	for _, ns := range snap.Nodes {
+		if ns.Node.ID == 1 && ns.Health != HealthUnknown {
+			t.Errorf("node 1 health = %q after BaseURL change, want %q", ns.Health, HealthUnknown)
+		}
+	}
+}
+
+func TestSetNodeState_UnknownNodeIgnored(t *testing.T) {
+	r := twoHealthyNodes(t)
+	r.SetNodeState(99, HealthHealthy, []string{"ghost-model"})
+
+	if _, err := r.Resolve("ghost-model"); !errors.Is(err, ErrModelUnavailable) {
+		t.Fatal("state for an unregistered node ID must be ignored")
+	}
+	if len(r.Snapshot().Nodes) != 2 {
+		t.Fatalf("snapshot has %d nodes, want 2", len(r.Snapshot().Nodes))
+	}
+}
+
+func TestSnapshot_Contents(t *testing.T) {
+	r := twoHealthyNodes(t)
+	r.SetNodes([]Node{
+		testNode(t, 1, "alpha", "http://alpha:11434"),
+		testNode(t, 2, "beta", "http://beta:11434"),
+		testNode(t, 3, "gamma", "http://gamma:11434"),
+	})
+	r.SetNodeState(3, HealthUnhealthy, nil)
+
+	snap := r.Snapshot()
+	if len(snap.Nodes) != 3 {
+		t.Fatalf("snapshot has %d nodes, want 3", len(snap.Nodes))
+	}
+	// Nodes are ordered by ID.
+	wantHealth := map[int64]Health{1: HealthHealthy, 2: HealthHealthy, 3: HealthUnhealthy}
+	for i, ns := range snap.Nodes {
+		if ns.Node.ID != int64(i+1) {
+			t.Errorf("snapshot.Nodes[%d].Node.ID = %d, want %d", i, ns.Node.ID, i+1)
+		}
+		if ns.Health != wantHealth[ns.Node.ID] {
+			t.Errorf("node %d health = %q, want %q", ns.Node.ID, ns.Health, wantHealth[ns.Node.ID])
+		}
+	}
+
+	// Routing map: only healthy nodes with known model lists.
+	if got := len(snap.Models["shared-model"]); got != 2 {
+		t.Errorf("shared-model has %d candidates, want 2", got)
+	}
+	if got := len(snap.Models["solo-model"]); got != 1 {
+		t.Errorf("solo-model has %d candidates, want 1", got)
+	}
+	if _, ok := snap.Models["missing"]; ok {
+		t.Error("unexpected entry for unserved model")
+	}
+
+	// Node 1's model list is visible for display.
+	if len(snap.Nodes[0].Models) != 2 {
+		t.Errorf("node 1 snapshot models = %v, want 2 entries", snap.Nodes[0].Models)
+	}
+}
+
+func TestSnapshot_CallerMutationIsIsolated(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	snap := r.Snapshot()
+	snap.Nodes[0].Health = HealthUnhealthy
+	snap.Nodes[0].Models[0] = "clobbered"
+	snap.Nodes[0].Node.BaseURL.Host = "evil:1"
+	snap.Models["shared-model"][0] = Node{ID: 999}
+	delete(snap.Models, "solo-model")
+
+	fresh := r.Snapshot()
+	if fresh.Nodes[0].Health != HealthHealthy {
+		t.Error("mutating a returned snapshot changed registry health state")
+	}
+	if fresh.Nodes[0].Models[0] == "clobbered" {
+		t.Error("mutating a returned snapshot changed registry model state")
+	}
+	if fresh.Nodes[0].Node.BaseURL.Host == "evil:1" {
+		t.Error("mutating a returned snapshot changed a registry URL")
+	}
+	if fresh.Models["shared-model"][0].ID == 999 {
+		t.Error("mutating a returned routing map changed registry state")
+	}
+	n, err := r.Resolve("solo-model")
+	if err != nil || n.ID != 1 {
+		t.Errorf("solo-model no longer resolves after caller map mutation: %v", err)
+	}
+}
+
+func TestResolve_ReturnedURLIsCopy(t *testing.T) {
+	r := twoHealthyNodes(t)
+
+	n, err := r.Resolve("solo-model")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// Today's proxy handler mutates upstreamURL.Path; a returned node must
+	// not share URL storage with the registry.
+	n.BaseURL.Path = "/v1/chat/completions"
+
+	again, err := r.Resolve("solo-model")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if again.BaseURL.Path != "" {
+		t.Errorf("registry URL was mutated through a resolved node: path %q", again.BaseURL.Path)
+	}
+}
+
+func TestConcurrentResolveAndPublish(t *testing.T) {
+	r := New()
+	nodes := []Node{
+		testNode(t, 1, "alpha", "http://alpha:11434"),
+		testNode(t, 2, "beta", "http://beta:11434"),
+		testNode(t, 3, "gamma", "http://gamma:11434"),
+	}
+	r.SetNodes(nodes)
+	r.SetNodeState(1, HealthHealthy, []string{"m1", "m2"})
+	r.SetNodeState(2, HealthHealthy, []string{"m1"})
+	r.SetNodeState(3, HealthHealthy, []string{"m2"})
+
+	stop := make(chan struct{})
+	var publishers sync.WaitGroup
+	publishers.Add(1)
+	go func() {
+		defer publishers.Done()
+		healths := []Health{HealthHealthy, HealthUnhealthy, HealthUnknown}
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			r.SetNodeState(int64(i%3+1), healths[i%len(healths)], []string{"m1", "m2"})
+			if i%7 == 0 {
+				r.SetNodes(nodes)
+			}
+		}
+	}()
+
+	var readers sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		readers.Add(1)
+		go func(g int) {
+			defer readers.Done()
+			models := []string{"m1", "m2", "no-such-model"}
+			for i := 0; i < 2000; i++ {
+				model := models[(g+i)%len(models)]
+				n, err := r.Resolve(model)
+				if err == nil {
+					if n.ID < 1 || n.ID > 3 || n.BaseURL == nil {
+						t.Errorf("Resolve(%q) returned torn node: %+v", model, n)
+					}
+				} else if !errors.Is(err, ErrModelUnavailable) {
+					t.Errorf("Resolve(%q) unexpected error: %v", model, err)
+				}
+				if i%50 == 0 {
+					snap := r.Snapshot()
+					if len(snap.Nodes) != 3 {
+						t.Errorf("snapshot has %d nodes, want 3", len(snap.Nodes))
+					}
+				}
+			}
+		}(g)
+	}
+
+	readers.Wait()
+	close(stop)
+	publishers.Wait()
+}


### PR DESCRIPTION
Implements **Distributed Nodes BE-3: Registry core (snapshot + Resolve)** per `docs/design/distributed-nodes.md` (PR #43), sections "Registry concurrency" and "Request routing".

## What

New package `internal/registry` — the pure in-memory routing core for distributed backend nodes. No HTTP, no database, stdlib only. Merges unused-but-tested: the health poller (BE-4) will feed it, DB/config loaders (BE-5) declare nodes into it, and the proxy handler (BE-6) consumes it.

## Design

- **Immutable snapshots via `atomic.Pointer`** (copy-on-write): writers rebuild a complete snapshot (node states + model→[]node routing map) under the registry mutex and publish it atomically. `Resolve` reads exactly one snapshot per call — never a torn mix.
- **Round-robin counters live outside the snapshot** in a mutex-guarded map, so snapshot republishes (every poll cycle) do not reset balancing — per the design-review finding. Counters are pruned to the routable model catalog on each publish and are never allocated by lookups of arbitrary client-supplied model names.
- **No optimistic routing**: `Resolve` only considers healthy nodes with a *known* model list; unknown-health and unhealthy nodes are equally non-routable (distinct states for display). Misses return the sentinel `ErrModelUnavailable` (wrapped with the model name, `errors.Is`-compatible).
- **Publish API for the poller/loaders**: `SetNodes([]Node)` replaces the declared node set (runtime state carries over by ID; a changed BaseURL resets the node to unknown — it is effectively an unprobed backend); `SetNodeState(nodeID, health, models)` records a probe result. Both republish before returning.
- **Defensive copies**: `Resolve` and `Snapshot` return deep copies (including `*url.URL`), so callers — e.g. today's handler habit of mutating `upstreamURL.Path` — cannot corrupt registry state.

## API

```go
var ErrModelUnavailable error

type Health string // HealthUnknown | HealthHealthy | HealthUnhealthy

type Node struct {
    ID         int64
    Name       string
    BaseURL    *url.URL
    AuthHeader string        // "" = none
    Timeout    time.Duration // 0 = default (from nodes.timeout_seconds)
}

type NodeState struct {
    Node   Node
    Health Health
    Models []string // nil = not yet discovered
}

type RegistrySnapshot struct {
    Nodes  []NodeState       // all known nodes, ascending by ID
    Models map[string][]Node // model -> routable candidates, ascending by ID
}

func New() *Registry
func (r *Registry) SetNodes(nodes []Node)
func (r *Registry) SetNodeState(nodeID int64, health Health, models []string)
func (r *Registry) Resolve(model string) (Node, error)
func (r *Registry) Snapshot() RegistrySnapshot
```

## Testing (TDD — tests written first)

`go test -race ./internal/registry/...` — **21 tests pass**, covering:

- Resolve hit (full Node field fidelity) and miss (`errors.Is` sentinel)
- Non-routable states table: unhealthy, unknown-health, healthy-with-nil-models, never-probed
- Deterministic round-robin sequence over 6 calls across 2 healthy nodes; unhealthy candidates skipped
- Counters **survive** a snapshot republish (balancing continuity, the design-review finding)
- Counter pruning after a model disappears from the routable map
- No counter growth from a 1000-call flood of nonexistent model names
- `SetNodes` removal/carry-over/BaseURL-change semantics; `SetNodeState` for unknown IDs ignored
- Snapshot contents + deep-copy isolation (mutating returned snapshots/nodes/URLs cannot touch registry state)
- Concurrent Resolve + Snapshot (8 goroutines) against a hot publisher under `-race`

`gofmt` clean, `go vet ./...` clean, `go build ./...` green.

## Out of scope (later PRs)

HTTP probing/discovery (BE-4), DB/config loading + `OLLAMA_URL` synthesis (BE-5), proxy integration/routing (BE-6). No existing package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSYCn4mZxomD5Aauu5hJPr