### PR TITLE
feat(poller): node discovery, health checking, and startup sweep

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,6 +27,7 @@ type Metrics struct {
 
 	// Infrastructure
 	OllamaUp prometheus.Gauge
+	NodeUp   *prometheus.GaugeVec // labels: node — per-node probe health (1=up, 0=down)
 
 	// Sweeper
 	SweeperRuns  *prometheus.CounterVec // labels: operation (stale_holds|settled_cleanup), outcome (success|error)
@@ -100,6 +101,11 @@ func New(usageChLen func() int) *Metrics {
 			Help: "Whether Ollama is reachable (1=up, 0=down). Updated on readiness check.",
 		}),
 
+		NodeUp: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "aiproxy_node_up",
+			Help: "Whether a backend node is healthy per its last probe (1=up, 0=down), by node name.",
+		}, []string{"node"}),
+
 		SweeperRuns: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "aiproxy_credit_sweeper_runs_total",
 			Help: "Credit-hold sweeper tick invocations by operation and outcome.",
@@ -140,6 +146,7 @@ func New(usageChLen func() int) *Metrics {
 		m.RateLimitRejects,
 		m.UsageDrops,
 		m.OllamaUp,
+		m.NodeUp,
 		m.SweeperRuns,
 		m.SweeperSwept,
 		m.Registrations,
@@ -200,6 +207,45 @@ func (m *Metrics) RecordUsageDrop() {
 		return
 	}
 	m.UsageDrops.Inc()
+}
+
+// SetNodeUp sets aiproxy_node_up{node} to 1 (up) or 0 (down). Called by the
+// node health poller on every probe. Nil-safe.
+func (m *Metrics) SetNodeUp(node string, up bool) {
+	if m == nil {
+		return
+	}
+	v := 0.0
+	if up {
+		v = 1.0
+	}
+	m.NodeUp.WithLabelValues(node).Set(v)
+}
+
+// DeleteNodeUp removes the aiproxy_node_up series for a node that no longer
+// exists (removed or renamed), so stale series don't linger on /metrics.
+// Deleting a series that was never set is a no-op. Nil-safe.
+func (m *Metrics) DeleteNodeUp(node string) {
+	if m == nil {
+		return
+	}
+	m.NodeUp.DeleteLabelValues(node)
+}
+
+// SetOllamaUp sets the legacy aiproxy_ollama_up gauge. Kept for one release
+// as the OR of all node states: the node health poller calls this with
+// "any node healthy" after every probe cycle (see internal/poller). While a
+// poller is running it owns this gauge — BE-6 must not also wire
+// health.Checker.SetOllamaGauge, or the two writers will fight. Nil-safe.
+func (m *Metrics) SetOllamaUp(up bool) {
+	if m == nil {
+		return
+	}
+	if up {
+		m.OllamaUp.Set(1)
+		return
+	}
+	m.OllamaUp.Set(0)
 }
 
 // RecordSweeperRun records a sweeper tick. On success, rowsAffected is added

