### PR TITLE
feat(admin): node management endpoints

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -234,6 +234,7 @@ func main() {
 		BuildTime:                        buildTime,
 		GoVersion:                        runtime.Version(),
 		ModelsListAll:                    cfg.ModelsListAll,
+		NodesFile:                        cfg.NodesFile,
 	}
 
 	adminHandler := admin.NewHandler(db, cfg.AdminKey, usageCh, admin.Options{
@@ -241,6 +242,8 @@ func main() {
 		Checker:   hc,
 		StartTime: startTime,
 		Metrics:   m,
+		Registry:  reg,
+		Refresher: nodePoller,
 	})
 	bootstrapHandler := bootstrap.New(db, cfg.AdminBootstrapToken, m)
 	userHandler := user.NewHandler(db, cfg.DefaultCreditGrant, m, authGuard)

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -20,6 +20,7 @@ import (
 	"github.com/krishna/local-ai-proxy/internal/metrics"
 	"github.com/krishna/local-ai-proxy/internal/proxy"
 	"github.com/krishna/local-ai-proxy/internal/ratelimit"
+	"github.com/krishna/local-ai-proxy/internal/registry"
 	"github.com/krishna/local-ai-proxy/internal/store"
 )
 
@@ -50,6 +51,27 @@ type handler struct {
 
 	// BE 6: optional metrics sink. Nil-safe via m.Record* methods.
 	metrics *metrics.Metrics
+
+	// BE 7: node routing dependencies for /api/admin/nodes. Both are nil-safe:
+	// without a registry, live state reads as unknown; without a refresher,
+	// node mutations skip the synchronous probe.
+	nodeRegistry  NodeSnapshotter
+	nodeRefresher NodeRefresher
+}
+
+// NodeSnapshotter exposes the node registry's current routing state.
+// Satisfied by *registry.Registry.
+type NodeSnapshotter interface {
+	Snapshot() registry.RegistrySnapshot
+}
+
+// NodeRefresher synchronously reloads and re-probes one node, publishing the
+// outcome to the registry before returning. Satisfied by *poller.Poller
+// (RefreshNode). The admin handler calls it after every node mutation so the
+// change is live — probed and routable (or removed from routing) — before the
+// HTTP response returns.
+type NodeRefresher interface {
+	RefreshNode(ctx context.Context, nodeID int64) error
 }
 
 // Options carries optional dependencies wired by main. Tests that don't touch
@@ -59,6 +81,10 @@ type Options struct {
 	Checker   *health.Checker
 	StartTime time.Time
 	Metrics   *metrics.Metrics
+
+	// BE 7: node routing registry + poller for /api/admin/nodes.
+	Registry  NodeSnapshotter
+	Refresher NodeRefresher
 }
 
 type adminSessionCtxKey struct{}
@@ -104,6 +130,8 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 		healthChecker:     opts.Checker,
 		startTime:         opts.StartTime,
 		metrics:           opts.Metrics,
+		nodeRegistry:      opts.Registry,
+		nodeRefresher:     opts.Refresher,
 	}
 
 	mux := http.NewServeMux()
@@ -149,6 +177,14 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 	// Config + health (BE 5)
 	mux.HandleFunc("GET /api/admin/config", handler.getConfig)
 	mux.HandleFunc("GET /api/admin/health", handler.getHealth)
+
+	// Backend node management (BE 7)
+	mux.HandleFunc("POST /api/admin/nodes", handler.createNode)
+	mux.HandleFunc("GET /api/admin/nodes", handler.listNodes)
+	mux.HandleFunc("GET /api/admin/nodes/{id}", handler.getNode)
+	mux.HandleFunc("PUT /api/admin/nodes/{id}", handler.updateNode)
+	mux.HandleFunc("DELETE /api/admin/nodes/{id}", handler.deleteNode)
+	mux.HandleFunc("POST /api/admin/nodes/{id}/refresh", handler.refreshNode)
 
 	return handler.authMiddleware(mux)
 }
@@ -389,6 +425,7 @@ func (h *handler) getUsage(w http.ResponseWriter, r *http.Request) {
 
 	var keyID *int64
 	var since *time.Time
+	var nodeID *int64
 
 	if v := r.URL.Query().Get("key_id"); v != "" {
 		id, err := strconv.ParseInt(v, 10, 64)
@@ -397,6 +434,15 @@ func (h *handler) getUsage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		keyID = &id
+	}
+
+	if v := r.URL.Query().Get("node_id"); v != "" {
+		id, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			proxy.WriteError(w, r, http.StatusBadRequest, "invalid_node_id", "invalid_request_error", "Invalid node_id parameter")
+			return
+		}
+		nodeID = &id
 	}
 
 	if v := r.URL.Query().Get("since"); v != "" {
@@ -412,7 +458,7 @@ func (h *handler) getUsage(w http.ResponseWriter, r *http.Request) {
 		since = &t
 	}
 
-	stats, err := h.store.GetUsageStats(keyID, since)
+	stats, err := h.store.GetUsageStats(keyID, since, nodeID)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "usage stats error", "error", err)
 		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to get usage stats")