--- a/internal/metrics/node_up_test.go
+++ b/internal/metrics/node_up_test.go
@@ -1,0 +1,64 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSetNodeUp(t *testing.T) {
+	m := New(func() int { return 0 })
+
+	m.SetNodeUp("mac-studio", true)
+	m.SetNodeUp("gaming-pc", false)
+
+	if got := testutil.ToFloat64(m.NodeUp.WithLabelValues("mac-studio")); got != 1 {
+		t.Errorf("aiproxy_node_up{node=mac-studio} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.NodeUp.WithLabelValues("gaming-pc")); got != 0 {
+		t.Errorf("aiproxy_node_up{node=gaming-pc} = %v, want 0", got)
+	}
+
+	// Flipping works.
+	m.SetNodeUp("mac-studio", false)
+	if got := testutil.ToFloat64(m.NodeUp.WithLabelValues("mac-studio")); got != 0 {
+		t.Errorf("aiproxy_node_up{node=mac-studio} = %v, want 0 after flip", got)
+	}
+}
+
+func TestDeleteNodeUp_RemovesSeries(t *testing.T) {
+	m := New(func() int { return 0 })
+
+	m.SetNodeUp("old-node", true)
+	if n := testutil.CollectAndCount(m.NodeUp); n != 1 {
+		t.Fatalf("series count = %d, want 1", n)
+	}
+
+	m.DeleteNodeUp("old-node")
+	if n := testutil.CollectAndCount(m.NodeUp); n != 0 {
+		t.Errorf("series count = %d after delete, want 0", n)
+	}
+
+	// Deleting a nonexistent series is a no-op.
+	m.DeleteNodeUp("never-existed")
+}
+
+func TestSetOllamaUp(t *testing.T) {
+	m := New(func() int { return 0 })
+
+	m.SetOllamaUp(true)
+	if got := testutil.ToFloat64(m.OllamaUp); got != 1 {
+		t.Errorf("aiproxy_ollama_up = %v, want 1", got)
+	}
+	m.SetOllamaUp(false)
+	if got := testutil.ToFloat64(m.OllamaUp); got != 0 {
+		t.Errorf("aiproxy_ollama_up = %v, want 0", got)
+	}
+}
+
+func TestNodeUpMethods_NilSafe(t *testing.T) {
+	var m *Metrics
+	m.SetNodeUp("x", true) // must not panic
+	m.DeleteNodeUp("x")
+	m.SetOllamaUp(true)
+}

--- a/internal/poller/loader_test.go
+++ b/internal/poller/loader_test.go
@@ -2,7 +2,10 @@ package poller
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -115,6 +118,121 @@ func TestLoad_ReloadPicksUpChangesAndResetsOnBaseURLChange(t *testing.T) {
 	if ns := nodeState(t, reg, 1); ns.Models != nil {
 		t.Errorf("node 1 Models = %v, want nil after BaseURL change", ns.Models)
 	}
+}
+
+// A transient reload failure must not stop health probing: the cycle falls
+// back to the last successfully loaded node set, otherwise routing would
+// trust stale registry state until the DB recovers.
+func TestPollCycle_ReloadFailureKeepsProbingLastNodes(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Write([]byte(`{"models":[{"name":"m"}]}`))
+	}))
+	defer srv.Close()
+
+	p, reg, src := newTestPoller(t, []store.Node{enabledNode(1, "n1", srv.URL, "ollama")}, Options{})
+
+	// Load succeeds once (no probe yet), then the source starts failing.
+	if _, err := p.load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	src.set(nil, context.DeadlineExceeded)
+
+	p.pollCycle(context.Background())
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("backend probed %d times, want 1 (cycle must fall back to cached node set)", got)
+	}
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy despite reload failure", ns.Health)
+	}
+}
+
+// A node whose probe configuration changed without a BaseURL change (new
+// static_models list, backend_type flip, static_models removed) is a
+// different probing target: its carried-over health/models must reset so a
+// removed model can never stay routable on stale state.
+func TestLoad_ResetsStateWhenProbeConfigChanges(t *testing.T) {
+	discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"models":[{"name":"discovered"}]}`))
+	}))
+	defer discovery.Close()
+
+	staticNode := func(models []string) store.Node {
+		n := enabledNode(1, "n1", discovery.URL, "ollama")
+		n.StaticModels = models
+		return n
+	}
+
+	t.Run("static_models replaced", func(t *testing.T) {
+		p, reg, src := newTestPoller(t, []store.Node{staticNode([]string{"old-model"})}, Options{})
+		pollOnce(t, p)
+		if _, err := reg.Resolve("old-model"); err != nil {
+			t.Fatalf("setup: old-model not routable: %v", err)
+		}
+
+		src.set([]store.Node{staticNode([]string{"new-model"})}, nil)
+		if _, err := p.load(); err != nil {
+			t.Fatalf("load: %v", err)
+		}
+
+		// Immediately after the reload — before any probe — the stale
+		// static model must no longer be routable.
+		if _, err := reg.Resolve("old-model"); err == nil {
+			t.Error("old-model still routable after static_models changed")
+		}
+		if ns := nodeState(t, reg, 1); ns.Health != registry.HealthUnknown {
+			t.Errorf("Health = %q, want unknown after config change", ns.Health)
+		}
+
+		// The node is due immediately and the next probe publishes the new list.
+		pollOnce(t, p)
+		if _, err := reg.Resolve("new-model"); err != nil {
+			t.Errorf("new-model not routable after reprobe: %v", err)
+		}
+	})
+
+	t.Run("backend_type changed", func(t *testing.T) {
+		p, reg, src := newTestPoller(t, []store.Node{enabledNode(1, "n1", discovery.URL, "ollama")}, Options{})
+		pollOnce(t, p)
+
+		changed := enabledNode(1, "n1", discovery.URL, "openai_compat")
+		src.set([]store.Node{changed}, nil)
+		if _, err := p.load(); err != nil {
+			t.Fatalf("load: %v", err)
+		}
+
+		ns := nodeState(t, reg, 1)
+		if ns.Health != registry.HealthUnknown {
+			t.Errorf("Health = %q, want unknown after backend_type change", ns.Health)
+		}
+		if ns.Models != nil {
+			t.Errorf("Models = %v, want nil after backend_type change", ns.Models)
+		}
+	})
+
+	t.Run("static_models removed", func(t *testing.T) {
+		p, reg, src := newTestPoller(t, []store.Node{staticNode([]string{"pinned"})}, Options{})
+		pollOnce(t, p)
+		if _, err := reg.Resolve("pinned"); err != nil {
+			t.Fatalf("setup: pinned not routable: %v", err)
+		}
+
+		src.set([]store.Node{enabledNode(1, "n1", discovery.URL, "ollama")}, nil)
+		if _, err := p.load(); err != nil {
+			t.Fatalf("load: %v", err)
+		}
+
+		if _, err := reg.Resolve("pinned"); err == nil {
+			t.Error("pinned still routable after static_models removed")
+		}
+
+		pollOnce(t, p)
+		if _, err := reg.Resolve("discovered"); err != nil {
+			t.Errorf("discovered model not routable after switch to discovery: %v", err)
+		}
+	})
 }
 
 func TestLoad_SourceErrorLeavesRegistryUntouched(t *testing.T) {

--- a/internal/poller/loader_test.go
+++ b/internal/poller/loader_test.go
@@ -1,0 +1,227 @@
+package poller
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/registry"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+func TestLoad_MapsStoreRowsToRegistryNodes(t *testing.T) {
+	full := store.Node{
+		ID:             1,
+		Name:           "mac-studio",
+		BaseURL:        "http://100.101.2.3:11434",
+		BackendType:    "ollama",
+		AuthHeader:     strPtr("Bearer raw-secret"),
+		TimeoutSeconds: intPtr(600),
+		Enabled:        true,
+	}
+	disabled := store.Node{
+		ID:          2,
+		Name:        "retired",
+		BaseURL:     "http://gone:11434",
+		BackendType: "ollama",
+		Enabled:     false,
+	}
+	minimal := store.Node{
+		ID:          3,
+		Name:        "cloud",
+		BaseURL:     "https://api.example.com/openai",
+		BackendType: "openai_compat",
+		Enabled:     true,
+	}
+
+	p, reg, _ := newTestPoller(t, []store.Node{full, disabled, minimal}, Options{})
+	specs, err := p.load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("len(specs) = %d, want 2 (disabled node excluded)", len(specs))
+	}
+
+	snap := reg.Snapshot()
+	if len(snap.Nodes) != 2 {
+		t.Fatalf("registry has %d nodes, want 2", len(snap.Nodes))
+	}
+
+	n1 := nodeState(t, reg, 1).Node
+	if n1.Name != "mac-studio" {
+		t.Errorf("Name = %q, want mac-studio", n1.Name)
+	}
+	if n1.BaseURL == nil || n1.BaseURL.String() != "http://100.101.2.3:11434" {
+		t.Errorf("BaseURL = %v, want http://100.101.2.3:11434", n1.BaseURL)
+	}
+	if n1.AuthHeader != "Bearer raw-secret" {
+		t.Errorf("AuthHeader = %q, want raw secret", n1.AuthHeader)
+	}
+	if n1.Timeout != 600*time.Second {
+		t.Errorf("Timeout = %v, want 600s", n1.Timeout)
+	}
+
+	n3 := nodeState(t, reg, 3).Node
+	if n3.BaseURL == nil || n3.BaseURL.String() != "https://api.example.com/openai" {
+		t.Errorf("BaseURL = %v, want https://api.example.com/openai", n3.BaseURL)
+	}
+	if n3.AuthHeader != "" {
+		t.Errorf("AuthHeader = %q, want empty", n3.AuthHeader)
+	}
+	if n3.Timeout != 0 {
+		t.Errorf("Timeout = %v, want 0 (default)", n3.Timeout)
+	}
+
+	for _, ns := range snap.Nodes {
+		if ns.Node.ID == 2 {
+			t.Error("disabled node 2 must not be loaded into the registry")
+		}
+	}
+}
+
+// A reload picks up node changes (BE-7 admin edits) without a restart, and a
+// node whose BaseURL changed loses its runtime state (poller + registry).
+func TestLoad_ReloadPicksUpChangesAndResetsOnBaseURLChange(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, src := newTestPoller(t, []store.Node{enabledNode(1, "n1", f.srv.URL, "ollama")}, Options{})
+
+	pollOnce(t, p)
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Fatalf("setup: Health = %q, want healthy", ns.Health)
+	}
+
+	// Add a node and change node 1's BaseURL: 1 resets to unknown, 2 appears.
+	src.set([]store.Node{
+		enabledNode(1, "n1", "http://moved:11434", "ollama"),
+		enabledNode(2, "n2", f.srv.URL, "ollama"),
+	}, nil)
+	if _, err := p.load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	snap := reg.Snapshot()
+	if len(snap.Nodes) != 2 {
+		t.Fatalf("registry has %d nodes, want 2 after reload", len(snap.Nodes))
+	}
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthUnknown {
+		t.Errorf("node 1 Health = %q, want unknown after BaseURL change", ns.Health)
+	}
+
+	// The poller's own hysteresis state must reset too: one failure on the
+	// moved node keeps it unknown (not an immediate unhealthy carried over
+	// from stale counters), and its model list is no longer trusted.
+	if ns := nodeState(t, reg, 1); ns.Models != nil {
+		t.Errorf("node 1 Models = %v, want nil after BaseURL change", ns.Models)
+	}
+}
+
+func TestLoad_SourceErrorLeavesRegistryUntouched(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, src := newTestPoller(t, []store.Node{enabledNode(1, "n1", f.srv.URL, "ollama")}, Options{})
+	pollOnce(t, p)
+
+	src.set(nil, context.DeadlineExceeded)
+	if _, err := p.load(); err == nil {
+		t.Fatal("load = nil error, want source error")
+	}
+
+	// Registry still has the node with its last-known state.
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy preserved across a failed reload", ns.Health)
+	}
+}
+
+// TestLoad_DBIntegration exercises the loader against real store rows in
+// Postgres (skipped without DATABASE_URL, matching the store test suite).
+func TestLoad_DBIntegration(t *testing.T) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("DATABASE_URL not set, skipping DB integration test")
+	}
+
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	wipe := func() {
+		c := context.Background()
+		// usage_logs references nodes; delete referencing rows first.
+		_, _ = s.Pool().Exec(c, "DELETE FROM usage_logs")
+		_, _ = s.Pool().Exec(c, "DELETE FROM nodes")
+	}
+	wipe()
+	t.Cleanup(func() {
+		wipe()
+		s.Close()
+	})
+
+	fullID, err := s.CreateNode(store.Node{
+		Name:           "db-full",
+		BaseURL:        "http://100.64.0.7:11434/",
+		BackendType:    "ollama",
+		AuthHeader:     strPtr("Bearer db-secret"),
+		StaticModels:   []string{"pinned:latest"},
+		HealthPath:     strPtr("/healthz"),
+		TimeoutSeconds: intPtr(120),
+	})
+	if err != nil {
+		t.Fatalf("CreateNode full: %v", err)
+	}
+	minID, err := s.CreateNode(store.Node{
+		Name:        "db-min",
+		BaseURL:     "https://API.example.com/openai",
+		BackendType: "openai_compat",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode minimal: %v", err)
+	}
+	offID, err := s.CreateNode(store.Node{
+		Name:    "db-disabled",
+		BaseURL: "http://gone:11434",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode disabled: %v", err)
+	}
+	if err := s.DisableNode(offID); err != nil {
+		t.Fatalf("DisableNode: %v", err)
+	}
+
+	reg := registry.New()
+	p := New(s, reg, nil, Options{})
+	specs, err := p.load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("len(specs) = %d, want 2", len(specs))
+	}
+
+	snap := reg.Snapshot()
+	if len(snap.Nodes) != 2 {
+		t.Fatalf("registry has %d nodes, want 2", len(snap.Nodes))
+	}
+
+	full := nodeState(t, reg, fullID).Node
+	// Canonicalization happened at write: trailing slash trimmed.
+	if full.BaseURL.String() != "http://100.64.0.7:11434" {
+		t.Errorf("full BaseURL = %q, want canonical http://100.64.0.7:11434", full.BaseURL)
+	}
+	if full.AuthHeader != "Bearer db-secret" {
+		t.Errorf("full AuthHeader = %q, want the RAW secret (loader must use ListNodesWithSecrets)", full.AuthHeader)
+	}
+	if full.Timeout != 120*time.Second {
+		t.Errorf("full Timeout = %v, want 120s", full.Timeout)
+	}
+
+	min := nodeState(t, reg, minID).Node
+	// Canonicalization lowercases the host.
+	if min.BaseURL.String() != "https://api.example.com/openai" {
+		t.Errorf("min BaseURL = %q, want https://api.example.com/openai", min.BaseURL)
+	}
+	if min.AuthHeader != "" {
+		t.Errorf("min AuthHeader = %q, want empty", min.AuthHeader)
+	}
+}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -54,6 +54,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -130,12 +131,26 @@ func (s nodeSpec) probeURL() string {
 	}
 }
 
+// identity returns the node's probe identity: every field that changes what
+// a probe means — the URL it hits, the credentials it carries, and whether
+// the model list is discovered or statically pinned (and to what). Runtime
+// state carried across a reload is only valid while the identity is
+// unchanged; the nil-vs-empty staticModels distinction is encoded so
+// switching between discovery and an empty static list also resets.
+func (s nodeSpec) identity() string {
+	id := s.baseURL.String() + "\x1f" + s.backendType + "\x1f" + s.authHeader + "\x1f" + s.healthPath + "\x1f"
+	if s.staticModels == nil {
+		return id + "discovery"
+	}
+	return id + "static\x1f" + strings.Join(s.staticModels, "\x1f")
+}
+
 // nodeRuntime is the poller-owned per-node state machine, guarded by
 // Poller.mu. The poller (not the registry) owns hysteresis: the registry only
 // ever sees the already-smoothed health value.
 type nodeRuntime struct {
 	name      string          // last published metric label, for series cleanup
-	baseURL   string          // to detect re-pointed nodes on reload
+	identity  string          // probe identity; a change invalidates runtime state
 	health    registry.Health // smoothed health as last published
 	failures  int             // consecutive probe failures
 	models    []string        // last known model list; nil = never discovered
@@ -153,8 +168,9 @@ type Poller struct {
 	client *http.Client
 	now    func() time.Time // injectable clock for tests
 
-	mu    sync.Mutex
-	state map[int64]*nodeRuntime
+	mu        sync.Mutex
+	state     map[int64]*nodeRuntime
+	lastSpecs []nodeSpec // last successfully loaded node set (reload fallback)
 }
 
 // New builds a poller. reg must be non-nil; m may be nil (metrics disabled).
@@ -227,36 +243,56 @@ func (p *Poller) Run(ctx context.Context) {
 		case <-timer.C:
 		}
 
-		specs, err := p.load()
-		if err != nil {
-			// Keep probing the last-loaded node set on DB hiccups: routing
-			// should not degrade just because a reload failed.
-			slog.Error("node poller: reloading nodes failed", "error", err)
-		}
-		now := p.now()
-		due := make([]nodeSpec, 0, len(specs))
-		for _, s := range specs {
-			if !p.nextDue(s.id).After(now) {
-				due = append(due, s)
-			}
-		}
-		p.probeSpecs(ctx, due, false)
+		wait := p.pollCycle(ctx)
 		if ctx.Err() != nil {
 			return
 		}
-
-		next := p.now().Add(p.opts.Interval)
-		for _, s := range specs {
-			if d := p.nextDue(s.id); d.Before(next) {
-				next = d
-			}
-		}
-		wait := next.Sub(p.now())
-		if wait < minWait {
-			wait = minWait
-		}
 		timer.Reset(wait)
 	}
+}
+
+// pollCycle runs one poll cycle — reload, probe everything due, compute the
+// next wake — and returns how long to wait before the next cycle. When the
+// reload fails it falls back to the last successfully loaded node set: a
+// transient DB error must not stop health refreshing, or routing would trust
+// stale registry state until the DB recovers.
+func (p *Poller) pollCycle(ctx context.Context) time.Duration {
+	specs, err := p.load()
+	if err != nil {
+		specs = p.cachedSpecs()
+		slog.Error("node poller: reloading nodes failed; probing last-known node set",
+			"error", err, "nodes", len(specs))
+	}
+	now := p.now()
+	due := make([]nodeSpec, 0, len(specs))
+	for _, s := range specs {
+		if !p.nextDue(s.id).After(now) {
+			due = append(due, s)
+		}
+	}
+	p.probeSpecs(ctx, due, false)
+
+	// Next wake: the earliest node due, capped at one base interval so node
+	// additions/changes in the DB are picked up within ~Interval even when
+	// nothing is due sooner.
+	next := p.now().Add(p.opts.Interval)
+	for _, s := range specs {
+		if d := p.nextDue(s.id); d.Before(next) {
+			next = d
+		}
+	}
+	wait := next.Sub(p.now())
+	if wait < minWait {
+		wait = minWait
+	}
+	return wait
+}
+
+// cachedSpecs returns the node set from the last successful load.
+func (p *Poller) cachedSpecs() []nodeSpec {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastSpecs
 }
 
 // load reads all nodes from the source, maps the enabled ones into the
@@ -317,8 +353,12 @@ func (p *Poller) load() ([]nodeSpec, error) {
 // reconcile aligns the poller's runtime state with a freshly loaded node
 // set: new nodes start unknown and immediately due, removed nodes drop their
 // state and metric series, renamed nodes migrate their metric series, and a
-// node whose BaseURL changed is a different backend — its hysteresis state,
-// model list, and schedule reset (mirroring registry.SetNodes semantics).
+// node whose probe identity changed (BaseURL, backend_type, auth_header,
+// health_path, or static_models) is a different probing target — its
+// hysteresis state, model list, and schedule reset, and the reset is
+// published to the registry immediately so stale carried-over models (e.g. a
+// removed static model) can never stay routable while waiting for the next
+// probe. The reset node is due at once, so the same cycle reprobes it.
 func (p *Poller) reconcile(specs []nodeSpec) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -329,18 +369,22 @@ func (p *Poller) reconcile(specs []nodeSpec) {
 		st, ok := p.state[s.id]
 		if !ok {
 			p.state[s.id] = &nodeRuntime{
-				name:    s.name,
-				baseURL: s.baseURL.String(),
-				health:  registry.HealthUnknown,
+				name:     s.name,
+				identity: s.identity(),
+				health:   registry.HealthUnknown,
 			}
 			continue
 		}
-		if st.baseURL != s.baseURL.String() {
-			st.baseURL = s.baseURL.String()
+		if id := s.identity(); st.identity != id {
+			st.identity = id
 			st.health = registry.HealthUnknown
 			st.failures = 0
 			st.models = nil
 			st.lastProbe = time.Time{}
+			// registry.SetNodes only resets on BaseURL changes; for the
+			// other identity fields it carried the old state over, so
+			// publish the reset explicitly.
+			p.reg.SetNodeProbe(s.id, registry.ProbeResult{Health: registry.HealthUnknown})
 		}
 		if st.name != s.name {
 			p.m.DeleteNodeUp(st.name)
@@ -353,6 +397,7 @@ func (p *Poller) reconcile(specs []nodeSpec) {
 			delete(p.state, id)
 		}
 	}
+	p.lastSpecs = specs
 	p.m.SetOllamaUp(p.anyHealthyLocked())
 }
 

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -1,0 +1,571 @@
+// Package poller loads backend nodes from the database into the routing
+// registry and keeps their health and model lists current by probing them.
+// It implements the "Discovery and health checking" section of
+// docs/design/distributed-nodes.md:
+//
+//   - SweepOnce is the startup sweep: it probes all enabled nodes in
+//     parallel under a bounded budget (per-probe 5s, overall ~6s) and marks
+//     non-responders unhealthy on a SINGLE failure, so restarts are
+//     deterministic before the HTTP listener opens.
+//   - Run is the ongoing poll loop: each node is probed every ~15s with a
+//     deterministic per-node ±20% jitter, and the node set is re-read from
+//     the database on every cycle so admin-API changes (BE-7) are picked up
+//     without a restart. Run returns when its context is cancelled.
+//   - The running loop applies hysteresis: healthy/unknown → unhealthy only
+//     after 2 consecutive failures; any success is immediately healthy.
+//
+// Probe = discovery: for `ollama` nodes GET {base_url}/api/tags supplies both
+// liveness and the model list (tag names); for `openai_compat` nodes GET
+// {base_url}/v1/models (data[].id). Nodes with static_models are only
+// health-checked (health_path if set, else the type's discovery endpoint);
+// 2xx = alive, the body is ignored, and the static list stays authoritative.
+//
+// Probe client hardening (review-mandated): redirects are NEVER followed
+// (CheckRedirect returns an error — with auth_header attached, following a
+// redirect could exfiltrate backend credentials), response bodies are read
+// through a 1MB cap, and every probe carries the node's auth_header as the
+// Authorization header when set.
+//
+// Probe outcomes are published to the registry after every probe via
+// registry.SetNodeProbe, including LastError and LastCheckedAt (NodeState
+// was extended additively for this; BE-7's admin endpoints can read both
+// straight from Registry.Snapshot).
+//
+// Wiring notes for BE-6 (main.go):
+//
+//	p := poller.New(db, reg, m, poller.Options{})
+//	if err := p.SweepOnce(ctx); err != nil { /* fail fast: DB unreadable */ }
+//	go p.Run(ctx) // alongside credits.StartSweeper; returns on ctx cancel
+//
+// Metrics: the poller sets aiproxy_node_up{node} on every probe and keeps
+// the legacy aiproxy_ollama_up gauge equal to the OR of all node states
+// after every probe and reload. While the poller runs it owns that gauge —
+// do not also wire health.Checker.SetOllamaGauge.
+package poller
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/metrics"
+	"github.com/krishna/local-ai-proxy/internal/registry"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+const (
+	defaultInterval     = 15 * time.Second
+	defaultJitterFrac   = 0.20
+	defaultProbeTimeout = 5 * time.Second
+	defaultSweepBudget  = 6 * time.Second
+	defaultMaxBodyBytes = 1 << 20 // 1MB
+
+	// failureThreshold is the number of CONSECUTIVE probe failures needed to
+	// take a node from healthy (or unknown) to unhealthy in the running
+	// poller. The startup sweep bypasses it by design.
+	failureThreshold = 2
+
+	// minWait keeps the Run loop from busy-spinning if a computed wake time
+	// is already in the past.
+	minWait = 100 * time.Millisecond
+
+	backendOllama = "ollama"
+)
+
+// errRedirectRefused is returned from the probe client's CheckRedirect:
+// following a redirect with auth_header attached could exfiltrate backend
+// credentials to an attacker-influenced Location.
+var errRedirectRefused = errors.New("upstream redirect refused (probes never follow redirects)")
+
+// NodeSource is the subset of *store.Store the poller needs. The loader must
+// see raw auth_header values (they are sent on probes), hence WithSecrets.
+type NodeSource interface {
+	ListNodesWithSecrets() ([]store.Node, error)
+}
+
+// Options tunes the poller. Zero values take the documented defaults.
+type Options struct {
+	Interval     time.Duration // base poll interval; default 15s
+	JitterFrac   float64       // per-node jitter fraction; default 0.20 (±20%)
+	ProbeTimeout time.Duration // per-probe budget; default 5s
+	SweepBudget  time.Duration // overall SweepOnce budget; default 6s
+	MaxBodyBytes int64         // probe response body cap; default 1MB
+}
+
+// nodeSpec is the poller's probing view of one enabled node, built from a
+// store row on each load.
+type nodeSpec struct {
+	id           int64
+	name         string
+	baseURL      *url.URL
+	backendType  string
+	authHeader   string   // "" = none
+	staticModels []string // non-nil disables discovery; the list is authoritative
+	healthPath   string   // "" = none; only meaningful with staticModels
+}
+
+// discoveryProbe reports whether the probe response body is parsed for
+// models (true) or ignored (false, static_models nodes).
+func (s nodeSpec) discoveryProbe() bool { return s.staticModels == nil }
+
+// probeURL path-joins the probe endpoint onto base_url. Joining (never
+// overwriting url.Path) preserves base_url path prefixes like /openai.
+func (s nodeSpec) probeURL() string {
+	switch {
+	case !s.discoveryProbe() && s.healthPath != "":
+		return s.baseURL.JoinPath(s.healthPath).String()
+	case s.backendType == backendOllama:
+		return s.baseURL.JoinPath("api/tags").String()
+	default: // openai_compat
+		return s.baseURL.JoinPath("v1/models").String()
+	}
+}
+
+// nodeRuntime is the poller-owned per-node state machine, guarded by
+// Poller.mu. The poller (not the registry) owns hysteresis: the registry only
+// ever sees the already-smoothed health value.
+type nodeRuntime struct {
+	name      string          // last published metric label, for series cleanup
+	baseURL   string          // to detect re-pointed nodes on reload
+	health    registry.Health // smoothed health as last published
+	failures  int             // consecutive probe failures
+	models    []string        // last known model list; nil = never discovered
+	lastProbe time.Time       // for scheduling; zero = probe immediately
+}
+
+// Poller loads nodes from a NodeSource into a registry and probes them.
+// SweepOnce and Run are safe to use from one goroutine each; internal state
+// is locked because probes within a cycle run in parallel.
+type Poller struct {
+	src    NodeSource
+	reg    *registry.Registry
+	m      *metrics.Metrics // nil-safe (metrics disabled)
+	opts   Options
+	client *http.Client
+	now    func() time.Time // injectable clock for tests
+
+	mu    sync.Mutex
+	state map[int64]*nodeRuntime
+}
+
+// New builds a poller. reg must be non-nil; m may be nil (metrics disabled).
+// Zero Options fields take the defaults documented on Options.
+func New(src NodeSource, reg *registry.Registry, m *metrics.Metrics, opts Options) *Poller {
+	if opts.Interval <= 0 {
+		opts.Interval = defaultInterval
+	}
+	if opts.JitterFrac <= 0 {
+		opts.JitterFrac = defaultJitterFrac
+	}
+	if opts.ProbeTimeout <= 0 {
+		opts.ProbeTimeout = defaultProbeTimeout
+	}
+	if opts.SweepBudget <= 0 {
+		opts.SweepBudget = defaultSweepBudget
+	}
+	if opts.MaxBodyBytes <= 0 {
+		opts.MaxBodyBytes = defaultMaxBodyBytes
+	}
+	return &Poller{
+		src:   src,
+		reg:   reg,
+		m:     m,
+		opts:  opts,
+		now:   time.Now,
+		state: make(map[int64]*nodeRuntime),
+		client: &http.Client{
+			Timeout: opts.ProbeTimeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return errRedirectRefused
+			},
+		},
+	}
+}
+
+// SweepOnce is the synchronous startup sweep: it loads enabled nodes from
+// the database and probes them all in parallel, bounded by SweepBudget
+// overall and ProbeTimeout per node. Nodes that respond are healthy with a
+// populated model list; nodes that don't are unhealthy after this SINGLE
+// failure (per the design doc — hysteresis only applies to the running
+// loop) and receive no traffic until the poller reaches them. The returned
+// error is only for a failed node load (DB unreachable); probe failures are
+// recorded in the registry, not returned.
+func (p *Poller) SweepOnce(ctx context.Context) error {
+	specs, err := p.load()
+	if err != nil {
+		return err
+	}
+	sweepCtx, cancel := context.WithTimeout(ctx, p.opts.SweepBudget)
+	defer cancel()
+	p.probeSpecs(sweepCtx, specs, true)
+	return nil
+}
+
+// Run is the ongoing poll loop. Each cycle re-reads the node set from the
+// database (a cheap single-gateway query, so BE-7 admin changes apply
+// without a restart), probes every node that is due, and sleeps until the
+// next node is due — capped at one base interval so newly added nodes are
+// probed within ~Interval. The first cycle runs immediately; nodes already
+// probed by SweepOnce are not due again until a full jittered interval after
+// the sweep. Run returns when ctx is cancelled.
+func (p *Poller) Run(ctx context.Context) {
+	timer := time.NewTimer(0) // immediate first cycle
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		specs, err := p.load()
+		if err != nil {
+			// Keep probing the last-loaded node set on DB hiccups: routing
+			// should not degrade just because a reload failed.
+			slog.Error("node poller: reloading nodes failed", "error", err)
+		}
+		now := p.now()
+		due := make([]nodeSpec, 0, len(specs))
+		for _, s := range specs {
+			if !p.nextDue(s.id).After(now) {
+				due = append(due, s)
+			}
+		}
+		p.probeSpecs(ctx, due, false)
+		if ctx.Err() != nil {
+			return
+		}
+
+		next := p.now().Add(p.opts.Interval)
+		for _, s := range specs {
+			if d := p.nextDue(s.id); d.Before(next) {
+				next = d
+			}
+		}
+		wait := next.Sub(p.now())
+		if wait < minWait {
+			wait = minWait
+		}
+		timer.Reset(wait)
+	}
+}
+
+// load reads all nodes from the source, maps the enabled ones into the
+// registry (registry.SetNodes carries runtime state over by ID and resets
+// nodes whose BaseURL changed), and reconciles the poller's own runtime
+// state to the new node set. It returns the probing specs for the cycle.
+func (p *Poller) load() ([]nodeSpec, error) {
+	rows, err := p.src.ListNodesWithSecrets()
+	if err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+
+	specs := make([]nodeSpec, 0, len(rows))
+	regNodes := make([]registry.Node, 0, len(rows))
+	for _, n := range rows {
+		if !n.Enabled {
+			continue
+		}
+		u, err := url.Parse(n.BaseURL)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			// base_url is canonicalized at write time, so this indicates DB
+			// corruption; skip the node rather than probing garbage.
+			slog.Error("node poller: skipping node with unparseable base_url", "node", n.Name, "error", err)
+			continue
+		}
+		spec := nodeSpec{
+			id:           n.ID,
+			name:         n.Name,
+			baseURL:      u,
+			backendType:  n.BackendType,
+			staticModels: n.StaticModels,
+		}
+		if n.AuthHeader != nil {
+			spec.authHeader = *n.AuthHeader
+		}
+		if n.HealthPath != nil {
+			spec.healthPath = *n.HealthPath
+		}
+		var timeout time.Duration
+		if n.TimeoutSeconds != nil {
+			timeout = time.Duration(*n.TimeoutSeconds) * time.Second
+		}
+		specs = append(specs, spec)
+		regNodes = append(regNodes, registry.Node{
+			ID:         n.ID,
+			Name:       n.Name,
+			BaseURL:    u,
+			AuthHeader: spec.authHeader,
+			Timeout:    timeout,
+		})
+	}
+
+	p.reg.SetNodes(regNodes)
+	p.reconcile(specs)
+	return specs, nil
+}
+
+// reconcile aligns the poller's runtime state with a freshly loaded node
+// set: new nodes start unknown and immediately due, removed nodes drop their
+// state and metric series, renamed nodes migrate their metric series, and a
+// node whose BaseURL changed is a different backend — its hysteresis state,
+// model list, and schedule reset (mirroring registry.SetNodes semantics).
+func (p *Poller) reconcile(specs []nodeSpec) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	current := make(map[int64]bool, len(specs))
+	for _, s := range specs {
+		current[s.id] = true
+		st, ok := p.state[s.id]
+		if !ok {
+			p.state[s.id] = &nodeRuntime{
+				name:    s.name,
+				baseURL: s.baseURL.String(),
+				health:  registry.HealthUnknown,
+			}
+			continue
+		}
+		if st.baseURL != s.baseURL.String() {
+			st.baseURL = s.baseURL.String()
+			st.health = registry.HealthUnknown
+			st.failures = 0
+			st.models = nil
+			st.lastProbe = time.Time{}
+		}
+		if st.name != s.name {
+			p.m.DeleteNodeUp(st.name)
+			st.name = s.name
+		}
+	}
+	for id, st := range p.state {
+		if !current[id] {
+			p.m.DeleteNodeUp(st.name)
+			delete(p.state, id)
+		}
+	}
+	p.m.SetOllamaUp(p.anyHealthyLocked())
+}
+
+// probeSpecs probes the given nodes in parallel and applies each outcome.
+// sweep selects startup-sweep semantics (single failure = unhealthy).
+func (p *Poller) probeSpecs(ctx context.Context, specs []nodeSpec, sweep bool) {
+	var wg sync.WaitGroup
+	for _, s := range specs {
+		wg.Add(1)
+		go func(s nodeSpec) {
+			defer wg.Done()
+			probeCtx, cancel := context.WithTimeout(ctx, p.opts.ProbeTimeout)
+			defer cancel()
+			models, err := p.probe(probeCtx, s)
+			p.apply(s, models, err, sweep)
+		}(s)
+	}
+	wg.Wait()
+}
+
+// probe performs one HTTP probe. On success it returns the node's model
+// list: parsed from the discovery response, or a copy of the static list for
+// health-only probes. All response reading goes through the body cap.
+func (p *Poller) probe(ctx context.Context, s nodeSpec) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.probeURL(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build probe request: %w", err)
+	}
+	if s.authHeader != "" {
+		req.Header.Set("Authorization", s.authHeader)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		drainCapped(resp.Body, p.opts.MaxBodyBytes)
+		return nil, fmt.Errorf("probe returned status %d", resp.StatusCode)
+	}
+
+	if !s.discoveryProbe() {
+		// Health-only probe: 2xx = alive, body ignored (the cap bounds how
+		// much of it is ever read). The static list is authoritative.
+		drainCapped(resp.Body, p.opts.MaxBodyBytes)
+		models := make([]string, len(s.staticModels))
+		copy(models, s.staticModels)
+		return models, nil
+	}
+
+	body, err := readCapped(resp.Body, p.opts.MaxBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+	return parseModels(s.backendType, body)
+}
+
+// apply runs the per-node state machine on a probe outcome, logs health
+// transitions, and publishes the result to the registry and metrics.
+//
+// Transitions: any success → healthy with the failure counter reset;
+// a failure increments the counter and demotes to unhealthy once it reaches
+// failureThreshold — or immediately when sweep is set (startup semantics:
+// nodes that miss the sweep get no traffic until the poller reaches them).
+// On failure the last-known model list keeps being published: routing
+// ignores it while unhealthy, and it documents what the node served.
+func (p *Poller) apply(s nodeSpec, models []string, probeErr error, sweep bool) {
+	now := p.now()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	st, ok := p.state[s.id]
+	if !ok {
+		// The node vanished in a concurrent reload; drop the result (the
+		// registry would ignore it anyway).
+		return
+	}
+
+	prev := st.health
+	var lastErr string
+	if probeErr == nil {
+		st.failures = 0
+		st.health = registry.HealthHealthy
+		st.models = models
+	} else {
+		lastErr = probeErr.Error()
+		st.failures++
+		if sweep || st.failures >= failureThreshold {
+			st.health = registry.HealthUnhealthy
+		}
+	}
+	st.lastProbe = now
+
+	if st.health != prev {
+		if lastErr != "" {
+			slog.Info("node health transition",
+				"node", s.name, "from", prev, "to", st.health, "error", lastErr)
+		} else {
+			slog.Info("node health transition", "node", s.name, "from", prev, "to", st.health)
+		}
+	} else if probeErr != nil {
+		slog.Debug("node probe failed",
+			"node", s.name, "health", st.health, "consecutive_failures", st.failures, "error", lastErr)
+	}
+
+	p.reg.SetNodeProbe(s.id, registry.ProbeResult{
+		Health:        st.health,
+		Models:        st.models,
+		LastError:     lastErr,
+		LastCheckedAt: now,
+	})
+	p.m.SetNodeUp(s.name, st.health == registry.HealthHealthy)
+	p.m.SetOllamaUp(p.anyHealthyLocked())
+}
+
+// anyHealthyLocked reports whether any known node is healthy (the OR fed
+// into the legacy aiproxy_ollama_up gauge). Callers must hold p.mu.
+func (p *Poller) anyHealthyLocked() bool {
+	for _, st := range p.state {
+		if st.health == registry.HealthHealthy {
+			return true
+		}
+	}
+	return false
+}
+
+// nextDue returns when the node should next be probed: a full jittered
+// interval after its last probe, or immediately (zero time) if it has never
+// been probed by this poller.
+func (p *Poller) nextDue(id int64) time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	st, ok := p.state[id]
+	if !ok || st.lastProbe.IsZero() {
+		return time.Time{}
+	}
+	return st.lastProbe.Add(p.intervalFor(id))
+}
+
+// intervalFor returns the node's poll interval: the base interval with a
+// deterministic per-node jitter in [-JitterFrac, +JitterFrac], derived from
+// the node ID. Deriving jitter from the ID (rather than a live RNG) spreads
+// probes across nodes, keeps each node's cadence steady, and makes
+// scheduling fully deterministic in tests.
+func (p *Poller) intervalFor(nodeID int64) time.Duration {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], uint64(nodeID))
+	h := fnv.New64a()
+	h.Write(b[:])
+	// Map the hash onto [-1, 1] exactly: n/1023.5 - 1 for n in [0, 2047].
+	frac := float64(h.Sum64()%2048)/1023.5 - 1.0
+	return time.Duration(float64(p.opts.Interval) * (1 + p.opts.JitterFrac*frac))
+}
+
+// readCapped reads r fully, failing if the body exceeds max bytes — a
+// truncated discovery response cannot be trusted, so the probe must fail
+// rather than publish a partial model list.
+func readCapped(r io.Reader, limit int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read probe response: %w", err)
+	}
+	if int64(len(b)) > limit {
+		return nil, fmt.Errorf("probe response body exceeds %d bytes", limit)
+	}
+	return b, nil
+}
+
+// drainCapped discards up to max bytes of r so the connection can be reused,
+// without ever reading an unbounded body.
+func drainCapped(r io.Reader, limit int64) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(r, limit))
+}
+
+// parseModels extracts the model list from a discovery response body.
+// Ollama /api/tags: {"models":[{"name":...}]}; openai_compat /v1/models:
+// {"data":[{"id":...}]}. The result is always non-nil: a successful probe
+// with zero models is a known-empty list, distinct from never-discovered.
+func parseModels(backendType string, body []byte) ([]string, error) {
+	if backendType == backendOllama {
+		var tags struct {
+			Models []struct {
+				Name string `json:"name"`
+			} `json:"models"`
+		}
+		if err := json.Unmarshal(body, &tags); err != nil {
+			return nil, fmt.Errorf("parse ollama /api/tags response: %w", err)
+		}
+		models := make([]string, 0, len(tags.Models))
+		for _, m := range tags.Models {
+			if m.Name != "" {
+				models = append(models, m.Name)
+			}
+		}
+		return models, nil
+	}
+
+	var list struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("parse /v1/models response: %w", err)
+	}
+	models := make([]string, 0, len(list.Data))
+	for _, m := range list.Data {
+		if m.ID != "" {
+			models = append(models, m.ID)
+		}
+	}
+	return models, nil
+}

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -1,0 +1,673 @@
+package poller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/krishna/local-ai-proxy/internal/metrics"
+	"github.com/krishna/local-ai-proxy/internal/registry"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// fakeSource is an in-memory NodeSource.
+type fakeSource struct {
+	mu    sync.Mutex
+	nodes []store.Node
+	err   error
+}
+
+func (f *fakeSource) ListNodesWithSecrets() ([]store.Node, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]store.Node, len(f.nodes))
+	copy(out, f.nodes)
+	return out, nil
+}
+
+func (f *fakeSource) set(nodes []store.Node, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nodes = nodes
+	f.err = err
+}
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+
+// enabledNode returns a minimal enabled store.Node for tests.
+func enabledNode(id int64, name, baseURL, backendType string) store.Node {
+	return store.Node{ID: id, Name: name, BaseURL: baseURL, BackendType: backendType, Enabled: true}
+}
+
+// newTestPoller builds a poller over a fake source with a fresh registry.
+func newTestPoller(t *testing.T, nodes []store.Node, opts Options) (*Poller, *registry.Registry, *fakeSource) {
+	t.Helper()
+	src := &fakeSource{nodes: nodes}
+	reg := registry.New()
+	p := New(src, reg, nil, opts)
+	return p, reg, src
+}
+
+func nodeState(t *testing.T, reg *registry.Registry, id int64) registry.NodeState {
+	t.Helper()
+	for _, ns := range reg.Snapshot().Nodes {
+		if ns.Node.ID == id {
+			return ns
+		}
+	}
+	t.Fatalf("node %d not in registry snapshot", id)
+	return registry.NodeState{}
+}
+
+// ---------------------------------------------------------------------------
+// Discovery parsing
+// ---------------------------------------------------------------------------
+
+func TestSweepOnce_OllamaDiscovery(t *testing.T) {
+	var gotPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"models":[{"name":"llama3:8b"},{"name":"qwen3:32b"}]}`))
+	}))
+	defer srv.Close()
+
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "mac", srv.URL, "ollama")}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if got := gotPath.Load(); got != "/api/tags" {
+		t.Errorf("probe path = %v, want /api/tags", got)
+	}
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+	if len(ns.Models) != 2 || ns.Models[0] != "llama3:8b" || ns.Models[1] != "qwen3:32b" {
+		t.Errorf("Models = %v, want [llama3:8b qwen3:32b]", ns.Models)
+	}
+	if ns.LastError != "" {
+		t.Errorf("LastError = %q, want empty", ns.LastError)
+	}
+	if ns.LastCheckedAt.IsZero() {
+		t.Error("LastCheckedAt is zero, want set")
+	}
+}
+
+func TestSweepOnce_OpenAICompatDiscovery(t *testing.T) {
+	var gotPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"object":"list","data":[{"id":"gpt-oss-20b"},{"id":"qwen3-coder"}]}`))
+	}))
+	defer srv.Close()
+
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "cloud", srv.URL, "openai_compat")}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if got := gotPath.Load(); got != "/v1/models" {
+		t.Errorf("probe path = %v, want /v1/models", got)
+	}
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+	if len(ns.Models) != 2 || ns.Models[0] != "gpt-oss-20b" || ns.Models[1] != "qwen3-coder" {
+		t.Errorf("Models = %v, want [gpt-oss-20b qwen3-coder]", ns.Models)
+	}
+}
+
+// Probe URLs must be built by path-joining onto base_url: a base_url carrying
+// a path prefix keeps that prefix.
+func TestProbe_PathJoinsBaseURLPrefix(t *testing.T) {
+	var gotPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath.Store(r.URL.Path)
+		w.Write([]byte(`{"data":[{"id":"m"}]}`))
+	}))
+	defer srv.Close()
+
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "prefixed", srv.URL+"/openai", "openai_compat")}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if got := gotPath.Load(); got != "/openai/v1/models" {
+		t.Errorf("probe path = %v, want /openai/v1/models", got)
+	}
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+}
+
+// A discovery probe that succeeds with zero models publishes a non-nil empty
+// list (probed, nothing served) — distinct from nil (never discovered).
+func TestSweepOnce_EmptyDiscoveryIsNonNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "empty", srv.URL, "ollama")}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+	if ns.Models == nil {
+		t.Error("Models is nil, want non-nil empty after successful probe")
+	}
+	if len(ns.Models) != 0 {
+		t.Errorf("Models = %v, want empty", ns.Models)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// static_models + health_path
+// ---------------------------------------------------------------------------
+
+func TestProbe_StaticModelsWithHealthPath(t *testing.T) {
+	var gotPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath.Store(r.URL.Path)
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write([]byte("OK not json at all")) // body must be ignored
+	}))
+	defer srv.Close()
+
+	n := enabledNode(1, "static", srv.URL, "openai_compat")
+	n.StaticModels = []string{"custom-a", "custom-b"}
+	n.HealthPath = strPtr("/healthz")
+
+	p, reg, _ := newTestPoller(t, []store.Node{n}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if got := gotPath.Load(); got != "/healthz" {
+		t.Errorf("probe path = %v, want /healthz", got)
+	}
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+	if len(ns.Models) != 2 || ns.Models[0] != "custom-a" || ns.Models[1] != "custom-b" {
+		t.Errorf("Models = %v, want static list", ns.Models)
+	}
+}
+
+// Without health_path, a static_models node probes its type's discovery
+// endpoint but only the status code matters — a non-JSON body is fine and the
+// static list stays authoritative.
+func TestProbe_StaticModelsWithoutHealthPathUsesDiscoveryEndpoint(t *testing.T) {
+	var gotPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath.Store(r.URL.Path)
+		w.Write([]byte("<html>definitely not json</html>"))
+	}))
+	defer srv.Close()
+
+	n := enabledNode(1, "static-ollama", srv.URL, "ollama")
+	n.StaticModels = []string{"pinned:latest"}
+
+	p, reg, _ := newTestPoller(t, []store.Node{n}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if got := gotPath.Load(); got != "/api/tags" {
+		t.Errorf("probe path = %v, want /api/tags", got)
+	}
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+	if len(ns.Models) != 1 || ns.Models[0] != "pinned:latest" {
+		t.Errorf("Models = %v, want [pinned:latest]", ns.Models)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Probe client hardening
+// ---------------------------------------------------------------------------
+
+func TestProbe_AuthHeaderSentWhenConfigured(t *testing.T) {
+	var gotAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+
+	n := enabledNode(1, "authed", srv.URL, "ollama")
+	n.AuthHeader = strPtr("Bearer super-secret")
+
+	p, _, _ := newTestPoller(t, []store.Node{n}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if got := gotAuth.Load(); got != "Bearer super-secret" {
+		t.Errorf("Authorization = %v, want %q", got, "Bearer super-secret")
+	}
+}
+
+func TestProbe_NoAuthHeaderWhenAbsent(t *testing.T) {
+	var gotAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+
+	p, _, _ := newTestPoller(t, []store.Node{enabledNode(1, "open", srv.URL, "ollama")}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if got := gotAuth.Load(); got != "" {
+		t.Errorf("Authorization = %v, want empty", got)
+	}
+}
+
+// Redirects must never be followed: with auth_header attached, following one
+// could exfiltrate backend credentials. The redirect target must never be
+// contacted and the probe must fail.
+func TestProbe_RedirectRefused(t *testing.T) {
+	var targetHits atomic.Int64
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHits.Add(1)
+		w.Write([]byte(`{"models":[{"name":"evil"}]}`))
+	}))
+	defer target.Close()
+
+	redirecter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/api/tags", http.StatusFound)
+	}))
+	defer redirecter.Close()
+
+	n := enabledNode(1, "redirecting", redirecter.URL, "ollama")
+	n.AuthHeader = strPtr("Bearer secret-that-must-not-leak")
+
+	p, reg, _ := newTestPoller(t, []store.Node{n}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if hits := targetHits.Load(); hits != 0 {
+		t.Errorf("redirect target was contacted %d times, want 0", hits)
+	}
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthUnhealthy {
+		t.Errorf("Health = %q, want unhealthy (redirect refused)", ns.Health)
+	}
+	if ns.LastError == "" {
+		t.Error("LastError is empty, want redirect refusal error")
+	}
+	if strings.Contains(ns.LastError, "secret-that-must-not-leak") {
+		t.Error("LastError leaks the auth header")
+	}
+}
+
+// A discovery response larger than the body cap cannot be trusted (it would
+// be truncated), so the probe fails.
+func TestProbe_DiscoveryBodyOverCapFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"models":[`))
+		filler := `{"name":"` + strings.Repeat("x", 1024) + `"},`
+		for i := 0; i < 1100; i++ { // ~1.1MB
+			w.Write([]byte(filler))
+		}
+		w.Write([]byte(`{"name":"last"}]}`))
+	}))
+	defer srv.Close()
+
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "huge", srv.URL, "ollama")}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthUnhealthy {
+		t.Errorf("Health = %q, want unhealthy (body over cap)", ns.Health)
+	}
+	if ns.LastError == "" {
+		t.Error("LastError is empty, want body-cap error")
+	}
+	if ns.Models != nil {
+		t.Errorf("Models = %v, want nil (never successfully discovered)", ns.Models)
+	}
+}
+
+// A health-only probe (static_models) ignores the body entirely, so an
+// oversized body does not fail it — the cap just bounds how much is read.
+func TestProbe_HealthProbeIgnoresOversizedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for i := 0; i < 2048; i++ {
+			w.Write([]byte(strings.Repeat("y", 1024))) // 2MB of ignored body
+		}
+	}))
+	defer srv.Close()
+
+	n := enabledNode(1, "chatty", srv.URL, "ollama")
+	n.StaticModels = []string{"m"}
+	n.HealthPath = strPtr("/healthz")
+
+	p, reg, _ := newTestPoller(t, []store.Node{n}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy (body ignored)", ns.Health)
+	}
+}
+
+func TestProbe_Non2xxIsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "sad", srv.URL, "ollama")}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthUnhealthy {
+		t.Errorf("Health = %q, want unhealthy", ns.Health)
+	}
+	if !strings.Contains(ns.LastError, "503") {
+		t.Errorf("LastError = %q, want it to mention status 503", ns.LastError)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Hysteresis state machine (running poller, not sweep)
+// ---------------------------------------------------------------------------
+
+// flakyBackend serves ollama discovery, failing with 500 while fail is true.
+type flakyBackend struct {
+	fail atomic.Bool
+	srv  *httptest.Server
+}
+
+func newFlakyBackend(t *testing.T) *flakyBackend {
+	t.Helper()
+	f := &flakyBackend{}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if f.fail.Load() {
+			http.Error(w, "down", http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(`{"models":[{"name":"llama3:8b"}]}`))
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+// pollOnce drives one running-poller probe cycle over the poller's loaded specs.
+func pollOnce(t *testing.T, p *Poller) {
+	t.Helper()
+	specs, err := p.load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	p.probeSpecs(context.Background(), specs, false)
+}
+
+func TestHysteresis_UnknownToUnhealthyNeedsTwoFailures(t *testing.T) {
+	f := newFlakyBackend(t)
+	f.fail.Store(true)
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "flaky", f.srv.URL, "ollama")}, Options{})
+
+	pollOnce(t, p)
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthUnknown {
+		t.Errorf("after 1 failure: Health = %q, want unknown (hysteresis)", ns.Health)
+	}
+	if ns.LastError == "" {
+		t.Error("after 1 failure: LastError empty, want set")
+	}
+
+	pollOnce(t, p)
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthUnhealthy {
+		t.Errorf("after 2 failures: Health = %q, want unhealthy", ns.Health)
+	}
+}
+
+func TestHysteresis_UnknownToHealthyOnFirstSuccess(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "flaky", f.srv.URL, "ollama")}, Options{})
+
+	pollOnce(t, p)
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy on first success", ns.Health)
+	}
+	if len(ns.Models) != 1 || ns.Models[0] != "llama3:8b" {
+		t.Errorf("Models = %v, want [llama3:8b]", ns.Models)
+	}
+}
+
+func TestHysteresis_HealthyToUnhealthyNeedsTwoConsecutiveFailures(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "flaky", f.srv.URL, "ollama")}, Options{})
+
+	pollOnce(t, p) // healthy
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Fatalf("setup: Health = %q, want healthy", ns.Health)
+	}
+
+	f.fail.Store(true)
+	pollOnce(t, p) // failure 1 of 2: still healthy
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("after 1 failure: Health = %q, want still healthy", ns.Health)
+	}
+	if ns.LastError == "" {
+		t.Error("after 1 failure: LastError empty, want set even while still healthy")
+	}
+	// Last-known models are retained through the failure.
+	if len(ns.Models) != 1 || ns.Models[0] != "llama3:8b" {
+		t.Errorf("after 1 failure: Models = %v, want last-known [llama3:8b]", ns.Models)
+	}
+
+	pollOnce(t, p) // failure 2 of 2: unhealthy
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthUnhealthy {
+		t.Errorf("after 2 failures: Health = %q, want unhealthy", ns.Health)
+	}
+}
+
+// A success between two failures resets the failure counter: the failures are
+// no longer consecutive.
+func TestHysteresis_SuccessResetsFailureCount(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "flaky", f.srv.URL, "ollama")}, Options{})
+
+	pollOnce(t, p) // healthy
+	f.fail.Store(true)
+	pollOnce(t, p) // failure 1: still healthy
+	f.fail.Store(false)
+	pollOnce(t, p) // success: counter resets
+	f.fail.Store(true)
+	pollOnce(t, p) // failure 1 again: must still be healthy
+
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy (failures were not consecutive)", ns.Health)
+	}
+}
+
+func TestHysteresis_UnhealthyToHealthyOnFirstSuccess(t *testing.T) {
+	f := newFlakyBackend(t)
+	f.fail.Store(true)
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "flaky", f.srv.URL, "ollama")}, Options{})
+
+	pollOnce(t, p)
+	pollOnce(t, p) // unhealthy
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthUnhealthy {
+		t.Fatalf("setup: Health = %q, want unhealthy", ns.Health)
+	}
+
+	f.fail.Store(false)
+	pollOnce(t, p)
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy on first success", ns.Health)
+	}
+	if ns.LastError != "" {
+		t.Errorf("LastError = %q, want cleared on success", ns.LastError)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Startup sweep
+// ---------------------------------------------------------------------------
+
+// The sweep marks a node unhealthy on a SINGLE failure (per the design doc);
+// the two-failure hysteresis only applies to the running poller.
+func TestSweepOnce_SingleFailureMarksUnhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "down", srv.URL, "ollama")}, Options{})
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthUnhealthy {
+		t.Errorf("Health = %q, want unhealthy after single sweep failure", ns.Health)
+	}
+}
+
+// The sweep probes in parallel and is bounded by the sweep budget even when a
+// node hangs forever: the responsive node comes up healthy, the hung one is
+// published unhealthy, and the sweep returns well before the per-probe 5s
+// default.
+func TestSweepOnce_BudgetBoundedWithHungNode(t *testing.T) {
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"models":[{"name":"m1"}]}`))
+	}))
+	defer healthy.Close()
+
+	hung := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // never respond; unblocks when the client gives up
+	}))
+	defer hung.Close()
+
+	p, reg, _ := newTestPoller(t, []store.Node{
+		enabledNode(1, "fast", healthy.URL, "ollama"),
+		enabledNode(2, "hung", hung.URL, "ollama"),
+	}, Options{SweepBudget: 500 * time.Millisecond}) // per-probe stays at the 5s default
+
+	start := time.Now()
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 3*time.Second {
+		t.Errorf("SweepOnce took %v, want bounded by the ~500ms sweep budget", elapsed)
+	}
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Errorf("fast node Health = %q, want healthy", ns.Health)
+	}
+	ns := nodeState(t, reg, 2)
+	if ns.Health != registry.HealthUnhealthy {
+		t.Errorf("hung node Health = %q, want unhealthy", ns.Health)
+	}
+	if ns.LastError == "" {
+		t.Error("hung node LastError empty, want deadline error")
+	}
+}
+
+func TestSweepOnce_SourceErrorReturned(t *testing.T) {
+	p, _, src := newTestPoller(t, nil, Options{})
+	src.set(nil, context.DeadlineExceeded)
+
+	if err := p.SweepOnce(context.Background()); err == nil {
+		t.Fatal("SweepOnce = nil error, want the source error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+func TestMetrics_NodeUpAndOllamaUpOr(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"models":[{"name":"m"}]}`))
+	}))
+	defer up.Close()
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	defer down.Close()
+
+	src := &fakeSource{nodes: []store.Node{
+		enabledNode(1, "alive", up.URL, "ollama"),
+		enabledNode(2, "dead", down.URL, "ollama"),
+	}}
+	reg := registry.New()
+	m := metrics.New(func() int { return 0 })
+	p := New(src, reg, m, Options{})
+
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+
+	if got := testutil.ToFloat64(m.NodeUp.WithLabelValues("alive")); got != 1 {
+		t.Errorf("aiproxy_node_up{node=alive} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.NodeUp.WithLabelValues("dead")); got != 0 {
+		t.Errorf("aiproxy_node_up{node=dead} = %v, want 0", got)
+	}
+	// OR of node states: one healthy node keeps the legacy gauge at 1.
+	if got := testutil.ToFloat64(m.OllamaUp); got != 1 {
+		t.Errorf("aiproxy_ollama_up = %v, want 1 (OR of node states)", got)
+	}
+
+	// Drop the healthy node; only the dead one remains -> OR falls to 0 and
+	// the removed node's gauge series is deleted.
+	src.set([]store.Node{enabledNode(2, "dead", down.URL, "ollama")}, nil)
+	specs, err := p.load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	p.probeSpecs(context.Background(), specs, false)
+
+	if got := testutil.ToFloat64(m.OllamaUp); got != 0 {
+		t.Errorf("aiproxy_ollama_up = %v, want 0 after healthy node removed", got)
+	}
+	if n := testutil.CollectAndCount(m.NodeUp); n != 1 {
+		t.Errorf("aiproxy_node_up series count = %d, want 1 (removed node deleted)", n)
+	}
+}

--- a/internal/poller/schedule_test.go
+++ b/internal/poller/schedule_test.go
@@ -1,0 +1,165 @@
+package poller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/registry"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+func TestIntervalFor_JitterBounds(t *testing.T) {
+	p, _, _ := newTestPoller(t, nil, Options{}) // defaults: 15s ±20%
+
+	lo := time.Duration(float64(defaultInterval) * (1 - defaultJitterFrac))
+	hi := time.Duration(float64(defaultInterval) * (1 + defaultJitterFrac))
+
+	seen := make(map[time.Duration]bool)
+	for id := int64(1); id <= 1000; id++ {
+		iv := p.intervalFor(id)
+		if iv < lo || iv > hi {
+			t.Fatalf("intervalFor(%d) = %v, want within [%v, %v]", id, iv, lo, hi)
+		}
+		seen[iv] = true
+	}
+
+	// Jitter must actually spread nodes out, not collapse to one value.
+	if len(seen) < 10 {
+		t.Errorf("only %d distinct intervals across 1000 node IDs, want a real spread", len(seen))
+	}
+}
+
+func TestIntervalFor_DeterministicPerNode(t *testing.T) {
+	p, _, _ := newTestPoller(t, nil, Options{})
+	for id := int64(1); id <= 50; id++ {
+		if a, b := p.intervalFor(id), p.intervalFor(id); a != b {
+			t.Fatalf("intervalFor(%d) not deterministic: %v vs %v", id, a, b)
+		}
+	}
+}
+
+func TestRun_ReturnsOnContextCancel(t *testing.T) {
+	p, _, _ := newTestPoller(t, nil, Options{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		p.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+// Run's first cycle probes never-before-seen nodes immediately (no initial
+// interval wait), so a poller started without a prior sweep still converges.
+func TestRun_FirstCycleProbesImmediately(t *testing.T) {
+	probed := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case probed <- struct{}{}:
+		default:
+		}
+		w.Write([]byte(`{"models":[{"name":"m"}]}`))
+	}))
+	defer srv.Close()
+
+	// A huge interval proves the probe came from the immediate first cycle.
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "n1", srv.URL, "ollama")},
+		Options{Interval: time.Hour})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-probed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("node was not probed by the first Run cycle")
+	}
+
+	// Wait for the probe result to land in the registry before cancelling —
+	// cancelling ctx would abort the in-flight probe.
+	waitFor(t, 5*time.Second, func() bool {
+		for _, ns := range reg.Snapshot().Nodes {
+			if ns.Node.ID == 1 && ns.Health == registry.HealthHealthy {
+				return true
+			}
+		}
+		return false
+	})
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// waitFor polls cond until it holds or the deadline passes.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.After(timeout)
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if cond() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("condition not met before deadline")
+		case <-tick.C:
+		}
+	}
+}
+
+// A node already probed by the startup sweep is NOT due again on Run's first
+// cycle — its next probe is a full jittered interval after the sweep.
+func TestRun_DoesNotReprobeFreshlySweptNode(t *testing.T) {
+	hits := make(chan struct{}, 16)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits <- struct{}{}
+		w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+
+	p, _, _ := newTestPoller(t, []store.Node{enabledNode(1, "n1", srv.URL, "ollama")},
+		Options{Interval: time.Hour})
+
+	if err := p.SweepOnce(context.Background()); err != nil {
+		t.Fatalf("SweepOnce: %v", err)
+	}
+	<-hits // the sweep's probe
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.Run(ctx)
+		close(done)
+	}()
+
+	// Give Run a moment to complete its first cycle, then assert it did not
+	// probe the freshly swept node (its interval is an hour).
+	select {
+	case <-hits:
+		t.Error("Run re-probed a node the sweep had just probed")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	cancel()
+	<-done
+}