--- a/internal/admin/config_health.go
+++ b/internal/admin/config_health.go
@@ -37,6 +37,9 @@ type ConfigSnapshot struct {
 	BuildTime                        string  `json:"build_time"`
 	GoVersion                        string  `json:"go_version"`
 	ModelsListAll                    bool    `json:"models_list_all"`
+	// NodesFile reports the NODES_FILE path; empty when unset. Also used by
+	// the nodes API's config-sourced 409 message to point at the file.
+	NodesFile string `json:"nodes_file"`
 }
 
 func (h *handler) getConfig(w http.ResponseWriter, r *http.Request) {
@@ -68,12 +71,48 @@ func (h *handler) getHealth(w http.ResponseWriter, r *http.Request) {
 		uptime = int64(time.Since(h.startTime).Seconds())
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(httpStatus)
-	_ = json.NewEncoder(w).Encode(map[string]any{
+	resp := map[string]any{
 		"status":         status,
 		"checks":         checks,
 		"uptime_seconds": uptime,
 		"version":        h.configSnapshot.Version,
-	})
+	}
+
+	// BE 7: per-node breakdown from the registry snapshot, additive to the
+	// existing shape. Zero enabled nodes is not degraded (a fresh install
+	// must serve the admin API to register its first node) but is flagged.
+	if h.nodeRegistry != nil {
+		snap := h.nodeRegistry.Snapshot()
+		nodes := make([]nodeHealthDTO, 0, len(snap.Nodes))
+		for _, ns := range snap.Nodes {
+			n := nodeHealthDTO{
+				Name:       ns.Node.Name,
+				Health:     string(ns.Health),
+				LastError:  ns.LastError,
+				ModelCount: len(ns.Models),
+			}
+			if !ns.LastCheckedAt.IsZero() {
+				s := ns.LastCheckedAt.Format(time.RFC3339)
+				n.LastCheckedAt = &s
+			}
+			nodes = append(nodes, n)
+		}
+		resp["nodes"] = nodes
+		if len(nodes) == 0 {
+			resp["warning"] = "no nodes configured"
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// nodeHealthDTO is one node's row in the /api/admin/health breakdown.
+type nodeHealthDTO struct {
+	Name          string  `json:"name"`
+	Health        string  `json:"health"`
+	LastError     string  `json:"last_error,omitempty"`
+	LastCheckedAt *string `json:"last_checked_at"`
+	ModelCount    int     `json:"model_count"`
 }

--- a/internal/admin/nodes.go
+++ b/internal/admin/nodes.go
@@ -1,0 +1,446 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/apierror"
+	"github.com/krishna/local-ai-proxy/internal/proxy"
+	"github.com/krishna/local-ai-proxy/internal/registry"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// BE 7: backend node management. Every response goes through nodeDTO built
+// from the store's MASKED reads (GetNode/ListNodes) — the raw auth_header can
+// never reach the wire — joined with live state from the registry snapshot.
+// Mutations call the poller's RefreshNode synchronously, so a node is probed
+// and routable (or removed from routing) before the HTTP response returns.
+
+// nodeDTO is the wire shape of a node on all /api/admin/nodes responses:
+// masked store config plus live registry state. FE-1 renders this directly.
+type nodeDTO struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	BaseURL     string `json:"base_url"`
+	BackendType string `json:"backend_type"`
+	// AuthHeader is MASKED (e.g. "Bearer sk-…abcd"); null = no auth header.
+	AuthHeader *string `json:"auth_header"`
+	// StaticModels null = model list is discovered by probing.
+	StaticModels   []string `json:"static_models"`
+	HealthPath     *string  `json:"health_path"`
+	TimeoutSeconds *int     `json:"timeout_seconds"`
+	Enabled        bool     `json:"enabled"`
+	Source         string   `json:"source"`
+	CreatedAt      string   `json:"created_at"`
+	UpdatedAt      string   `json:"updated_at"`
+
+	// Live state from the registry snapshot. Nodes the registry doesn't know
+	// (disabled, or created before any probe) read health "unknown" with an
+	// empty model list.
+	Health        string   `json:"health"`
+	Models        []string `json:"models"`
+	LastError     string   `json:"last_error,omitempty"`
+	LastCheckedAt *string  `json:"last_checked_at"`
+}
+
+// createNodeRequest is the POST /api/admin/nodes body (design doc, Admin API).
+type createNodeRequest struct {
+	Name           string   `json:"name"`
+	BaseURL        string   `json:"base_url"`
+	BackendType    string   `json:"backend_type"`
+	AuthHeader     *string  `json:"auth_header"`
+	StaticModels   []string `json:"static_models"`
+	HealthPath     *string  `json:"health_path"`
+	TimeoutSeconds *int     `json:"timeout_seconds"`
+}
+
+// updateNodeRequest is the PUT /api/admin/nodes/{id} body. Every field is
+// optional; omitted fields keep their current value (PATCH-like semantics,
+// chosen because UpdateNode is a full-row write and a masked read must never
+// round-trip into it):
+//
+//   - auth_header: absent (or JSON null) = keep, "" = clear, value = replace.
+//   - health_path: absent = keep, "" = clear, value = replace.
+//   - static_models: absent (or null) = keep, [] = clear (switch the node
+//     back to probe discovery), non-empty = replace.
+//   - timeout_seconds: absent = keep, 0 = clear (use the default timeout),
+//     positive = replace.
+//   - enabled: absent = keep; true re-enables a previously deleted node.
+type updateNodeRequest struct {
+	Name           *string   `json:"name"`
+	BaseURL        *string   `json:"base_url"`
+	BackendType    *string   `json:"backend_type"`
+	AuthHeader     *string   `json:"auth_header"`
+	StaticModels   *[]string `json:"static_models"`
+	HealthPath     *string   `json:"health_path"`
+	TimeoutSeconds *int      `json:"timeout_seconds"`
+	Enabled        *bool     `json:"enabled"`
+}
+
+// nodeLiveStates indexes the registry snapshot by node ID. A nil registry
+// (zero Options) behaves as an empty snapshot.
+func (h *handler) nodeLiveStates() map[int64]registry.NodeState {
+	if h.nodeRegistry == nil {
+		return nil
+	}
+	snap := h.nodeRegistry.Snapshot()
+	states := make(map[int64]registry.NodeState, len(snap.Nodes))
+	for _, ns := range snap.Nodes {
+		states[ns.Node.ID] = ns
+	}
+	return states
+}
+
+// toNodeDTO joins a MASKED store node with its live registry state. Callers
+// must never pass a node loaded via GetNodeWithSecrets.
+func toNodeDTO(n *store.Node, states map[int64]registry.NodeState) nodeDTO {
+	dto := nodeDTO{
+		ID:             n.ID,
+		Name:           n.Name,
+		BaseURL:        n.BaseURL,
+		BackendType:    n.BackendType,
+		AuthHeader:     n.AuthHeader,
+		StaticModels:   n.StaticModels,
+		HealthPath:     n.HealthPath,
+		TimeoutSeconds: n.TimeoutSeconds,
+		Enabled:        n.Enabled,
+		Source:         n.Source,
+		CreatedAt:      n.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:      n.UpdatedAt.Format(time.RFC3339),
+		Health:         string(registry.HealthUnknown),
+		Models:         []string{},
+	}
+	ns, ok := states[n.ID]
+	if !ok {
+		return dto
+	}
+	dto.Health = string(ns.Health)
+	if ns.Models != nil {
+		dto.Models = ns.Models
+	}
+	dto.LastError = ns.LastError
+	if !ns.LastCheckedAt.IsZero() {
+		s := ns.LastCheckedAt.Format(time.RFC3339)
+		dto.LastCheckedAt = &s
+	}
+	return dto
+}
+
+// runNodeRefresh forces a synchronous reload + probe of one node. A nil
+// refresher (zero Options) is a no-op. The returned error is a failed DB
+// reload only; probe failures land in the registry as live state.
+func (h *handler) runNodeRefresh(r *http.Request, nodeID int64) error {
+	if h.nodeRefresher == nil {
+		return nil
+	}
+	return h.nodeRefresher.RefreshNode(r.Context(), nodeID)
+}
+
+// configSourcedNodeError writes the 409 for mutations of config-sourced
+// nodes, pointing the admin at the nodes file that owns them.
+func (h *handler) configSourcedNodeError(w http.ResponseWriter, r *http.Request) {
+	msg := "Node is config-sourced and read-only via the API; edit the nodes file (NODES_FILE) and restart"
+	if path := h.configSnapshot.NodesFile; path != "" {
+		msg = "Node is config-sourced and read-only via the API; edit " + path + " (NODES_FILE) and restart"
+	}
+	proxy.WriteError(w, r, http.StatusConflict, "config_sourced_node", "invalid_request_error", msg)
+}
+
+// writeNodeResponse emits the standard {data: nodeDTO} envelope, reloading
+// the node (masked) and its live state so the client always sees post-refresh
+// truth.
+func (h *handler) writeNodeResponse(w http.ResponseWriter, r *http.Request, nodeID int64, status int) {
+	n, err := h.store.GetNode(nodeID)
+	if err != nil || n == nil {
+		slog.ErrorContext(r.Context(), "reload node for response", "error", err, "node_id", nodeID)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to reload node")
+		return
+	}
+	dto := toNodeDTO(n, h.nodeLiveStates())
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(Envelope{Data: dto})
+}
+
+// createNode handles POST /api/admin/nodes: validate via the store's node
+// validators, insert, probe synchronously, and return 201 with the masked
+// node plus its initial live state.
+func (h *handler) createNode(w http.ResponseWriter, r *http.Request) {
+	var req createNodeRequest
+	if !apierror.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	n := store.Node{
+		Name:           req.Name,
+		BaseURL:        req.BaseURL,
+		BackendType:    req.BackendType,
+		AuthHeader:     req.AuthHeader,
+		StaticModels:   req.StaticModels,
+		HealthPath:     req.HealthPath,
+		TimeoutSeconds: req.TimeoutSeconds,
+	}
+	if err := store.ValidateNode(&n); err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_node", "invalid_request_error", err.Error())
+		return
+	}
+
+	id, err := h.store.CreateNode(n)
+	if err != nil {
+		if errors.Is(err, store.ErrNodeNameExists) {
+			proxy.WriteError(w, r, http.StatusConflict, "node_name_exists", "invalid_request_error", "A node with this name already exists")
+			return
+		}
+		slog.ErrorContext(r.Context(), "create node error", "error", err)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to create node")
+		return
+	}
+
+	// Initial synchronous probe (design doc: nodes created via the API are
+	// probed immediately so the response includes initial health). A failed
+	// reload is logged, not fatal — the node exists; live state stays unknown
+	// until the poller reaches it.
+	if err := h.runNodeRefresh(r, id); err != nil {
+		slog.ErrorContext(r.Context(), "initial node refresh error", "error", err, "node_id", id)
+	}
+	h.writeNodeResponse(w, r, id, http.StatusCreated)
+}
+
+// listNodes handles GET /api/admin/nodes: all nodes (masked) joined with live
+// state from one registry snapshot.
+func (h *handler) listNodes(w http.ResponseWriter, r *http.Request) {
+	envelope, ecode, emsg, eerr := wantEnvelope(r)
+	if eerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, ecode, "invalid_request_error", emsg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
+	nodes, err := h.store.ListNodes()
+	if err != nil {
+		slog.ErrorContext(r.Context(), "list nodes error", "error", err)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to list nodes")
+		return
+	}
+
+	states := h.nodeLiveStates()
+	resp := make([]nodeDTO, 0, len(nodes))
+	for i := range nodes {
+		resp = append(resp, toNodeDTO(&nodes[i], states))
+	}
+
+	if envelope {
+		page, pag := sliceWindow(resp, limit, offset)
+		writeEnvelope(w, page, pag)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// getNode handles GET /api/admin/nodes/{id}.
+func (h *handler) getNode(w http.ResponseWriter, r *http.Request) {
+	id, ok := h.nodeIDFromPath(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.store.GetNode(id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "get node error", "error", err, "node_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to get node")
+		return
+	}
+	if n == nil {
+		proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Node not found")
+		return
+	}
+	writeEnvelope(w, toNodeDTO(n, h.nodeLiveStates()), nil)
+}
+
+// updateNode handles PUT /api/admin/nodes/{id}: PATCH-like update of the
+// mutable fields (see updateNodeRequest for the keep/clear/replace rules),
+// then a synchronous re-probe. Config-sourced nodes are read-only → 409.
+func (h *handler) updateNode(w http.ResponseWriter, r *http.Request) {
+	id, ok := h.nodeIDFromPath(w, r)
+	if !ok {
+		return
+	}
+
+	// Read-modify-write MUST load the raw secret: UpdateNode is a full-row
+	// write where nil AuthHeader clears the stored value, and writing a
+	// masked value back is rejected by validation.
+	current, err := h.store.GetNodeWithSecrets(id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "load node for update", "error", err, "node_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to load node")
+		return
+	}
+	if current == nil {
+		proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Node not found")
+		return
+	}
+	if current.Source == "config" {
+		h.configSourcedNodeError(w, r)
+		return
+	}
+
+	var req updateNodeRequest
+	if !apierror.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name != nil {
+		current.Name = *req.Name
+	}
+	if req.BaseURL != nil {
+		current.BaseURL = *req.BaseURL
+	}
+	if req.BackendType != nil {
+		current.BackendType = *req.BackendType
+	}
+	if req.AuthHeader != nil {
+		if *req.AuthHeader == "" {
+			current.AuthHeader = nil // "" = clear the stored secret
+		} else {
+			current.AuthHeader = req.AuthHeader
+		}
+	}
+	if req.StaticModels != nil {
+		if len(*req.StaticModels) == 0 {
+			current.StaticModels = nil // [] = back to probe discovery
+		} else {
+			current.StaticModels = *req.StaticModels
+		}
+	}
+	if req.HealthPath != nil {
+		if *req.HealthPath == "" {
+			current.HealthPath = nil // "" = clear the override
+		} else {
+			current.HealthPath = req.HealthPath
+		}
+	}
+	if req.TimeoutSeconds != nil {
+		if *req.TimeoutSeconds == 0 {
+			current.TimeoutSeconds = nil // 0 = back to the default timeout
+		} else {
+			current.TimeoutSeconds = req.TimeoutSeconds
+		}
+	}
+	if req.Enabled != nil {
+		current.Enabled = *req.Enabled
+	}
+
+	if err := store.ValidateNode(current); err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_node", "invalid_request_error", err.Error())
+		return
+	}
+	if err := h.store.UpdateNode(*current); err != nil {
+		switch {
+		case errors.Is(err, store.ErrNodeNameExists):
+			proxy.WriteError(w, r, http.StatusConflict, "node_name_exists", "invalid_request_error", "A node with this name already exists")
+		case errors.Is(err, store.ErrNodeNotFound):
+			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Node not found")
+		default:
+			slog.ErrorContext(r.Context(), "update node error", "error", err, "node_id", id)
+			proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to update node")
+		}
+		return
+	}
+
+	if err := h.runNodeRefresh(r, id); err != nil {
+		slog.ErrorContext(r.Context(), "node refresh after update", "error", err, "node_id", id)
+	}
+	h.writeNodeResponse(w, r, id, http.StatusOK)
+}
+
+// deleteNode handles DELETE /api/admin/nodes/{id}: soft-delete (disable) and
+// synchronously drop the node from routing. Nodes are never hard-deleted —
+// usage_logs rows reference them. Config-sourced nodes → 409 (remove them
+// from the nodes file instead).
+func (h *handler) deleteNode(w http.ResponseWriter, r *http.Request) {
+	id, ok := h.nodeIDFromPath(w, r)
+	if !ok {
+		return
+	}
+
+	n, err := h.store.GetNode(id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "load node for delete", "error", err, "node_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to load node")
+		return
+	}
+	if n == nil {
+		proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Node not found")
+		return
+	}
+	if n.Source == "config" {
+		h.configSourcedNodeError(w, r)
+		return
+	}
+
+	if err := h.store.DisableNode(id); err != nil {
+		if errors.Is(err, store.ErrNodeNotFound) {
+			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Node not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "disable node error", "error", err, "node_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to disable node")
+		return
+	}
+
+	// The refresher's reload reconciles the registry to the DB, removing the
+	// now-disabled node from routing before we answer. A failure here is
+	// surfaced: "deleted" must mean "no longer routable", not "will stop
+	// being routable within a poll interval".
+	if err := h.runNodeRefresh(r, id); err != nil {
+		slog.ErrorContext(r.Context(), "node refresh after delete", "error", err, "node_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Node disabled but not yet removed from routing")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// refreshNode handles POST /api/admin/nodes/{id}/refresh: force an immediate
+// probe + rediscovery and return the node with its fresh live state.
+func (h *handler) refreshNode(w http.ResponseWriter, r *http.Request) {
+	id, ok := h.nodeIDFromPath(w, r)
+	if !ok {
+		return
+	}
+
+	n, err := h.store.GetNode(id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "load node for refresh", "error", err, "node_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to load node")
+		return
+	}
+	if n == nil {
+		proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Node not found")
+		return
+	}
+
+	if err := h.runNodeRefresh(r, id); err != nil {
+		slog.ErrorContext(r.Context(), "node refresh error", "error", err, "node_id", id)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to refresh node")
+		return
+	}
+	h.writeNodeResponse(w, r, id, http.StatusOK)
+}
+
+// nodeIDFromPath parses the {id} path segment, writing a 400 on garbage.
+func (h *handler) nodeIDFromPath(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid node ID")
+		return 0, false
+	}
+	return id, true
+}

--- a/internal/admin/nodes_test.go
+++ b/internal/admin/nodes_test.go
@@ -1,0 +1,742 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/health"
+	"github.com/krishna/local-ai-proxy/internal/poller"
+	"github.com/krishna/local-ai-proxy/internal/registry"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+const testNodesFile = "/etc/laip/nodes.json"
+
+// setupNodesTest builds a full admin handler wired to a real registry and
+// poller over the test database, mirroring main.go's BE-7 wiring.
+func setupNodesTest(t *testing.T) (http.Handler, *store.Store, *registry.Registry, *poller.Poller) {
+	t.Helper()
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("DATABASE_URL not set, skipping admin nodes integration test")
+	}
+
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+
+	wipe := func() {
+		c := context.Background()
+		// FK-aware order: usage_logs references api_keys and nodes.
+		_, _ = s.Pool().Exec(c, "DELETE FROM usage_logs")
+		_, _ = s.Pool().Exec(c, "DELETE FROM nodes")
+		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
+		_, _ = s.Pool().Exec(c, "DELETE FROM users")
+		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
+	}
+	wipe()
+	t.Cleanup(func() {
+		wipe()
+		s.Close()
+	})
+
+	reg := registry.New()
+	p := poller.New(s, reg, nil, poller.Options{ProbeTimeout: 2 * time.Second})
+	usageCh := make(chan store.UsageEntry, 100)
+	h := NewHandler(s, testAdminKey, usageCh, Options{
+		Snapshot:  ConfigSnapshot{NodesFile: testNodesFile},
+		Checker:   health.NewChecker(nil, reg, nil, 0),
+		Registry:  reg,
+		Refresher: p,
+	})
+	return h, s, reg, p
+}
+
+// nodesReq performs an authenticated admin request and returns the recorder.
+func nodesReq(t *testing.T, h http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// nodeBackend is a controllable fake ollama backend.
+type nodeBackend struct {
+	srv  *httptest.Server
+	fail atomic.Bool
+}
+
+func newNodeBackend(t *testing.T, models ...string) *nodeBackend {
+	t.Helper()
+	b := &nodeBackend{}
+	b.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if b.fail.Load() {
+			http.Error(w, "down", http.StatusInternalServerError)
+			return
+		}
+		entries := make([]string, len(models))
+		for i, m := range models {
+			entries[i] = fmt.Sprintf(`{"name":%q}`, m)
+		}
+		fmt.Fprintf(w, `{"models":[%s]}`, strings.Join(entries, ","))
+	}))
+	t.Cleanup(b.srv.Close)
+	return b
+}
+
+// assertNoRawSecret fails if any raw secret leaked into an admin response.
+func assertNoRawSecret(t *testing.T, body string, rawSecrets ...string) {
+	t.Helper()
+	for _, s := range rawSecrets {
+		if strings.Contains(body, s) {
+			t.Errorf("response leaked raw secret %q: %s", s, body)
+		}
+	}
+}
+
+func decodeNodeEnvelope(t *testing.T, rec *httptest.ResponseRecorder) nodeDTO {
+	t.Helper()
+	var env struct {
+		Data nodeDTO `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode node envelope: %v (body: %s)", err, rec.Body.String())
+	}
+	return env.Data
+}
+
+func errCode(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var resp map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	errObj, _ := resp["error"].(map[string]any)
+	code, _ := errObj["code"].(string)
+	return code
+}
+
+func errMessage(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var resp map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	errObj, _ := resp["error"].(map[string]any)
+	msg, _ := errObj["message"].(string)
+	return msg
+}
+
+// --- POST /api/admin/nodes -------------------------------------------------
+
+func TestAdminNodes_Create_ProbesAndRoutesBeforeResponding(t *testing.T) {
+	h, _, reg, _ := setupNodesTest(t)
+	backend := newNodeBackend(t, "llama3:8b", "qwen3:32b")
+	const rawSecret = "Bearer sk-raw-node-secret-12345"
+
+	body := fmt.Sprintf(`{"name":"mac-studio","base_url":"%s/","backend_type":"ollama","auth_header":%q}`,
+		backend.srv.URL, rawSecret)
+	rec := nodesReq(t, h, http.MethodPost, "/api/admin/nodes", body)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	assertNoRawSecret(t, rec.Body.String(), rawSecret)
+
+	n := decodeNodeEnvelope(t, rec)
+	if n.ID <= 0 {
+		t.Errorf("expected positive id, got %d", n.ID)
+	}
+	if n.Name != "mac-studio" {
+		t.Errorf("name = %q", n.Name)
+	}
+	// Canonicalized: trailing slash trimmed.
+	if n.BaseURL != backend.srv.URL {
+		t.Errorf("base_url = %q, want canonical %q", n.BaseURL, backend.srv.URL)
+	}
+	if n.Source != "api" || !n.Enabled {
+		t.Errorf("source/enabled = %q/%v, want api/true", n.Source, n.Enabled)
+	}
+	if n.AuthHeader == nil || !strings.Contains(*n.AuthHeader, "…") {
+		t.Errorf("auth_header = %v, want masked value", n.AuthHeader)
+	}
+	// Live state from the synchronous initial probe.
+	if n.Health != "healthy" {
+		t.Errorf("health = %q, want healthy", n.Health)
+	}
+	if len(n.Models) != 2 || n.Models[0] != "llama3:8b" {
+		t.Errorf("models = %v, want discovered list", n.Models)
+	}
+	if n.LastCheckedAt == nil {
+		t.Error("last_checked_at = null, want probe timestamp")
+	}
+	if n.LastError != "" {
+		t.Errorf("last_error = %q, want empty", n.LastError)
+	}
+	// The node must already be routable when the response returns.
+	if _, err := reg.Resolve("llama3:8b"); err != nil {
+		t.Errorf("model not routable after create: %v", err)
+	}
+}
+
+func TestAdminNodes_Create_ValidationErrors(t *testing.T) {
+	h, _, _, _ := setupNodesTest(t)
+
+	cases := []struct {
+		name, body, wantIn string
+	}{
+		{"bad scheme", `{"name":"n","base_url":"ftp://host/x"}`, "scheme"},
+		{"v1 suffix", `{"name":"n","base_url":"http://host:11434/v1"}`, "/v1"},
+		{"bad backend_type", `{"name":"n","base_url":"http://host:11434","backend_type":"vllm"}`, "backend_type"},
+		{"missing name", `{"base_url":"http://host:11434"}`, "name"},
+		{"bad auth header", `{"name":"n","base_url":"http://host:11434","auth_header":"x\r\ny"}`, "auth_header"},
+		{"bad health path", `{"name":"n","base_url":"http://host:11434","health_path":"http://evil"}`, "health_path"},
+		{"bad timeout", `{"name":"n","base_url":"http://host:11434","timeout_seconds":-5}`, "timeout_seconds"},
+	}
+	for _, c := range cases {
+		rec := nodesReq(t, h, http.MethodPost, "/api/admin/nodes", c.body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d: %s", c.name, rec.Code, rec.Body.String())
+			continue
+		}
+		if msg := errMessage(t, rec); !strings.Contains(msg, c.wantIn) {
+			t.Errorf("%s: error message %q should mention %q", c.name, msg, c.wantIn)
+		}
+	}
+}
+
+func TestAdminNodes_Create_NameConflict409(t *testing.T) {
+	h, _, _, _ := setupNodesTest(t)
+	backend := newNodeBackend(t, "m")
+
+	body := fmt.Sprintf(`{"name":"dup","base_url":%q}`, backend.srv.URL)
+	if rec := nodesReq(t, h, http.MethodPost, "/api/admin/nodes", body); rec.Code != http.StatusCreated {
+		t.Fatalf("first create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	rec := nodesReq(t, h, http.MethodPost, "/api/admin/nodes", body)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate create: expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if code := errCode(t, rec); code != "node_name_exists" {
+		t.Errorf("error code = %q, want node_name_exists", code)
+	}
+}
+
+func TestAdminNodes_Create_ProbeFailureStillCreates(t *testing.T) {
+	h, _, _, _ := setupNodesTest(t)
+	backend := newNodeBackend(t, "m")
+	backend.fail.Store(true)
+
+	body := fmt.Sprintf(`{"name":"downer","base_url":%q}`, backend.srv.URL)
+	rec := nodesReq(t, h, http.MethodPost, "/api/admin/nodes", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 even when the initial probe fails, got %d: %s", rec.Code, rec.Body.String())
+	}
+	n := decodeNodeEnvelope(t, rec)
+	if n.Health != "unhealthy" {
+		t.Errorf("health = %q, want unhealthy (decisive initial probe)", n.Health)
+	}
+	if n.LastError == "" {
+		t.Error("last_error empty, want probe failure recorded")
+	}
+	if n.LastCheckedAt == nil {
+		t.Error("last_checked_at = null, want probe timestamp")
+	}
+}
+
+// --- GET /api/admin/nodes --------------------------------------------------
+
+func TestAdminNodes_List_JoinsLiveState(t *testing.T) {
+	h, s, _, p := setupNodesTest(t)
+	backend := newNodeBackend(t, "llama3:8b")
+	const rawSecret = "Bearer sk-list-raw-secret-999"
+
+	probedID, err := s.CreateNode(store.Node{
+		Name: "probed", BaseURL: backend.srv.URL, BackendType: "ollama",
+		AuthHeader: strPtr(rawSecret),
+	})
+	if err != nil {
+		t.Fatalf("CreateNode probed: %v", err)
+	}
+	if _, err := s.CreateNode(store.Node{Name: "unprobed", BaseURL: "http://unprobed:11434"}); err != nil {
+		t.Fatalf("CreateNode unprobed: %v", err)
+	}
+	if err := p.RefreshNode(context.Background(), probedID); err != nil {
+		t.Fatalf("RefreshNode: %v", err)
+	}
+
+	rec := nodesReq(t, h, http.MethodGet, "/api/admin/nodes", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	assertNoRawSecret(t, rec.Body.String(), rawSecret)
+
+	var env struct {
+		Data       []nodeDTO   `json:"data"`
+		Pagination *Pagination `json:"pagination"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode list envelope: %v (body: %s)", err, rec.Body.String())
+	}
+	if env.Pagination == nil || env.Pagination.Total != 2 {
+		t.Fatalf("pagination = %+v, want total 2", env.Pagination)
+	}
+	if len(env.Data) != 2 {
+		t.Fatalf("len(data) = %d, want 2", len(env.Data))
+	}
+
+	byName := map[string]nodeDTO{}
+	for _, n := range env.Data {
+		byName[n.Name] = n
+	}
+	probed := byName["probed"]
+	if probed.Health != "healthy" {
+		t.Errorf("probed health = %q, want healthy", probed.Health)
+	}
+	if len(probed.Models) != 1 || probed.Models[0] != "llama3:8b" {
+		t.Errorf("probed models = %v, want [llama3:8b]", probed.Models)
+	}
+	if probed.AuthHeader == nil || !strings.Contains(*probed.AuthHeader, "…") {
+		t.Errorf("probed auth_header = %v, want masked", probed.AuthHeader)
+	}
+	if probed.Source != "api" || !probed.Enabled {
+		t.Errorf("probed source/enabled = %q/%v, want api/true", probed.Source, probed.Enabled)
+	}
+
+	unprobed := byName["unprobed"]
+	if unprobed.Health != "unknown" {
+		t.Errorf("unprobed health = %q, want unknown", unprobed.Health)
+	}
+	if unprobed.Models == nil || len(unprobed.Models) != 0 {
+		t.Errorf("unprobed models = %v, want empty list", unprobed.Models)
+	}
+	if unprobed.LastCheckedAt != nil {
+		t.Errorf("unprobed last_checked_at = %v, want null", *unprobed.LastCheckedAt)
+	}
+}
+
+// --- GET /api/admin/nodes/{id} ----------------------------------------------
+
+func TestAdminNodes_Get(t *testing.T) {
+	h, s, _, _ := setupNodesTest(t)
+
+	id, err := s.CreateNode(store.Node{Name: "solo", BaseURL: "http://solo:11434"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	rec := nodesReq(t, h, http.MethodGet, fmt.Sprintf("/api/admin/nodes/%d", id), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	n := decodeNodeEnvelope(t, rec)
+	if n.ID != id || n.Name != "solo" || n.Health != "unknown" {
+		t.Errorf("got %+v, want id=%d name=solo health=unknown", n, id)
+	}
+
+	if rec := nodesReq(t, h, http.MethodGet, "/api/admin/nodes/999999", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown id: expected 404, got %d", rec.Code)
+	}
+}
+
+// --- PUT /api/admin/nodes/{id} ----------------------------------------------
+
+// The PATCH-like auth_header contract: absent = keep, "" = clear,
+// value = replace. The masked value must never round-trip into the store.
+func TestAdminNodes_Update_AuthHeaderKeepReplaceClear(t *testing.T) {
+	h, s, _, _ := setupNodesTest(t)
+	const rawOne = "Bearer sk-raw-original-secret"
+	const rawTwo = "Bearer sk-raw-replacement-secret"
+
+	id, err := s.CreateNode(store.Node{
+		Name: "authy", BaseURL: "http://authy:11434", AuthHeader: strPtr(rawOne),
+	})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	path := fmt.Sprintf("/api/admin/nodes/%d", id)
+
+	// 1. auth_header absent → keep.
+	rec := nodesReq(t, h, http.MethodPut, path, `{"name":"authy-renamed"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("keep: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	assertNoRawSecret(t, rec.Body.String(), rawOne, rawTwo)
+	raw, _ := s.GetNodeWithSecrets(id)
+	if raw.AuthHeader == nil || *raw.AuthHeader != rawOne {
+		t.Fatalf("after omitted auth_header: stored = %v, want original kept", raw.AuthHeader)
+	}
+	if raw.Name != "authy-renamed" {
+		t.Errorf("name = %q, want authy-renamed", raw.Name)
+	}
+
+	// 2. auth_header = new value → replace.
+	rec = nodesReq(t, h, http.MethodPut, path, fmt.Sprintf(`{"auth_header":%q}`, rawTwo))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("replace: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	assertNoRawSecret(t, rec.Body.String(), rawOne, rawTwo)
+	if n := decodeNodeEnvelope(t, rec); n.AuthHeader == nil || !strings.Contains(*n.AuthHeader, "…") {
+		t.Errorf("response auth_header = %v, want masked", n.AuthHeader)
+	}
+	raw, _ = s.GetNodeWithSecrets(id)
+	if raw.AuthHeader == nil || *raw.AuthHeader != rawTwo {
+		t.Fatalf("after replace: stored = %v, want %q", raw.AuthHeader, rawTwo)
+	}
+
+	// 3. auth_header = "" → clear.
+	rec = nodesReq(t, h, http.MethodPut, path, `{"auth_header":""}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if n := decodeNodeEnvelope(t, rec); n.AuthHeader != nil {
+		t.Errorf("response auth_header = %v, want null after clear", *n.AuthHeader)
+	}
+	raw, _ = s.GetNodeWithSecrets(id)
+	if raw.AuthHeader != nil {
+		t.Fatalf("after clear: stored = %q, want nil", *raw.AuthHeader)
+	}
+}
+
+func TestAdminNodes_Update_RefreshesLiveState(t *testing.T) {
+	h, s, reg, _ := setupNodesTest(t)
+	backend := newNodeBackend(t, "qwen3:32b")
+
+	id, err := s.CreateNode(store.Node{Name: "movable", BaseURL: "http://old-target:11434"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"base_url":%q}`, backend.srv.URL)
+	rec := nodesReq(t, h, http.MethodPut, fmt.Sprintf("/api/admin/nodes/%d", id), body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	n := decodeNodeEnvelope(t, rec)
+	if n.BaseURL != backend.srv.URL {
+		t.Errorf("base_url = %q, want %q", n.BaseURL, backend.srv.URL)
+	}
+	if n.Health != "healthy" {
+		t.Errorf("health = %q, want healthy from synchronous re-probe", n.Health)
+	}
+	if len(n.Models) != 1 || n.Models[0] != "qwen3:32b" {
+		t.Errorf("models = %v, want [qwen3:32b]", n.Models)
+	}
+	if _, err := reg.Resolve("qwen3:32b"); err != nil {
+		t.Errorf("model not routable after update: %v", err)
+	}
+}
+
+func TestAdminNodes_Update_ConfigSourced409(t *testing.T) {
+	h, s, _, _ := setupNodesTest(t)
+
+	id, err := s.CreateNode(store.Node{Name: "from-file", BaseURL: "http://file:11434", Source: "config"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	rec := nodesReq(t, h, http.MethodPut, fmt.Sprintf("/api/admin/nodes/%d", id), `{"name":"nope"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for config-sourced node, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if msg := errMessage(t, rec); !strings.Contains(msg, testNodesFile) {
+		t.Errorf("error message %q should point at NODES_FILE %q", msg, testNodesFile)
+	}
+}
+
+func TestAdminNodes_Update_NameConflict409(t *testing.T) {
+	h, s, _, _ := setupNodesTest(t)
+
+	if _, err := s.CreateNode(store.Node{Name: "taken", BaseURL: "http://a:11434"}); err != nil {
+		t.Fatalf("CreateNode a: %v", err)
+	}
+	id, err := s.CreateNode(store.Node{Name: "renamer", BaseURL: "http://b:11434"})
+	if err != nil {
+		t.Fatalf("CreateNode b: %v", err)
+	}
+
+	rec := nodesReq(t, h, http.MethodPut, fmt.Sprintf("/api/admin/nodes/%d", id), `{"name":"taken"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 on rename collision, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if code := errCode(t, rec); code != "node_name_exists" {
+		t.Errorf("error code = %q, want node_name_exists", code)
+	}
+}
+
+func TestAdminNodes_Update_Errors(t *testing.T) {
+	h, s, _, _ := setupNodesTest(t)
+
+	id, err := s.CreateNode(store.Node{Name: "target", BaseURL: "http://t:11434"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	if rec := nodesReq(t, h, http.MethodPut, "/api/admin/nodes/999999", `{"name":"x"}`); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown id: expected 404, got %d", rec.Code)
+	}
+	if rec := nodesReq(t, h, http.MethodPut, "/api/admin/nodes/abc", `{"name":"x"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid id: expected 400, got %d", rec.Code)
+	}
+	rec := nodesReq(t, h, http.MethodPut, fmt.Sprintf("/api/admin/nodes/%d", id), `{"base_url":"ftp://nope"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid base_url: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- DELETE /api/admin/nodes/{id} --------------------------------------------
+
+func TestAdminNodes_Delete_RemovesFromRouting(t *testing.T) {
+	h, s, reg, _ := setupNodesTest(t)
+	backend := newNodeBackend(t, "llama3:8b")
+
+	body := fmt.Sprintf(`{"name":"goner","base_url":%q}`, backend.srv.URL)
+	rec := nodesReq(t, h, http.MethodPost, "/api/admin/nodes", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	n := decodeNodeEnvelope(t, rec)
+	if _, err := reg.Resolve("llama3:8b"); err != nil {
+		t.Fatalf("precondition: model not routable: %v", err)
+	}
+
+	rec = nodesReq(t, h, http.MethodDelete, fmt.Sprintf("/api/admin/nodes/%d", n.ID), "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Soft-deleted in the store...
+	stored, err := s.GetNode(n.ID)
+	if err != nil || stored == nil {
+		t.Fatalf("GetNode after delete: %v, %v (row must survive; DELETE is a disable)", stored, err)
+	}
+	if stored.Enabled {
+		t.Error("node still enabled after DELETE")
+	}
+	// ...and synchronously out of routing.
+	snap := reg.Snapshot()
+	if len(snap.Nodes) != 0 {
+		t.Errorf("registry still has %d nodes after DELETE", len(snap.Nodes))
+	}
+	if _, err := reg.Resolve("llama3:8b"); err == nil {
+		t.Error("model still routable after DELETE")
+	}
+}
+
+func TestAdminNodes_Delete_Errors(t *testing.T) {
+	h, s, _, _ := setupNodesTest(t)
+
+	cfgID, err := s.CreateNode(store.Node{Name: "cfg", BaseURL: "http://cfg:11434", Source: "config"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	rec := nodesReq(t, h, http.MethodDelete, fmt.Sprintf("/api/admin/nodes/%d", cfgID), "")
+	if rec.Code != http.StatusConflict {
+		t.Errorf("config-sourced: expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if msg := errMessage(t, rec); !strings.Contains(msg, testNodesFile) {
+		t.Errorf("error message %q should point at NODES_FILE %q", msg, testNodesFile)
+	}
+	if rec := nodesReq(t, h, http.MethodDelete, "/api/admin/nodes/999999", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown id: expected 404, got %d", rec.Code)
+	}
+	if rec := nodesReq(t, h, http.MethodDelete, "/api/admin/nodes/abc", ""); rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid id: expected 400, got %d", rec.Code)
+	}
+}
+
+// --- POST /api/admin/nodes/{id}/refresh ---------------------------------------
+
+func TestAdminNodes_Refresh_ReturnsFreshLiveState(t *testing.T) {
+	h, s, _, _ := setupNodesTest(t)
+	backend := newNodeBackend(t, "llama3:8b")
+
+	id, err := s.CreateNode(store.Node{Name: "refreshable", BaseURL: backend.srv.URL, BackendType: "ollama"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	path := fmt.Sprintf("/api/admin/nodes/%d/refresh", id)
+
+	rec := nodesReq(t, h, http.MethodPost, path, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	n := decodeNodeEnvelope(t, rec)
+	if n.Health != "healthy" || len(n.Models) != 1 {
+		t.Errorf("after refresh: health=%q models=%v, want healthy/[llama3:8b]", n.Health, n.Models)
+	}
+
+	// Backend goes down; a second forced refresh must report it immediately.
+	backend.fail.Store(true)
+	rec = nodesReq(t, h, http.MethodPost, path, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	n = decodeNodeEnvelope(t, rec)
+	if n.Health != "unhealthy" {
+		t.Errorf("after failing refresh: health = %q, want unhealthy", n.Health)
+	}
+	if n.LastError == "" {
+		t.Error("last_error empty, want probe failure detail")
+	}
+}
+
+func TestAdminNodes_Refresh_NotFound(t *testing.T) {
+	h, _, _, _ := setupNodesTest(t)
+
+	if rec := nodesReq(t, h, http.MethodPost, "/api/admin/nodes/999999/refresh", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// --- GET /api/admin/usage?node_id= --------------------------------------------
+
+func TestAdminUsage_NodeIDFilter(t *testing.T) {
+	h, s, _, _ := setupNodesTest(t)
+
+	keyID, err := s.CreateKey("node-usage-key", "hash-node-usage", "sk-nodeusg", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	nodeA, err := s.CreateNode(store.Node{Name: "node-a", BaseURL: "http://a:11434"})
+	if err != nil {
+		t.Fatalf("CreateNode a: %v", err)
+	}
+	nodeB, err := s.CreateNode(store.Node{Name: "node-b", BaseURL: "http://b:11434"})
+	if err != nil {
+		t.Fatalf("CreateNode b: %v", err)
+	}
+
+	log := func(model string, nodeID *int64) {
+		t.Helper()
+		if err := s.LogUsage(store.UsageEntry{
+			APIKeyID: keyID, Model: model, PromptTokens: 10, CompletionTokens: 5,
+			TotalTokens: 15, DurationMs: 50, Status: "completed", NodeID: nodeID,
+		}); err != nil {
+			t.Fatalf("LogUsage: %v", err)
+		}
+	}
+	log("model-on-a", &nodeA)
+	log("model-on-b", &nodeB)
+	log("model-unrouted", nil)
+
+	rec := nodesReq(t, h, http.MethodGet, fmt.Sprintf("/api/admin/usage?node_id=%d&envelope=0", nodeA), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var stats []store.UsageStat
+	if err := json.Unmarshal(rec.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if len(stats) != 1 || stats[0].Model != "model-on-a" {
+		t.Errorf("stats = %+v, want exactly the node-a row", stats)
+	}
+
+	if rec := nodesReq(t, h, http.MethodGet, "/api/admin/usage?node_id=abc", ""); rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid node_id: expected 400, got %d", rec.Code)
+	}
+}
+
+// --- GET /api/admin/health node breakdown --------------------------------------
+
+func TestAdminHealth_PerNodeBreakdown(t *testing.T) {
+	h, _, reg, _ := setupNodesTest(t)
+
+	u1 := mustParseURL(t, "http://one:11434")
+	u2 := mustParseURL(t, "http://two:11434")
+	reg.SetNodes([]registry.Node{
+		{ID: 1, Name: "one", BaseURL: u1},
+		{ID: 2, Name: "two", BaseURL: u2},
+	})
+	checked := time.Now()
+	reg.SetNodeProbe(1, registry.ProbeResult{
+		Health: registry.HealthHealthy, Models: []string{"m1", "m2"}, LastCheckedAt: checked,
+	})
+	reg.SetNodeProbe(2, registry.ProbeResult{
+		Health: registry.HealthUnhealthy, LastError: "connection refused", LastCheckedAt: checked,
+	})
+
+	rec := nodesReq(t, h, http.MethodGet, "/api/admin/health", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (one healthy node), got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Status string `json:"status"`
+		Nodes  []struct {
+			Name          string  `json:"name"`
+			Health        string  `json:"health"`
+			LastError     string  `json:"last_error"`
+			LastCheckedAt *string `json:"last_checked_at"`
+			ModelCount    int     `json:"model_count"`
+		} `json:"nodes"`
+		Warning string `json:"warning"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if len(resp.Nodes) != 2 {
+		t.Fatalf("nodes = %+v, want 2 entries", resp.Nodes)
+	}
+	if resp.Warning != "" {
+		t.Errorf("warning = %q, want absent with nodes configured", resp.Warning)
+	}
+	one, two := resp.Nodes[0], resp.Nodes[1]
+	if one.Name != "one" || one.Health != "healthy" || one.ModelCount != 2 || one.LastCheckedAt == nil {
+		t.Errorf("node one = %+v, want healthy with 2 models and a timestamp", one)
+	}
+	if two.Name != "two" || two.Health != "unhealthy" || two.LastError != "connection refused" {
+		t.Errorf("node two = %+v, want unhealthy with last_error", two)
+	}
+}
+
+func TestAdminHealth_ZeroNodesWarning(t *testing.T) {
+	h, _, _, _ := setupNodesTest(t)
+
+	rec := nodesReq(t, h, http.MethodGet, "/api/admin/health", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (zero nodes is not degraded), got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Nodes   []any  `json:"nodes"`
+		Warning string `json:"warning"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if resp.Warning != "no nodes configured" {
+		t.Errorf("warning = %q, want 'no nodes configured'", resp.Warning)
+	}
+	if len(resp.Nodes) != 0 {
+		t.Errorf("nodes = %+v, want empty", resp.Nodes)
+	}
+}
+
+// --- helpers -------------------------------------------------------------------
+
+func strPtr(s string) *string { return &s }
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return u
+}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -251,6 +251,45 @@ func (p *Poller) Run(ctx context.Context) {
 	}
 }
 
+// RefreshNode synchronously refreshes one node for the admin API (BE-7): it
+// reloads the full node set from the database (so a node just created,
+// updated, or disabled is reconciled into the registry immediately — the
+// poller's periodic re-read is only the fallback), then probes the node with
+// the given ID once using the normal probe machinery and per-probe timeout,
+// publishing the outcome to the registry before returning.
+//
+// The forced probe uses startup-sweep semantics: a single failure is decisive
+// (unhealthy), with no hysteresis — the caller asked for a fresh verdict and
+// gets one. Any success is immediately healthy and routable.
+//
+// If the node is disabled or absent from the database, the reload alone is
+// the refresh: it drops the node from the registry and poller state, which is
+// how admin DELETE removes a node from routing synchronously. No error is
+// returned for that case. The returned error is only ever a failed database
+// load; probe failures are recorded in the registry, not returned (matching
+// SweepOnce).
+//
+// RefreshNode is safe to call concurrently with Run and with itself: reload
+// reconciliation and probe application both run under the poller's internal
+// lock, and the registry publishes atomically.
+func (p *Poller) RefreshNode(ctx context.Context, nodeID int64) error {
+	specs, err := p.load()
+	if err != nil {
+		return err
+	}
+	for _, s := range specs {
+		if s.id != nodeID {
+			continue
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, p.opts.ProbeTimeout)
+		models, probeErr := p.probe(probeCtx, s)
+		cancel()
+		p.apply(s, models, probeErr, true)
+		return nil
+	}
+	return nil
+}
+
 // pollCycle runs one poll cycle — reload, probe everything due, compute the
 // next wake — and returns how long to wait before the next cycle. When the
 // reload fails it falls back to the last successfully loaded node set: a

--- a/internal/poller/refresh_test.go
+++ b/internal/poller/refresh_test.go
@@ -1,0 +1,155 @@
+package poller
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/registry"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// RefreshNode is BE-7's synchronous single-node probe: admin handlers call it
+// after CreateNode/UpdateNode/DisableNode so the node's live state (and its
+// removal from routing) is published before the HTTP response returns.
+
+func TestRefreshNode_ProbesAndPublishesSynchronously(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "n1", f.srv.URL, "ollama")}, Options{})
+
+	if err := p.RefreshNode(context.Background(), 1); err != nil {
+		t.Fatalf("RefreshNode: %v", err)
+	}
+
+	// The outcome must be visible immediately — no waiting on a poll cycle.
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy", ns.Health)
+	}
+	if len(ns.Models) != 1 || ns.Models[0] != "llama3:8b" {
+		t.Errorf("Models = %v, want [llama3:8b]", ns.Models)
+	}
+	if ns.LastCheckedAt.IsZero() {
+		t.Error("LastCheckedAt is zero, want set")
+	}
+	if _, err := reg.Resolve("llama3:8b"); err != nil {
+		t.Errorf("model not routable after RefreshNode: %v", err)
+	}
+}
+
+func TestRefreshNode_PicksUpNewDBNode(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, src := newTestPoller(t, nil, Options{})
+	pollOnce(t, p)
+
+	// Node appears in the DB (admin POST); RefreshNode must reload before
+	// probing rather than relying on the poller's periodic re-read.
+	src.set([]store.Node{enabledNode(7, "new", f.srv.URL, "ollama")}, nil)
+	if err := p.RefreshNode(context.Background(), 7); err != nil {
+		t.Fatalf("RefreshNode: %v", err)
+	}
+	if ns := nodeState(t, reg, 7); ns.Health != registry.HealthHealthy {
+		t.Errorf("Health = %q, want healthy for freshly created node", ns.Health)
+	}
+}
+
+func TestRefreshNode_SingleFailureIsDecisive(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, _ := newTestPoller(t, []store.Node{enabledNode(1, "n1", f.srv.URL, "ollama")}, Options{})
+	pollOnce(t, p)
+	if ns := nodeState(t, reg, 1); ns.Health != registry.HealthHealthy {
+		t.Fatalf("precondition: Health = %q, want healthy", ns.Health)
+	}
+
+	// A forced refresh is a decisive probe (startup-sweep semantics): one
+	// failure marks the node unhealthy, no hysteresis.
+	f.fail.Store(true)
+	if err := p.RefreshNode(context.Background(), 1); err != nil {
+		t.Fatalf("RefreshNode: %v", err)
+	}
+	ns := nodeState(t, reg, 1)
+	if ns.Health != registry.HealthUnhealthy {
+		t.Errorf("Health = %q, want unhealthy after a single forced-probe failure", ns.Health)
+	}
+	if ns.LastError == "" {
+		t.Error("LastError empty, want probe error recorded")
+	}
+}
+
+func TestRefreshNode_DisabledNodeLeavesRouting(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, src := newTestPoller(t, []store.Node{enabledNode(1, "n1", f.srv.URL, "ollama")}, Options{})
+	pollOnce(t, p)
+	if _, err := reg.Resolve("llama3:8b"); err != nil {
+		t.Fatalf("precondition: model not routable: %v", err)
+	}
+
+	// Admin DELETE sets enabled=false, then calls RefreshNode: the reload must
+	// drop the node from the registry synchronously.
+	n := enabledNode(1, "n1", f.srv.URL, "ollama")
+	n.Enabled = false
+	src.set([]store.Node{n}, nil)
+	if err := p.RefreshNode(context.Background(), 1); err != nil {
+		t.Fatalf("RefreshNode on disabled node: %v", err)
+	}
+	snap := reg.Snapshot()
+	if len(snap.Nodes) != 0 {
+		t.Errorf("registry still has %d nodes, want 0 after disable+refresh", len(snap.Nodes))
+	}
+	if _, err := reg.Resolve("llama3:8b"); !errors.Is(err, registry.ErrModelUnavailable) {
+		t.Errorf("Resolve after disable = %v, want ErrModelUnavailable", err)
+	}
+}
+
+func TestRefreshNode_LoadErrorReturned(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, _, src := newTestPoller(t, []store.Node{enabledNode(1, "n1", f.srv.URL, "ollama")}, Options{})
+	src.set(nil, context.DeadlineExceeded)
+
+	if err := p.RefreshNode(context.Background(), 1); err == nil {
+		t.Fatal("RefreshNode = nil error, want DB load error surfaced")
+	}
+}
+
+// RefreshNode must be safe to call concurrently with the running poll loop
+// (admin requests land while Run owns the schedule). Run with -race.
+func TestRefreshNode_ConcurrentWithRun(t *testing.T) {
+	f := newFlakyBackend(t)
+	p, reg, _ := newTestPoller(t, []store.Node{
+		enabledNode(1, "n1", f.srv.URL, "ollama"),
+		enabledNode(2, "n2", f.srv.URL, "ollama"),
+	}, Options{Interval: 20 * time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var runDone sync.WaitGroup
+	runDone.Add(1)
+	go func() {
+		defer runDone.Done()
+		p.Run(ctx)
+	}()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(id int64) {
+			defer wg.Done()
+			for i := 0; i < 25; i++ {
+				if err := p.RefreshNode(context.Background(), id); err != nil {
+					t.Errorf("RefreshNode: %v", err)
+					return
+				}
+			}
+		}(int64(g%2 + 1))
+	}
+	wg.Wait()
+	cancel()
+	runDone.Wait()
+
+	for _, id := range []int64{1, 2} {
+		if ns := nodeState(t, reg, id); ns.Health != registry.HealthHealthy {
+			t.Errorf("node %d Health = %q, want healthy", id, ns.Health)
+		}
+	}
+}

--- a/internal/store/nodes.go
+++ b/internal/store/nodes.go
@@ -188,6 +188,16 @@ func validateNode(n *Node) error {
 	return nil
 }
 
+// ValidateNode normalizes and validates the caller-supplied fields of n in
+// place (trims the name, canonicalizes base_url, defaults backend_type, and
+// checks auth_header/health_path/timeout_seconds). Exported so admin handlers
+// can map validation failures to 400 with the validator's message before
+// attempting a write; CreateNode and UpdateNode run the same validation
+// internally, so skipping this can never persist an invalid node.
+func ValidateNode(n *Node) error {
+	return validateNode(n)
+}
+
 // CreateNode validates, canonicalizes, and inserts a new node, returning its
 // ID. BackendType defaults to "ollama" and Source to "api" when empty; new
 // nodes are always created enabled. Returns ErrNodeNameExists on a name

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1041,8 +1041,11 @@ func (s *Store) BackfillAccounts() error {
 	return nil
 }
 
-// GetUsageStats returns aggregated usage statistics.
-func (s *Store) GetUsageStats(keyID *int64, since *time.Time) ([]UsageStat, error) {
+// GetUsageStats returns aggregated usage statistics. All filters are
+// optional: keyID restricts to one API key, since to entries at or after a
+// time, and nodeID to entries served by one backend node (entries logged
+// before node routing have a NULL node_id and only appear unfiltered).
+func (s *Store) GetUsageStats(keyID *int64, since *time.Time, nodeID *int64) ([]UsageStat, error) {
 	query := `SELECT u.api_key_id, k.name, u.model, COUNT(*) as total_requests,
 		SUM(u.prompt_tokens), SUM(u.completion_tokens), SUM(u.total_tokens), u.status
 		FROM usage_logs u JOIN api_keys k ON u.api_key_id = k.id
@@ -1058,6 +1061,11 @@ func (s *Store) GetUsageStats(keyID *int64, since *time.Time) ([]UsageStat, erro
 	if since != nil {
 		query += fmt.Sprintf(` AND u.created_at >= $%d`, argIdx)
 		args = append(args, *since)
+		argIdx++
+	}
+	if nodeID != nil {
+		query += fmt.Sprintf(` AND u.node_id = $%d`, argIdx)
+		args = append(args, *nodeID)
 		argIdx++
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -260,7 +260,7 @@ func TestGetUsageStats_NoFilters(t *testing.T) {
 		DurationMs: 200, Status: "completed",
 	})
 
-	stats, err := s.GetUsageStats(nil, nil)
+	stats, err := s.GetUsageStats(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("GetUsageStats: %v", err)
 	}
@@ -284,7 +284,7 @@ func TestGetUsageStats_WithKeyFilter(t *testing.T) {
 	_ = s.LogUsage(UsageEntry{APIKeyID: id1, Model: "llama3", PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15, DurationMs: 100, Status: "completed"})
 	_ = s.LogUsage(UsageEntry{APIKeyID: id2, Model: "llama3", PromptTokens: 20, CompletionTokens: 10, TotalTokens: 30, DurationMs: 200, Status: "completed"})
 
-	stats, err := s.GetUsageStats(&id1, nil)
+	stats, err := s.GetUsageStats(&id1, nil, nil)
 	if err != nil {
 		t.Fatalf("GetUsageStats: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestGetUsageStats_WithSinceFilter(t *testing.T) {
 
 	// Query with a time in the past — should include the entry
 	past := time.Now().Add(-1 * time.Hour)
-	stats, err := s.GetUsageStats(nil, &past)
+	stats, err := s.GetUsageStats(nil, &past, nil)
 	if err != nil {
 		t.Fatalf("GetUsageStats with since: %v", err)
 	}
@@ -315,12 +315,50 @@ func TestGetUsageStats_WithSinceFilter(t *testing.T) {
 
 	// Query with a time in the future — should exclude everything
 	future := time.Now().Add(1 * time.Hour)
-	stats, err = s.GetUsageStats(nil, &future)
+	stats, err = s.GetUsageStats(nil, &future, nil)
 	if err != nil {
 		t.Fatalf("GetUsageStats with future since: %v", err)
 	}
 	if len(stats) != 0 {
 		t.Errorf("expected 0 stats with future since filter, got %d", len(stats))
+	}
+}
+
+func TestGetUsageStats_WithNodeFilter(t *testing.T) {
+	s := setupTestStore(t)
+
+	keyID, _ := s.CreateKey("node-filter-key", "hash-nodef", "sk-nodef", 60)
+	nodeA, err := s.CreateNode(Node{Name: "usage-a", BaseURL: "http://usage-a:11434"})
+	if err != nil {
+		t.Fatalf("CreateNode a: %v", err)
+	}
+	nodeB, err := s.CreateNode(Node{Name: "usage-b", BaseURL: "http://usage-b:11434"})
+	if err != nil {
+		t.Fatalf("CreateNode b: %v", err)
+	}
+
+	_ = s.LogUsage(UsageEntry{APIKeyID: keyID, Model: "on-a", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2, DurationMs: 10, Status: "completed", NodeID: &nodeA})
+	_ = s.LogUsage(UsageEntry{APIKeyID: keyID, Model: "on-b", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2, DurationMs: 10, Status: "completed", NodeID: &nodeB})
+	_ = s.LogUsage(UsageEntry{APIKeyID: keyID, Model: "no-node", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2, DurationMs: 10, Status: "completed"})
+
+	stats, err := s.GetUsageStats(nil, nil, &nodeA)
+	if err != nil {
+		t.Fatalf("GetUsageStats with node filter: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 stat row for node filter, got %d: %+v", len(stats), stats)
+	}
+	if stats[0].Model != "on-a" {
+		t.Errorf("expected model on-a, got %q", stats[0].Model)
+	}
+
+	// nil node filter keeps returning everything, including NULL-node rows.
+	stats, err = s.GetUsageStats(nil, nil, nil)
+	if err != nil {
+		t.Fatalf("GetUsageStats without node filter: %v", err)
+	}
+	if len(stats) != 3 {
+		t.Errorf("expected 3 stat rows without node filter, got %d", len(stats))
 	}
 }
 

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -559,7 +559,7 @@ func (h *handler) getUsage(w http.ResponseWriter, r *http.Request) {
 	var allStats []store.UsageStat
 	for _, k := range keys {
 		keyID := k.ID
-		stats, err := h.store.GetUsageStats(&keyID, nil)
+		stats, err := h.store.GetUsageStats(&keyID, nil, nil)
 		if err != nil {
 			slog.ErrorContext(r.Context(), "usage stats error", "error", err)
 			proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to get usage stats")


### PR DESCRIPTION
## Summary

Implements **Distributed Nodes BE-7** — the admin nodes API from `docs/design/distributed-nodes.md` ("Node registration → Admin API"), building on the merged store nodes CRUD, registry, poller, nodesource, and BE-6 routing integration.

### Endpoints (all under the existing X-Admin-Key/session auth, rate limiting, and JSON body cap)

| Method | Path | Behavior |
|--------|------|----------|
| `POST` | `/api/admin/nodes` | Validate via store validators (400 w/ message), insert, **synchronous initial probe**, 201 with masked node + live state. Name conflict → 409 `node_name_exists`. |
| `GET` | `/api/admin/nodes` | Masked config joined with live registry state; unprobed nodes read `health: "unknown"`, `models: []`. Envelope + pagination like other lists. |
| `GET` | `/api/admin/nodes/{id}` | Single-node detail, same joined shape. |
| `PUT` | `/api/admin/nodes/{id}` | PATCH-like mutable-field update on the raw row, synchronous re-probe. Config-sourced → 409 pointing at NODES_FILE. |
| `DELETE` | `/api/admin/nodes/{id}` | Soft-delete (`DisableNode`) + synchronous registry reconcile — the node is out of routing before the 204 returns. Config-sourced → 409. |
| `POST` | `/api/admin/nodes/{id}/refresh` | Forced probe + rediscovery; returns fresh live state. |

Unknown node IDs → 404 on GET/PUT/DELETE/refresh.

### PUT `auth_header` semantics (documented on `updateNodeRequest`)

`absent` (or JSON `null`) = **keep**, `""` = **clear**, value = **replace**. The handler loads via `GetNodeWithSecrets` so the masked read never round-trips into `UpdateNode`'s full-row write. `health_path` ("" = clear), `static_models` (`[]` = back to discovery), and `timeout_seconds` (`0` = default) follow the same keep/clear/replace contract; `enabled: true` can re-enable a deleted node.

### Poller: `RefreshNode(ctx context.Context, nodeID int64) error`

Reloads the node set from the DB (immediate registry reconcile — the ~15s periodic re-read is the fallback, not the contract), probes the target node once with the normal probe machinery/timeout, and publishes the outcome before returning. Decisive startup-sweep semantics (one failure = unhealthy). For a disabled/absent node the reload **is** the refresh: it drops the node from routing synchronously. Safe to call concurrently with `Run` (covered by a `-race` test hammering it during the poll loop); probe internals stay unexported.

### Also

- `/api/admin/usage` gains an optional `node_id` filter (`store.GetUsageStats` grew a `nodeID *int64` param alongside `key_id`/`since`).
- `/api/admin/health` gains an **additive** per-node breakdown (`name`, `health`, `last_error`, `last_checked_at`, `model_count`) plus `"warning": "no nodes configured"` when zero nodes are enabled.
- `/api/admin/config` reports `nodes_file` (empty when unset).
- `store.ValidateNode` exported so handlers surface validation failures as 400 with the validator's message.

### Security

Every response is built from the store's **masked** reads; tests assert raw `auth_header` secrets never appear in any response body (create/list/update paths).

## Testing

- TDD: endpoint tests written first in `internal/admin/nodes_test.go` (full-stack: real Postgres store + registry + poller + httptest backends) and `internal/poller/refresh_test.go`.
- Coverage: every endpoint success, validation failures, 409 config-sourced, 409 name conflict, 404 unknown id, masking in all responses, keep/replace/clear auth_header, refresh returns fresh state, DELETE drops the node from the registry snapshot, usage `node_id` filter (store + HTTP), health per-node section + zero-node warning, `RefreshNode` concurrent with `Run` under `-race`.
- `go test -race -count=1 -p 1 ./...` → **835 passed, 20 packages** (dedicated `test_laip_be7` database).
- `gofmt` clean, `go vet ./...` clean, `CGO_ENABLED=0 go build ./cmd/proxy` OK. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSYCn4mZxomD5Aauu5hJPr