--- a/internal/registry/probe_state_test.go
+++ b/internal/registry/probe_state_test.go
@@ -1,0 +1,165 @@
+package registry
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return u
+}
+
+func findNode(t *testing.T, snap RegistrySnapshot, id int64) NodeState {
+	t.Helper()
+	for _, ns := range snap.Nodes {
+		if ns.Node.ID == id {
+			return ns
+		}
+	}
+	t.Fatalf("node %d not in snapshot", id)
+	return NodeState{}
+}
+
+func TestSetNodeProbe_PublishesProbeMetadata(t *testing.T) {
+	r := New()
+	r.SetNodes([]Node{{ID: 1, Name: "a", BaseURL: mustParse(t, "http://a:11434")}})
+
+	checked := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	r.SetNodeProbe(1, ProbeResult{
+		Health:        HealthUnhealthy,
+		Models:        nil,
+		LastError:     "connection refused",
+		LastCheckedAt: checked,
+	})
+
+	ns := findNode(t, r.Snapshot(), 1)
+	if ns.Health != HealthUnhealthy {
+		t.Errorf("Health = %q, want unhealthy", ns.Health)
+	}
+	if ns.LastError != "connection refused" {
+		t.Errorf("LastError = %q, want %q", ns.LastError, "connection refused")
+	}
+	if !ns.LastCheckedAt.Equal(checked) {
+		t.Errorf("LastCheckedAt = %v, want %v", ns.LastCheckedAt, checked)
+	}
+	if ns.Models != nil {
+		t.Errorf("Models = %v, want nil", ns.Models)
+	}
+}
+
+func TestSetNodeProbe_SuccessClearsLastError(t *testing.T) {
+	r := New()
+	r.SetNodes([]Node{{ID: 1, Name: "a", BaseURL: mustParse(t, "http://a:11434")}})
+
+	r.SetNodeProbe(1, ProbeResult{Health: HealthUnhealthy, LastError: "boom", LastCheckedAt: time.Now()})
+	checked := time.Now().Add(time.Minute)
+	r.SetNodeProbe(1, ProbeResult{Health: HealthHealthy, Models: []string{"m1"}, LastCheckedAt: checked})
+
+	ns := findNode(t, r.Snapshot(), 1)
+	if ns.LastError != "" {
+		t.Errorf("LastError = %q, want empty after success", ns.LastError)
+	}
+	if ns.Health != HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+	if len(ns.Models) != 1 || ns.Models[0] != "m1" {
+		t.Errorf("Models = %v, want [m1]", ns.Models)
+	}
+}
+
+func TestSetNodeProbe_UnknownIDIsNoOp(t *testing.T) {
+	r := New()
+	r.SetNodes([]Node{{ID: 1, Name: "a", BaseURL: mustParse(t, "http://a:11434")}})
+
+	r.SetNodeProbe(99, ProbeResult{Health: HealthHealthy, Models: []string{"m"}, LastCheckedAt: time.Now()})
+
+	snap := r.Snapshot()
+	if len(snap.Nodes) != 1 {
+		t.Fatalf("len(Nodes) = %d, want 1", len(snap.Nodes))
+	}
+	if len(snap.Models) != 0 {
+		t.Errorf("Models map = %v, want empty", snap.Models)
+	}
+}
+
+func TestSetNodeProbe_PreservesEmptyVsNilModels(t *testing.T) {
+	r := New()
+	r.SetNodes([]Node{{ID: 1, Name: "a", BaseURL: mustParse(t, "http://a:11434")}})
+
+	r.SetNodeProbe(1, ProbeResult{Health: HealthHealthy, Models: []string{}, LastCheckedAt: time.Now()})
+
+	ns := findNode(t, r.Snapshot(), 1)
+	if ns.Models == nil {
+		t.Error("Models is nil, want non-nil empty (probed with zero models)")
+	}
+	if len(ns.Models) != 0 {
+		t.Errorf("Models = %v, want empty", ns.Models)
+	}
+}
+
+func TestSetNodes_CarriesOverProbeMetadata(t *testing.T) {
+	r := New()
+	r.SetNodes([]Node{{ID: 1, Name: "a", BaseURL: mustParse(t, "http://a:11434")}})
+
+	checked := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	r.SetNodeProbe(1, ProbeResult{Health: HealthUnhealthy, LastError: "timeout", LastCheckedAt: checked})
+
+	// Same ID, same BaseURL: runtime state including probe metadata carries over.
+	r.SetNodes([]Node{{ID: 1, Name: "a-renamed", BaseURL: mustParse(t, "http://a:11434")}})
+	ns := findNode(t, r.Snapshot(), 1)
+	if ns.LastError != "timeout" || !ns.LastCheckedAt.Equal(checked) {
+		t.Errorf("probe metadata not carried over: LastError=%q LastCheckedAt=%v", ns.LastError, ns.LastCheckedAt)
+	}
+	if ns.Health != HealthUnhealthy {
+		t.Errorf("Health = %q, want unhealthy carried over", ns.Health)
+	}
+
+	// Changed BaseURL: everything resets, including probe metadata.
+	r.SetNodes([]Node{{ID: 1, Name: "a", BaseURL: mustParse(t, "http://other:11434")}})
+	ns = findNode(t, r.Snapshot(), 1)
+	if ns.Health != HealthUnknown {
+		t.Errorf("Health = %q, want unknown after BaseURL change", ns.Health)
+	}
+	if ns.LastError != "" || !ns.LastCheckedAt.IsZero() {
+		t.Errorf("probe metadata not reset: LastError=%q LastCheckedAt=%v", ns.LastError, ns.LastCheckedAt)
+	}
+}
+
+func TestSetNodeState_LeavesProbeMetadataUntouched(t *testing.T) {
+	r := New()
+	r.SetNodes([]Node{{ID: 1, Name: "a", BaseURL: mustParse(t, "http://a:11434")}})
+
+	checked := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	r.SetNodeProbe(1, ProbeResult{Health: HealthUnhealthy, LastError: "boom", LastCheckedAt: checked})
+
+	r.SetNodeState(1, HealthHealthy, []string{"m"})
+
+	ns := findNode(t, r.Snapshot(), 1)
+	if ns.Health != HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+	if ns.LastError != "boom" || !ns.LastCheckedAt.Equal(checked) {
+		t.Errorf("SetNodeState must not touch probe metadata: LastError=%q LastCheckedAt=%v", ns.LastError, ns.LastCheckedAt)
+	}
+}
+
+func TestSetNodeProbe_RoutableAfterHealthyProbe(t *testing.T) {
+	r := New()
+	r.SetNodes([]Node{{ID: 1, Name: "a", BaseURL: mustParse(t, "http://a:11434")}})
+
+	r.SetNodeProbe(1, ProbeResult{Health: HealthHealthy, Models: []string{"llama3:8b"}, LastCheckedAt: time.Now()})
+
+	n, err := r.Resolve("llama3:8b")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if n.ID != 1 {
+		t.Errorf("Resolve returned node %d, want 1", n.ID)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -64,10 +64,25 @@ func (n Node) clone() Node {
 }
 
 // NodeState is a node plus its runtime state, as exposed by Snapshot.
+// LastError and LastCheckedAt are probe metadata published by the health
+// poller via SetNodeProbe, surfaced for admin/display consumers (BE-7).
 type NodeState struct {
 	Node   Node
 	Health Health
 	Models []string // last reported model list; nil = not yet discovered
+
+	LastError     string    // most recent probe error; "" after a successful probe or before any probe
+	LastCheckedAt time.Time // when the node was last probed; zero = never probed
+}
+
+// ProbeResult is a health-poller probe outcome published via SetNodeProbe.
+// Models carries the node's current model list (nil = unknown, non-nil empty
+// = probed with zero models); LastError is empty for successful probes.
+type ProbeResult struct {
+	Health        Health
+	Models        []string
+	LastError     string
+	LastCheckedAt time.Time
 }
 
 // RegistrySnapshot is a self-consistent view of the registry: every node the
@@ -90,9 +105,11 @@ type snapshot struct {
 // entry is the writer-side authoritative state for one node, guarded by
 // Registry.mu.
 type entry struct {
-	node   Node
-	health Health
-	models []string
+	node          Node
+	health        Health
+	models        []string
+	lastError     string
+	lastCheckedAt time.Time
 }
 
 // Registry routes models to healthy backend nodes.
@@ -135,6 +152,8 @@ func (r *Registry) SetNodes(nodes []Node) {
 		if prev, ok := r.entries[n.ID]; ok && sameURL(prev.node.BaseURL, n.BaseURL) {
 			e.health = prev.health
 			e.models = prev.models
+			e.lastError = prev.lastError
+			e.lastCheckedAt = prev.lastCheckedAt
 		}
 		next[n.ID] = e
 	}
@@ -142,11 +161,13 @@ func (r *Registry) SetNodes(nodes []Node) {
 	r.publishLocked()
 }
 
-// SetNodeState records a probe result for one node and publishes a new
-// snapshot. models is the node's discovered (or static) model list; nil
+// SetNodeState records a health/model update for one node and publishes a
+// new snapshot. models is the node's discovered (or static) model list; nil
 // means the list is unknown, which keeps the node non-routable even when
-// healthy. State reported for a node ID the registry does not know is
-// ignored (the poller may race a node removal).
+// healthy. Probe metadata (LastError, LastCheckedAt) is left untouched — the
+// health poller publishes full probe outcomes via SetNodeProbe instead.
+// State reported for a node ID the registry does not know is ignored (the
+// poller may race a node removal).
 func (r *Registry) SetNodeState(nodeID int64, health Health, models []string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -157,6 +178,25 @@ func (r *Registry) SetNodeState(nodeID int64, health Health, models []string) {
 	}
 	e.health = health
 	e.models = cloneModels(models)
+	r.publishLocked()
+}
+
+// SetNodeProbe records a full health-poller probe outcome for one node —
+// health, model list, and probe metadata (LastError, LastCheckedAt) — and
+// publishes a new snapshot. Results reported for a node ID the registry does
+// not know are ignored (the poller may race a node removal).
+func (r *Registry) SetNodeProbe(nodeID int64, res ProbeResult) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e, ok := r.entries[nodeID]
+	if !ok {
+		return
+	}
+	e.health = res.Health
+	e.models = cloneModels(res.Models)
+	e.lastError = res.LastError
+	e.lastCheckedAt = res.LastCheckedAt
 	r.publishLocked()
 }
 
@@ -197,9 +237,11 @@ func (r *Registry) Snapshot() RegistrySnapshot {
 	}
 	for i, ns := range s.nodes {
 		out.Nodes[i] = NodeState{
-			Node:   ns.Node.clone(),
-			Health: ns.Health,
-			Models: cloneModels(ns.Models),
+			Node:          ns.Node.clone(),
+			Health:        ns.Health,
+			Models:        cloneModels(ns.Models),
+			LastError:     ns.LastError,
+			LastCheckedAt: ns.LastCheckedAt,
 		}
 	}
 	for model, candidates := range s.models {
@@ -219,7 +261,13 @@ func (r *Registry) publishLocked() {
 	nodes := make([]NodeState, 0, len(r.entries))
 	models := make(map[string][]Node)
 	for _, e := range r.entries {
-		nodes = append(nodes, NodeState{Node: e.node, Health: e.health, Models: e.models})
+		nodes = append(nodes, NodeState{
+			Node:          e.node,
+			Health:        e.health,
+			Models:        e.models,
+			LastError:     e.lastError,
+			LastCheckedAt: e.lastCheckedAt,
+		})
 		if e.health != HealthHealthy || e.models == nil {
 			continue
 		}


### PR DESCRIPTION
Implements **Distributed Nodes BE-4** — the "Discovery and health checking" section of `docs/design/distributed-nodes.md`: DB → registry loading, per-node probing, and the synchronous startup sweep. No `main.go` wiring (that's BE-6); the package exposes a clean API.

## What's here

### New package `internal/poller`
- **API**: `New(src NodeSource, reg *registry.Registry, m *metrics.Metrics, opts Options) *Poller`, `SweepOnce(ctx) error` (synchronous startup sweep), `Run(ctx)` (poll loop, returns on ctx cancel like `credits.StartSweeper`). `NodeSource` is the `ListNodesWithSecrets` subset of `*store.Store`.
- **Loader**: enabled nodes only; raw `auth_header` (needed on probes); `timeout_seconds` → `time.Duration`; re-reads the DB on every poll cycle so BE-7 admin changes apply without a restart. A failed reload logs and keeps probing the last-loaded set.
- **Probing**: `ollama` → `GET {base_url}/api/tags` (tag names); `openai_compat` → `GET {base_url}/v1/models` (`data[].id`). `static_models` nodes probe `health_path` if set, else the type's discovery endpoint — 2xx = alive, body ignored, static list authoritative. Probe URLs are **path-joined** onto `base_url` (prefixes like `/openai` preserved).
- **Client hardening**: redirects never followed (`CheckRedirect` returns an error — with `auth_header` attached a redirect could exfiltrate credentials; explicit test included), 5s per-probe timeout, bodies read through a 1MB `io.LimitReader` cap, per-node `auth_header` sent as `Authorization`.
- **State machine (hysteresis)**: healthy/unknown → unhealthy only after **2 consecutive failures**; any success → healthy immediately. Transitions logged via `slog`; every probe republishes the registry snapshot; last-known model lists retained through failures (nil-vs-empty preserved).
- **Startup sweep**: all enabled nodes in parallel, per-probe 5s, overall ~6s budget; sweep non-responders are unhealthy after a **single** failure per the design doc (hysteresis governs only the running loop).
- **Scheduling**: 15s base interval with deterministic ±20% per-node jitter derived from the node ID (no live RNG → deterministic tests, steady per-node cadence, spread probes).

### `internal/registry` (additive)
`NodeState` gains `LastError`/`LastCheckedAt`; the poller publishes via new `SetNodeProbe(nodeID, ProbeResult)`. `SetNodeState` keeps its old shape and leaves probe metadata untouched. **BE-7**: read both fields straight from `Registry.Snapshot()`.

### `internal/metrics`
New `aiproxy_node_up{node}` gauge with `SetNodeUp`/`DeleteNodeUp` (stale series removed on node removal/rename), plus `SetOllamaUp`. **BE-6**: the poller keeps `aiproxy_ollama_up` equal to the OR of all node states on every probe/reload — while the poller runs, do **not** also wire `health.Checker.SetOllamaGauge` (two writers would fight).

## Testing
TDD with httptest fake backends: discovery parsing (both types), static_models/health_path, all hysteresis transitions, jitter bounds + determinism, redirect refusal (302 → probe fails, target never contacted), 1MB body cap (discovery fails; health-only probes ignore oversized bodies), auth header presence/absence, sweep budget bounded with a hung node, loader mapping (fake source + a Postgres integration test following the store suite's `DATABASE_URL` skip pattern).

- `go test -race -count=1 -p 1 ./...` — 727 passed, whole module, with `DATABASE_URL` set
- `gofmt` and `go vet ./...` clean
- Verified end-to-end with a demo harness (not committed): real Postgres rows → sweep → kill/restart a live backend → hysteresis transitions, recovery, redirect refusal, DB-disable picked up mid-run, metrics series cleanup, clean `Run` shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSYCn4mZxomD5Aauu5hJPr