### PR TITLE
docs: multi-node operation guide and self-hosting packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Go
 /vendor/
 
+# Tooling output
+graphify-out/
+
 # IDE
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,31 @@
 # local-ai-proxy
 
-An OpenAI-compatible reverse proxy to Ollama with API key authentication, per-key rate limiting, usage tracking, and user management. Deployed to k3s at `ai.kinvee.in/api`. All routes are under the `/api` prefix, leaving `ai.kinvee.in/` free for the frontend.
+An OpenAI-compatible gateway for self-hosted inference: API key authentication, per-key rate limiting, credit-based usage accounting, user management, and model-aware routing across multiple backend nodes (Ollama or any OpenAI-compatible server). All routes are under the `/api` prefix, leaving the root path free for a frontend.
 
 ## Architecture
 
 ```
-Client → RequestID → CORS → Auth → CreditGate → RateLimit → Proxy → Ollama
-                                                                ↓
-                                                    Async Usage Logger → PostgreSQL
+Client → RequestID → CORS → Auth → CreditGate → RateLimit → Proxy
+                                                              │ Resolve(model)
+                                                              ▼
+                                                        Node Registry ──► Node "workstation" (ollama)
+                                                              │      ──► Node "gpu-box"     (ollama)
+                                                              │      ──► Node "cloud"       (openai_compat)
+                                                              ▼
+                                                  Async Usage Logger → PostgreSQL
 ```
 
-Internal packages: `config`, `auth`, `store`, `ratelimit`, `proxy`, `middleware`, `admin`, `user`, `credits`, `logging`, `requestid`, `health`, `metrics`, `apierror` — all using stdlib `net/http`, no frameworks.
+The gateway routes each chat request **by model name** to a healthy backend node:
+
+- **Node registry** (`internal/registry`) — an in-memory model→nodes routing map, published as an immutable snapshot (`atomic.Pointer`, copy-on-write). Multiple healthy nodes serving the same model are round-robined.
+- **Health poller** (`internal/poller`) — probes every enabled node on a ~15s interval (±20% deterministic per-node jitter, 5s per-probe timeout, 1MB response cap, redirects refused). For `ollama` nodes one `GET {base_url}/api/tags` request is both liveness check and model discovery; for `openai_compat` nodes it is `GET {base_url}/v1/models`. Nodes with `static_models` are only health-checked (2xx = alive) and their configured list stays authoritative.
+- **Startup discovery sweep** — before the HTTP listener opens, all enabled nodes are probed in parallel under a bounded budget (5s per probe, ~6s overall), so restarts route deterministically. There is no optimistic routing: a node is only routable once a probe (or its static list) has established what it serves.
+- **Health hysteresis** — in the running poller a node goes `healthy → unhealthy` only after **2 consecutive probe failures** (no flapping on one timeout); any success is immediately healthy. The startup sweep and admin-triggered probes are decisive on a single failure.
+- **Immediate probe on admin writes** — creating, updating, or refreshing a node via the admin API probes it synchronously before the response returns; deleting a node removes it from routing before the response returns.
+
+Everything else — auth, credits, rate limiting, usage accounting — stays in the gateway against the single shared Postgres. There is exactly one gateway process by design (see Known Gaps).
+
+Internal packages: `config`, `auth`, `authlimit`, `store`, `ratelimit`, `proxy`, `registry`, `poller`, `nodesource`, `middleware`, `admin`, `user`, `credits`, `bootstrap`, `logging`, `requestid`, `health`, `metrics`, `apierror` — all using stdlib `net/http`, no frameworks.
 
 ## Endpoints
 
@@ -18,17 +33,19 @@ Internal packages: `config`, `auth`, `store`, `ratelimit`, `proxy`, `middleware`
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/v1/chat/completions` | Proxied to Ollama with usage tracking (streaming + non-streaming) |
-| `GET` | `/api/v1/models` | Lists models with active pricing |
+| `POST` | `/api/v1/chat/completions` | Routed to a healthy node serving the requested model (streaming + non-streaming), with usage tracking |
+| `GET` | `/api/v1/models` | Lists models with active pricing **and** at least one healthy node serving them (set `MODELS_LIST_ALL=true` to list the full priced catalog); `owned_by` is the node name, or `multiple` |
 
 ### Health & Observability
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/healthz/live` | Liveness probe — always 200 |
-| `GET` | `/api/healthz/ready` | Readiness probe — checks DB, Ollama, usage writer |
+| `GET` | `/api/healthz/ready` | Readiness probe — checks DB, node registry, usage writer (see below) |
 | `GET` | `/api/healthz` | Alias for `/api/healthz/live` (backward compat) |
 | `GET` | `/metrics` | Prometheus metrics endpoint |
+
+Readiness = DB ok **and** usage writer ok **and** (*zero enabled nodes* **or** *at least one healthy node*). Zero enabled nodes is deliberately *ready* — a fresh install must be able to serve the admin API to register its first node (the `nodes` check reports `"detail": "no nodes configured"`). Readiness reads the registry snapshot only; it never probes backends synchronously.
 
 ### Auth API (public + session-authenticated)
 
@@ -50,49 +67,121 @@ Internal packages: `config`, `auth`, `store`, `ratelimit`, `proxy`, `middleware`
 | `DELETE` | `/api/users/keys/{id}` | Revoke user's API key |
 | `GET` | `/api/users/usage` | Get usage stats for user's keys |
 
-### Admin (authenticated via `X-Admin-Key` header, rate limited to 10 req/min)
+### Admin (authenticated via `X-Admin-Key` header — rate limited to 10 req/min — or an admin Bearer session)
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/api/admin/keys` | Create API key (`{name, rate_limit}`) — returns full key once, never retrievable again |
 | `GET` | `/api/admin/keys` | List all keys (id, name, key_prefix, rate_limit, created_at, revoked) |
+| `GET` | `/api/admin/keys/{id}` | Key detail |
+| `PUT` | `/api/admin/keys/{id}/rate-limit` | Update a key's rate limit |
+| `PUT` | `/api/admin/keys/{id}/session-limit` | Set/clear a key's session token limit |
 | `DELETE` | `/api/admin/keys/{id}` | Revoke (soft-delete) a key |
-| `GET` | `/api/admin/usage` | Aggregated usage stats (filterable by `key_id` and `since`) |
+| `GET` | `/api/admin/usage` | Aggregated usage stats (filterable by `key_id`, `since`, and `node_id`) |
+| `GET` | `/api/admin/usage/summary` \| `/by-model` \| `/by-user` \| `/timeseries` | Usage analytics |
 | `GET` | `/api/admin/users` | List all users |
-| `PUT` | `/api/admin/users/{id}/activate` | Activate a user account |
-| `PUT` | `/api/admin/users/{id}/deactivate` | Deactivate a user account |
+| `GET` | `/api/admin/users/{id}` | User detail |
+| `PUT` | `/api/admin/users/{id}/activate` \| `/deactivate` \| `/role` | User mutations |
+| `GET` | `/api/admin/accounts` | List accounts (credit balances) |
+| `POST` | `/api/admin/accounts/{id}/credits` | Grant credits |
+| `POST` | `/api/admin/accounts/{id}/keys` | Create a key bound to an account |
+| `GET`/`POST` | `/api/admin/pricing` | List / upsert model pricing (`{model_id, prompt_rate, completion_rate, typical_completion}`) |
+| `DELETE` | `/api/admin/pricing/{id}` | Deactivate pricing |
+| `GET`/`POST`/`DELETE` | `/api/admin/registration-tokens` | Manage service-registration tokens |
+| `GET` | `/api/admin/registrations` | Registration audit feed |
+| `GET` | `/api/admin/config` | Effective config snapshot (includes `models_list_all`, `nodes_file`) |
+| `GET` | `/api/admin/health` | Component health: db, **nodes** (total/healthy counts), usage writer, uptime |
+| `POST` | `/api/admin/bootstrap` | One-time first-admin bootstrap (404 unless `ADMIN_BOOTSTRAP_TOKEN` is set) |
+
+#### Node management
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/admin/nodes` | Register a node `{name, base_url, backend_type?, auth_header?, static_models?, health_path?, timeout_seconds?}` — probed synchronously; the 201 response includes initial health |
+| `GET` | `/api/admin/nodes` | List nodes: stored config joined with live state |
+| `GET` | `/api/admin/nodes/{id}` | Node detail |
+| `PUT` | `/api/admin/nodes/{id}` | Update mutable fields (API-sourced nodes only), then re-probe synchronously |
+| `DELETE` | `/api/admin/nodes/{id}` | Disable the node (soft-delete) and remove it from routing before returning (204) |
+| `POST` | `/api/admin/nodes/{id}/refresh` | Force an immediate probe + model rediscovery |
+
+Response conventions:
+
+- List and detail responses use the `{"data": ...}` envelope (lists add `"pagination": {limit, offset, total}`). `?envelope=0` opts out for one deprecation release.
+- `auth_header` is always **masked** in responses (e.g. `"Bearer sk-…abcd"`) — the raw value is write-only.
+- Every node response carries live state alongside stored config: `health` (`healthy` / `unhealthy` / `unknown`), `models` (discovered or static list), `last_error`, `last_checked_at`.
+- `PUT` is PATCH-like — omitted fields keep their current value:
+  - `auth_header`: absent = keep, `""` = clear, value = replace
+  - `health_path`: absent = keep, `""` = clear, value = replace
+  - `static_models`: absent/null = keep, `[]` = clear (switch back to probe discovery), non-empty = replace
+  - `timeout_seconds`: absent = keep, `0` = clear (use the 5-minute default), positive = replace
+  - `enabled`: absent = keep; `true` re-enables a previously deleted node
+- Config-sourced nodes (from `NODES_FILE` / `OLLAMA_URL`) are **read-only via the API**: `PUT`/`DELETE` return `409 config_sourced_node` pointing at the file.
+
+## Node registration
+
+Nodes come from two coexisting sources: a static JSON file (`NODES_FILE`, the compose/self-hoster path) and the admin API (the dynamic path).
+
+### `NODES_FILE`
+
+```json
+{
+  "nodes": [
+    { "name": "workstation", "base_url": "http://192.0.2.10:11434", "backend_type": "ollama",
+      "timeout_seconds": 900 },
+    { "name": "gpu-box", "base_url": "http://ollama.example.internal:11434", "backend_type": "ollama" },
+    { "name": "cloud", "base_url": "https://api.example.com", "backend_type": "openai_compat",
+      "auth_header": "Bearer ${CLOUD_KEY}", "static_models": ["gpt-4o-mini"] }
+  ]
+}
+```
+
+- `${VAR}` references (braced form only) in any string value are expanded from the environment at load time, so secrets stay out of the file. Referencing an **undefined** variable fails startup with an error naming the variable.
+- The file is parsed strictly: unknown fields, duplicate node names, and trailing data after the JSON document all fail startup fast.
+- `backend_type` defaults to `"ollama"`. `static_models` (non-empty) disables discovery — the list is authoritative and the node is only health-checked (`health_path` if set, else the backend type's discovery endpoint; only the status code is used).
+- `base_url` is the backend's **API root, excluding the `/v1` segment** — the gateway path-joins `/v1/chat/completions`, `/v1/models`, or `/api/tags` onto it (a prefix like `https://host/openai` is preserved). Scheme must be `http`/`https`; userinfo, query, and fragment are rejected; a `base_url` ending in `/v1` is rejected with a hint.
+
+**Merge semantics at startup** (idempotent):
+
+- Declared nodes are upserted by `name` with `source="config"`.
+- Config-sourced nodes in the DB that are no longer declared are **disabled** (never hard-deleted; usage rows reference them).
+- API-sourced nodes are never touched by file loading — but a `name` collision between the file and an API-sourced node **fails startup** with a clear error.
+
+### `OLLAMA_URL` (single-node shortcut) — breaking change
+
+> **BREAKING**: the implicit `http://localhost:11434` default is **gone**. Older releases assumed a localhost Ollama when `OLLAMA_URL` was unset; now an unset `OLLAMA_URL` means **zero nodes**. If you relied on the implicit default, set `OLLAMA_URL=http://localhost:11434` explicitly — one line.
+
+- `OLLAMA_URL` explicitly set → a config-sourced node named `default` (`backend_type: "ollama"`) is synthesized from it at startup and merges exactly like a file node. Existing single-node deployments that set the variable upgrade with zero config changes. (Declaring another node named `default` in `NODES_FILE` at the same time is a startup error.)
+- `OLLAMA_URL` unset → no synthesis, ever. A `NODES_FILE`-only install gets exactly the nodes it declared; a fresh install starts with zero nodes — which is *ready*, so the admin API is available to register the first node via `POST /api/admin/nodes`. Chat requests return `503 model_unavailable` until a node serves the requested model.
 
 ## Request Flow
 
+The middleware chain (auth → credit gate → rate limit) runs before routing, so `401`/`402`/`429` always precede `503 model_unavailable`. Within the proxy handler, order matters:
+
+1. Body read into memory (capped by `MAX_REQUEST_BODY`) and validated: malformed JSON or a missing/empty `model` → `400` (OpenAI-shaped `invalid_request_error`).
+2. Pricing check (credit-backed keys only): unpriced model → `400 unknown_model`; session token limit checked.
+3. **`Resolve(model)`** against the registry snapshot: no healthy node serving the model → `503 model_unavailable`. Resolution happens **before** any credit hold, so node outages cause zero hold churn.
+4. Credits reserved (credit-backed keys only).
+5. Forward to `{node.base_url}/v1/chat/completions` with the node's `auth_header` (the client's own `Authorization` is stripped and never forwarded) under the node's timeout budget (`timeout_seconds`, default 5 minutes, applied as a per-request context deadline).
+
+The upstream client never follows redirects (a redirect with `auth_header` attached could exfiltrate node credentials — a redirecting upstream fails the request), and non-streaming/error response bodies are read through the `MAX_REQUEST_BODY` cap.
+
 ### Non-Streaming (`stream=false` or omitted)
 
-1. Request passes through CORS, auth, and rate limit middleware
-2. Request body read into memory (capped by `MAX_REQUEST_BODY`)
-3. Body peeked to extract model name and stream flag
-4. Reverse proxy forwards to Ollama
-5. `ModifyResponse` hook intercepts response, parses JSON for token usage
-6. Usage entry sent to async channel (non-blocking; drops if buffer full)
-7. Response written to client unchanged
+Response body read (capped), token usage parsed from the JSON, credits settled against the hold, usage entry queued, response written to the client unchanged.
 
 ### Streaming (`stream=true`)
 
-1. Request passes through middleware, body peeked for model name
-2. Direct HTTP connection established to Ollama
-3. Response streamed line-by-line via `bufio.Reader`
-4. Each `data: {...}` line observed for usage object (non-destructive parsing)
-5. Lines flushed to client immediately for SSE delivery
-6. On EOF/error, status logged as completed, partial, or error
-7. Usage entry sent to async channel
+Response streamed line-by-line via `bufio.Reader`; each `data: {...}` line is observed for a usage object (non-destructive) and flushed to the client immediately for SSE delivery. On EOF/error, status is logged as completed, partial, or error; credits settled from observed (or byte-estimated) usage.
 
 ### Async Usage Logging
 
-All requests write to a buffered channel (capacity 1000). A dedicated goroutine drains the channel and calls `store.LogUsage()`. On shutdown, the channel is closed and remaining entries are drained.
+All requests write to a buffered channel (capacity 1000). A dedicated goroutine drains the channel and calls `store.LogUsage()`. Every entry records the `node_id` of the node that served it (NULL when no node was resolved). On shutdown, the channel is closed and remaining entries are drained.
 
 ## Database
 
 PostgreSQL via pgx/v5 connection pool. Schema auto-migrated on startup via embedded SQL.
 
-### Schema
+### Schema (excerpt — see `internal/store/schema.sql` for the full schema, including accounts, credits, pricing, and sessions)
 
 ```sql
 api_keys (
@@ -103,7 +192,8 @@ api_keys (
   rate_limit  INTEGER NOT NULL DEFAULT 60,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   revoked     BOOLEAN NOT NULL DEFAULT FALSE,
-  user_id     BIGINT REFERENCES users(id)  -- NULL = legacy admin-created key
+  user_id     BIGINT REFERENCES users(id),  -- NULL = admin-created key
+  account_id  BIGINT REFERENCES accounts(id) -- NULL = key not credit-backed
 )
 
 usage_logs (
@@ -115,7 +205,26 @@ usage_logs (
   total_tokens      INTEGER NOT NULL DEFAULT 0,
   duration_ms       BIGINT NOT NULL DEFAULT 0,
   status            TEXT NOT NULL DEFAULT 'completed',
+  node_id           BIGINT REFERENCES nodes(id), -- node attribution; NULL = pre-routing rows
   created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)
+
+nodes (
+  id            BIGSERIAL PRIMARY KEY,
+  name          TEXT NOT NULL UNIQUE,
+  base_url      TEXT NOT NULL,
+  backend_type  TEXT NOT NULL DEFAULT 'ollama'
+                CHECK (backend_type IN ('ollama', 'openai_compat')),
+  auth_header   TEXT,            -- optional Authorization value sent to the node
+  static_models TEXT[],          -- non-NULL disables model discovery; exact list
+  health_path   TEXT,            -- optional liveness-probe path override
+  timeout_seconds INTEGER        -- optional per-node request timeout (NULL = default)
+                CHECK (timeout_seconds IS NULL OR timeout_seconds > 0),
+  enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+  source        TEXT NOT NULL DEFAULT 'api'
+                CHECK (source IN ('api', 'config')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )
 
 users (
@@ -128,15 +237,9 @@ users (
   created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )
-
-user_sessions (
-  id         BIGSERIAL PRIMARY KEY,
-  user_id    BIGINT NOT NULL REFERENCES users(id),
-  token_hash TEXT NOT NULL UNIQUE,
-  expires_at TIMESTAMPTZ NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-)
 ```
+
+Discovered model lists are deliberately **not** persisted — they are runtime state, re-derived by the startup sweep and the poller (`static_models` covers nodes where discovery is undesired).
 
 ## Configuration
 
@@ -146,10 +249,14 @@ All configuration via environment variables:
 |----------|---------|-------------|
 | `ADMIN_KEY` | *(required)* | Admin API authentication key |
 | `DATABASE_URL` | *(required)* | PostgreSQL connection string |
-| `OLLAMA_URL` | *(none)* | Optional single-node shortcut: when set, a config-sourced node named `default` is synthesized from it at startup; unset means no synthesized node (a fresh install starts with zero nodes and chat requests 503 until a node is registered) |
+| `OLLAMA_URL` | *(none)* | Optional single-node shortcut: when set, a config-sourced node named `default` is synthesized from it at startup; when unset there is **no** synthesized node — a fresh install starts with zero nodes (see Node registration; the old localhost default is gone) |
+| `NODES_FILE` | *(none)* | Path to a JSON node-declaration file (see Node registration) |
+| `MODELS_LIST_ALL` | `false` | `GET /v1/models` lists every actively priced model instead of the priced-AND-served intersection |
+| `ADMIN_BOOTSTRAP_TOKEN` | *(none)* | Enables `POST /api/admin/bootstrap` (one-time first-admin creation) when set |
+| `DEFAULT_CREDIT_GRANT` | `0` | Credits granted to newly registered accounts |
 | `PORT` | `8080` | Server listen port |
 | `CORS_ORIGINS` | `*` | Allowed CORS origins |
-| `MAX_REQUEST_BODY` | `52428800` (50MB) | Max request body size in bytes (chat proxy path) |
+| `MAX_REQUEST_BODY` | `52428800` (50MB) | Max request body size in bytes (chat proxy path); also caps upstream non-streaming/error response reads |
 | `MAX_JSON_REQUEST_BODY` | `1048576` (1MB) | Max body size for JSON API endpoints (auth/users/accounts/admin) |
 | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | `AUTH_RATELIMIT_LOGIN_PER_MIN` | `5` | Login attempts per minute per client IP |
@@ -160,45 +267,49 @@ All configuration via environment variables:
 
 ## Deployment
 
-Multi-stage Docker build (`deploy/Dockerfile`) with k8s manifests in `deploy/k8s/`. CI/CD pipeline: GitHub Actions → Tailscale → SSH to dev server → Docker build → k3s rollout.
+Multi-stage Docker build (`deploy/Dockerfile`); a complete self-hosting example (gateway + Postgres + two Ollama nodes) lives in [`deploy/examples/`](deploy/examples/), and [`docs/deployment.md`](docs/deployment.md) covers multi-machine topologies (k3s, native macOS, overlay networks) and Ollama tuning. Reference k8s manifests are in `deploy/k8s/`.
 
 ```bash
 # Build
 CGO_ENABLED=0 go build -ldflags="-s -w" -o proxy ./cmd/proxy
 
-# Run
-ADMIN_KEY=your-key DATABASE_URL=postgres://... ./proxy
+# Run (single-node shortcut)
+ADMIN_KEY=your-key DATABASE_URL=postgres://... OLLAMA_URL=http://localhost:11434 ./proxy
 
 # Docker
-docker build -f deploy/Dockerfile -t ai-proxy .
+docker build -f deploy/Dockerfile -t local-ai-proxy .
 ```
+
+> Backends are unauthenticated by default (Ollama has no auth). Never expose a node on an untrusted network without a reverse proxy + token (`auth_header` supports this) or a private overlay network — see `docs/deployment.md`.
 
 ## Strengths
 
 - Clean package separation with proper middleware chaining
+- Model-aware routing across N backend nodes with health checking, discovery, and round-robin
 - Async usage logging via buffered channel — non-blocking to requests
 - Streaming SSE support with line-by-line token extraction
-- Auth strips Bearer token before forwarding to Ollama (no key leakage)
-- User registration and session management
-- Full k3s deployment pipeline
-- Test coverage across all packages
+- Upstream hardening: redirects refused, response caps, per-node timeouts, header-injection validation
+- Auth strips the client's Bearer token before forwarding (no key leakage); per-node `auth_header` for protected backends
+- User registration, session management, credit accounting
+- Test coverage across all packages (including `-race` on the registry)
 
 ## Known Gaps
 
 | Area | Issue |
 |------|-------|
 | Endpoints | Only chat completions + models; no embeddings, completions, or images |
-| Rate limiting | In-memory only — resets on restart |
-| Validation | Request body forwarded as-is, no schema checks |
-| Scale | Single replica, no multi-backend support |
+| Scale | Exactly one gateway replica by design — rate limiting is in-memory (correct with a single gateway, resets on restart); multi-gateway needs shared rate-limit state |
+| Routing | Round-robin only; no weighted/least-loaded balancing, model aliases, or fallback chains yet |
+| Nodes | Gateway must reach nodes over the network (inbound HTTP); no push-mode agents for NAT'd machines |
+| Validation | Model name and JSON shape are validated; the rest of the request body is forwarded as-is, no schema checks |
 | Storage | No backup strategy, soft-delete only (unbounded growth) |
-| Streaming | Token extraction is fragile — silently fails if Ollama changes SSE format |
+| Streaming | Token extraction is fragile — silently fails if a backend changes its SSE format |
 
 ## Observability
 
 ### Structured Logging
 
-All logs are JSON to stdout via `slog`, collected by Alloy and shipped to Loki. Every log entry within an HTTP request includes `request_id` automatically via a context-aware slog handler.
+All logs are JSON to stdout via `slog`, ready for any log collector. Every log entry within an HTTP request includes `request_id` automatically via a context-aware slog handler. Routing decisions are logged at debug level with `request_id`, `model`, and `node`; node health transitions are logged at info level.
 
 ### Request IDs
 
@@ -216,8 +327,9 @@ Available at `GET /metrics`. Key metrics:
 |--------|------|-------------|
 | `aiproxy_request_duration_seconds` | Histogram | HTTP request latency |
 | `aiproxy_requests_total` | Counter | Total HTTP requests |
-| `aiproxy_tokens_total` | Counter | Tokens processed (by model, prompt/completion) |
+| `aiproxy_tokens_total` | Counter | Tokens processed (by model, node, prompt/completion) |
+| `aiproxy_node_up` | Gauge | Per-node health (`{node="name"}`), updated on every probe |
+| `aiproxy_ollama_up` | Gauge | Legacy: OR of all node states (kept for one release, then removed) |
 | `aiproxy_credit_gate_rejects_total` | Counter | Requests rejected by credit gate |
 | `aiproxy_ratelimit_rejects_total` | Counter | Requests rejected by rate limiter |
 | `aiproxy_usage_channel_depth` | Gauge | Async usage channel depth |
-| `aiproxy_ollama_up` | Gauge | Ollama reachability (updated on readiness check) |

--- a/deploy/examples/README.md
+++ b/deploy/examples/README.md
@@ -1,0 +1,133 @@
+# Self-hosting example
+
+A complete local stack: the gateway, Postgres, and two Ollama backend nodes
+declared via `NODES_FILE` (`nodes.json`).
+
+- **ollama-a** — plain auto-discovery node: the gateway probes `GET /api/tags`
+  and routes to whatever models you pull into it.
+- **ollama-b** — demonstrates `static_models`: discovery is disabled, the
+  declared list (`llama3.2:1b`) is authoritative, and the gateway only
+  health-checks the node.
+
+Host ports are non-standard on purpose (gateway on **18080**) so the stack
+never collides with services already running on your machine.
+
+## 1. Start the stack
+
+```bash
+cd deploy/examples
+export ADMIN_KEY=$(openssl rand -hex 24)   # or any secret you like
+docker compose build
+docker compose up -d
+```
+
+Wait for readiness (DB ok + usage writer ok + at least one healthy node):
+
+```bash
+curl -s http://localhost:18080/api/healthz/ready | jq
+```
+
+Check what the gateway discovered — both nodes should be `healthy`
+(ollama-a with an empty `models` list until you pull something; ollama-b
+pinned to its static list):
+
+```bash
+curl -s -H "X-Admin-Key: $ADMIN_KEY" http://localhost:18080/api/admin/nodes | jq
+```
+
+## 2. Pull a model
+
+Pull a small model into the auto-discovery node:
+
+```bash
+docker compose exec ollama-a ollama pull smollm2:135m
+```
+
+The poller re-discovers models within ~15 seconds, or force it immediately
+(use the node `id` from the listing above):
+
+```bash
+curl -s -X POST -H "X-Admin-Key: $ADMIN_KEY" \
+  http://localhost:18080/api/admin/nodes/1/refresh | jq '.data.health, .data.models'
+```
+
+If you want to route to **ollama-b**, pull its declared model there first —
+with `static_models` the gateway trusts the list, it cannot verify it:
+
+```bash
+docker compose exec ollama-b ollama pull llama3.2:1b
+```
+
+## 3. Create an API key and chat
+
+```bash
+KEY=$(curl -s -X POST -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
+  -d '{"name":"demo","rate_limit":60}' http://localhost:18080/api/admin/keys | jq -r .key)
+
+curl -s http://localhost:18080/api/v1/chat/completions \
+  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
+  -d '{"model":"smollm2:135m","messages":[{"role":"user","content":"Say hi in five words."}]}' | jq
+```
+
+Admin-created keys are not bound to a credit account, so they bypass the
+credit gate and the pricing allowlist — handy for smoke tests.
+
+## 4. Pricing and `/v1/models`
+
+`GET /api/v1/models` lists the intersection of *actively priced* models and
+models *served by a healthy node*. The gateway seeds a default pricing
+catalog, but your model probably isn't in it — add pricing so it shows up:
+
+```bash
+curl -s -X POST -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
+  -d '{"model_id":"smollm2:135m","prompt_rate":0.001,"completion_rate":0.001,"typical_completion":300}' \
+  http://localhost:18080/api/admin/pricing
+
+curl -s -H "Authorization: Bearer $KEY" http://localhost:18080/api/v1/models | jq
+```
+
+Pricing is also **required** for any credit-backed key (keys created for user
+or service accounts): requests for unpriced models are rejected with `400
+unknown_model`, and the account needs a positive credit balance
+(`POST /api/admin/accounts/{id}/credits`, or set `DEFAULT_CREDIT_GRANT`).
+
+## 5. Per-node usage attribution
+
+Every usage row records which node served it:
+
+```bash
+curl -s -H "X-Admin-Key: $ADMIN_KEY" \
+  "http://localhost:18080/api/admin/usage?node_id=1" | jq
+```
+
+## Adding a cloud (OpenAI-compatible) node
+
+JSON does not allow comments, so the third-node example lives here instead of
+in `nodes.json`. Append this entry to the `nodes` array, set `CLOUD_KEY` in
+the gateway's environment (uncomment it in `docker-compose.yml`), and restart —
+`${VAR}` references are expanded from the environment at load time so the
+secret never lives in the file:
+
+```json
+{
+  "name": "cloud",
+  "base_url": "https://api.example.com",
+  "backend_type": "openai_compat",
+  "auth_header": "Bearer ${CLOUD_KEY}",
+  "static_models": ["gpt-4o-mini"]
+}
+```
+
+Note `base_url` excludes the `/v1` segment — the gateway appends it.
+
+## Cleanup
+
+```bash
+docker compose down -v   # -v also removes the Postgres and model volumes
+```
+
+## Going multi-machine
+
+See [`docs/deployment.md`](../../docs/deployment.md) for running nodes on
+separate machines: k3s pod patterns, native macOS (Apple Silicon) nodes,
+network topologies, and Ollama memory tuning.

--- a/deploy/examples/docker-compose.yml
+++ b/deploy/examples/docker-compose.yml
@@ -1,0 +1,111 @@
+# Self-hosting example: gateway + Postgres + two Ollama nodes.
+#
+# Host ports are deliberately non-standard (18080) or unbound so the stack
+# never collides with a Postgres/Ollama already running on the host. See
+# README.md in this directory for the full bootstrap walkthrough.
+
+name: local-ai-proxy-example
+
+services:
+  gateway:
+    build:
+      # Build from the repo's Dockerfile — no registry image required.
+      context: ../..
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "18080:8080"
+    environment:
+      ADMIN_KEY: ${ADMIN_KEY:-change-me-admin-key}
+      DATABASE_URL: postgres://proxy:proxy@postgres:5432/proxy?sslmode=disable
+      # Nodes are declared in nodes.json (mounted below). Deliberately no
+      # OLLAMA_URL: unset means no synthesized "default" node.
+      NODES_FILE: /etc/local-ai-proxy/nodes.json
+      LOG_LEVEL: info
+      # Secrets referenced as ${VAR} inside nodes.json are expanded from this
+      # environment. Uncomment when enabling the cloud node (see README.md):
+      # CLOUD_KEY: ${CLOUD_KEY}
+    volumes:
+      - ./nodes.json:/etc/local-ai-proxy/nodes.json:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      ollama-a:
+        condition: service_healthy
+      ollama-b:
+        condition: service_healthy
+    healthcheck:
+      # Readiness = DB ok + usage writer ok + at least one healthy node
+      # (or zero nodes configured).
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/api/healthz/ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 15s
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    # No host port binding: only the gateway needs to reach it. If you want
+    # host access for debugging, bind a high port, e.g. "15432:5432".
+    environment:
+      POSTGRES_USER: proxy
+      POSTGRES_PASSWORD: proxy
+      POSTGRES_DB: proxy
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U proxy -d proxy"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  # Node 1: plain auto-discovery. The gateway probes GET /api/tags every ~15s;
+  # whatever models you `ollama pull` here become routable automatically.
+  ollama-a:
+    image: ollama/ollama:latest
+    environment:
+      # Single-model node: keep the model resident in memory permanently
+      # instead of unloading after the default 5 minutes.
+      OLLAMA_KEEP_ALIVE: "-1"
+    volumes:
+      - ollama_a_models:/root/.ollama
+    # Host access is not required (the gateway reaches it on the compose
+    # network). For host-side debugging, bind a high port:
+    # ports:
+    #   - "21434:11434"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+  # Node 2: demonstrates static_models (see nodes.json). Discovery is
+  # disabled for this node; the gateway only health-checks it and trusts the
+  # declared model list. Pull the declared model here before routing to it:
+  #   docker compose exec ollama-b ollama pull llama3.2:1b
+  ollama-b:
+    image: ollama/ollama:latest
+    environment:
+      # Multi-model / low-memory node tuning: cap concurrent requests per
+      # model instead of pinning everything in memory.
+      OLLAMA_KEEP_ALIVE: 5m
+      OLLAMA_NUM_PARALLEL: "1"
+    volumes:
+      - ollama_b_models:/root/.ollama
+    # ports:
+    #   - "21435:11434"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  ollama_a_models:
+  ollama_b_models:

--- a/deploy/examples/nodes.json
+++ b/deploy/examples/nodes.json
@@ -1,0 +1,15 @@
+{
+  "nodes": [
+    {
+      "name": "ollama-a",
+      "base_url": "http://ollama-a:11434",
+      "backend_type": "ollama"
+    },
+    {
+      "name": "ollama-b",
+      "base_url": "http://ollama-b:11434",
+      "backend_type": "ollama",
+      "static_models": ["llama3.2:1b"]
+    }
+  ]
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,210 @@
+# Deployment guide: multi-node operation
+
+How to run the gateway and its backend nodes across real machines. For a
+single-machine quickstart, use [`deploy/examples/`](../deploy/examples/).
+
+A **node** is anything the gateway can reach over HTTP that speaks the Ollama
+API (`backend_type: "ollama"`) or the OpenAI API (`backend_type:
+"openai_compat"`). The gateway needs *inbound* HTTP reachability to every
+node — there are no push-mode agents (yet), so NAT'd machines must be reached
+via an overlay network or a reverse proxy.
+
+All hostnames and addresses below are placeholders (`example.internal`,
+`192.0.2.x`, `100.64.x.x`) — substitute your own.
+
+## The hard rule
+
+> **Never expose a bare Ollama (or any unauthenticated backend) to the public
+> internet.** Ollama has no authentication: anyone who can reach the port can
+> run inference, pull models, and delete models. Put every node either on a
+> private network (LAN, VPN, overlay) or behind a reverse proxy that enforces
+> a token — the gateway sends a per-node `auth_header` for exactly this.
+
+## Network patterns
+
+### Same host
+
+Gateway and node on one machine. Use `OLLAMA_URL=http://localhost:11434`
+(the single-node shortcut) or a `NODES_FILE` entry pointing at localhost.
+Inside Docker Compose, use service names (`http://ollama-a:11434`). From a
+container to a natively-running host process, use
+`http://host.docker.internal:11434` (Docker Desktop) or the host's LAN/bridge
+address (Linux).
+
+### LAN
+
+Nodes on a trusted private network:
+
+```json
+{ "name": "gpu-box", "base_url": "http://192.0.2.10:11434", "backend_type": "ollama" }
+```
+
+Bind Ollama to the LAN interface (`OLLAMA_HOST=0.0.0.0` on the node) and
+firewall the port to the gateway's address. "Trusted LAN" means *you* trust
+every device on it; on shared networks prefer an overlay.
+
+### WireGuard / Tailscale overlay
+
+The recommended pattern for machines in different locations (home
+workstation + cloud VM + laptop). Every machine joins the overlay and gets a
+stable private address; the gateway reaches nodes by that address, and
+nothing is exposed publicly:
+
+```json
+{ "name": "workstation", "base_url": "http://100.64.0.10:11434", "backend_type": "ollama",
+  "timeout_seconds": 900 }
+```
+
+Tailscale MagicDNS names (`http://workstation.example.ts.net:11434`) work
+too — the gateway resolves them like any hostname.
+
+### Reverse proxy with token (`auth_header`)
+
+When a node must be reachable over an untrusted network, front it with a
+reverse proxy (Caddy, nginx, Traefik) that terminates TLS and requires a
+bearer token, and give the gateway that token:
+
+```json
+{ "name": "remote-gpu", "base_url": "https://ollama.example.com",
+  "backend_type": "ollama", "auth_header": "Bearer ${REMOTE_GPU_TOKEN}" }
+```
+
+The gateway sends `auth_header` as the `Authorization` header on every probe
+and every forwarded request, never logs it, masks it on all admin reads, and
+never follows upstream redirects (so the credential cannot be exfiltrated by
+a redirecting endpoint). TLS with a private CA works via the standard
+`SSL_CERT_FILE` mechanism on the gateway.
+
+## Pattern: Ollama node on k3s/Kubernetes
+
+Suitable for Linux boxes with (or without) GPUs that are already cluster
+members. The important, non-obvious parts:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-gpu-box
+spec:
+  replicas: 1
+  # Recreate, NOT RollingUpdate: a rolling update briefly runs two pods, and
+  # two Ollama processes loading the same model will OOM a machine sized for
+  # one copy. Take the brief downtime instead.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: { app: ollama-gpu-box }
+  template:
+    metadata:
+      labels: { app: ollama-gpu-box }
+    spec:
+      # Pin the pod to the machine that owns the model storage and the
+      # memory/GPU budget. Models are multi-GB; you do not want the scheduler
+      # moving this pod and re-pulling everything.
+      nodeSelector:
+        kubernetes.io/hostname: gpu-box.example.internal
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          ports: [{ containerPort: 11434 }]
+          env:
+            - name: OLLAMA_KEEP_ALIVE
+              value: "-1"          # single-model node: keep it resident
+          resources:
+            # Be GENEROUS with memory limits. Ollama mmaps model files, and
+            # page-cache pages for mmap'd files are charged to the container's
+            # cgroup — so the limit must fit the model weights PLUS KV cache
+            # and runtime overhead, not just the process heap. A limit sized
+            # to "the process" gets the pod OOM-killed mid-load.
+            requests: { memory: "6Gi" }
+            limits:   { memory: "10Gi" }   # ~2x the model size is a sane start
+          volumeMounts:
+            - { name: models, mountPath: /root/.ollama }
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: ollama-gpu-box-models
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama-gpu-box
+spec:
+  selector: { app: ollama-gpu-box }
+  ports: [{ port: 11434, targetPort: 11434 }]
+```
+
+Model storage: use a node-local PV (`local-path` on k3s, or an explicit
+`hostPath`) so model blobs survive pod restarts and never traverse the
+network. With `nodeSelector` pinning, a node-local volume is exactly right —
+the pod can't move anyway.
+
+Register the node with the cluster-internal DNS name:
+
+```json
+{ "name": "gpu-box", "base_url": "http://ollama-gpu-box.models.svc.cluster.local:11434",
+  "backend_type": "ollama" }
+```
+
+(gateway inside the same cluster), or via the overlay/LAN address of the
+machine if the gateway runs elsewhere.
+
+## Pattern: native macOS (Apple Silicon)
+
+**Metal GPU acceleration is not available inside Linux containers or VMs.**
+Docker on macOS runs a Linux VM, so a containerized Ollama on a Mac is
+CPU-only — a waste of exactly the hardware that makes Apple Silicon machines
+good inference nodes. Run Ollama **natively** (`brew install ollama`, or the
+app) and register the machine as a node over your overlay/LAN:
+
+```bash
+# On the Mac: listen beyond localhost (choose the interface deliberately)
+launchctl setenv OLLAMA_HOST 0.0.0.0
+launchctl setenv OLLAMA_KEEP_ALIVE -1
+# restart the Ollama app / brew service after changing these
+```
+
+```json
+{ "name": "macbook", "base_url": "http://100.64.0.20:11434", "backend_type": "ollama",
+  "timeout_seconds": 600 }
+```
+
+Use the tailnet/VPN address, not a public one (see the hard rule). Laptops
+sleep and roam: expect the node to go `unhealthy` and come back — the gateway
+routes around it automatically and re-lists its models when it returns. Give
+big models on battery-throttled hardware a generous `timeout_seconds`.
+
+## Ollama tuning for gateway duty
+
+- **`OLLAMA_KEEP_ALIVE=-1` on single-model nodes.** The default unloads a
+  model after 5 idle minutes, so the first request after a quiet period eats
+  a full model load (tens of seconds). A node dedicated to one model should
+  keep it resident permanently.
+- **`OLLAMA_NUM_PARALLEL=1` (or 2) on low-memory multi-model nodes.** Each
+  parallel slot multiplies KV-cache memory. On a machine juggling several
+  models, cap parallelism so a burst of concurrent requests can't OOM it.
+- **Placement rule: never co-locate two hot models on a machine that cannot
+  hold both in memory simultaneously.** Two frequently-used models on one
+  box that fits only one means constant load/unload thrash — every switch
+  costs a full model load. Split hot models across nodes (the gateway routes
+  by model, so this is the natural topology) and reserve multi-model nodes
+  for machines with headroom or for cold/rarely-used models.
+- **`timeout_seconds`** (per node, in the registration): raise it well above
+  the default 5 minutes for slow CPU-only nodes running large models —
+  a long non-streaming completion can legitimately exceed the default.
+
+## Operational notes
+
+- **Health cadence**: every enabled node is probed roughly every 15s (±20%
+  per-node jitter). A node is marked unhealthy after 2 consecutive failures
+  and healthy again on the first success. `POST /api/admin/nodes/{id}/refresh`
+  forces an immediate probe.
+- **Gateway restarts** run a parallel discovery sweep (~6s budget) before the
+  listener opens, so routing is deterministic immediately; a node that misses
+  the sweep gets no traffic until its first successful poll.
+- **Zero nodes is a valid state**: the gateway reports ready and serves the
+  admin API so you can register the first node. Chat requests return
+  `503 model_unavailable` until a healthy node serves the model.
+- **Monitoring**: watch `aiproxy_node_up{node="..."}` (per-node gauge) and
+  the `nodes` section of `GET /api/admin/health`. Per-node usage attribution
+  is available via `GET /api/admin/usage?node_id=...`.


### PR DESCRIPTION
## Summary

BE-8, the final step of the distributed-nodes rollout (`docs/design/distributed-nodes.md`, rollout item 5). Documentation and OSS packaging only — **no Go behavior changes** (`go build ./...` clean; the only non-doc change is a `.gitignore` line).

Every documented flag, endpoint, and behavior was verified against the shipped code (config.go, registry, poller, nodesource, admin nodes handlers, proxy, health) — where the design doc and implementation differ, the docs follow the code.

### README rewrite (multi-node)
- Architecture: gateway + node registry + model routing, startup discovery sweep, health hysteresis (2 consecutive failures → unhealthy, first success → healthy), immediate synchronous probe on admin writes.
- Admin nodes API table + response conventions: `{data}` envelope (`?envelope=0` escape hatch), masked `auth_header`, live state fields, PUT keep/clear/replace semantics, config-sourced 409s.
- Node registration: full `NODES_FILE` example with `${VAR}` expansion rules, merge semantics (upsert by name, disable-on-removal, API-collision = startup error), `OLLAMA_URL` synthesis — with a prominent **breaking change** callout: the implicit `localhost:11434` default is gone; unset now means zero nodes.
- Config table verified row-by-row against `internal/config/config.go`; adds `NODES_FILE`, `MODELS_LIST_ALL`, `ADMIN_BOOTSTRAP_TOKEN`, `DEFAULT_CREDIT_GRANT`.
- Known Gaps refreshed (multi-backend no longer a gap; single-gateway rate limiting stated as by-design; routing/NAT gaps added). Personal infrastructure references removed.

### deploy/examples/ (new)
`docker-compose.yml` (gateway built from `deploy/Dockerfile`, Postgres, two Ollama nodes — one auto-discovery, one `static_models`), `nodes.json`, and a bootstrap-walkthrough README including the cloud-node `${CLOUD_KEY}` example (in the README because JSON has no comments). Non-conflicting high host ports; healthchecks; `OLLAMA_KEEP_ALIVE` tuning shown.

### docs/deployment.md (new)
k3s pod pattern (`Recreate` strategy, `nodeSelector` pinning, generous memory limits because mmap'd model files count against the cgroup, node-local PVs), native macOS pattern (Metal unavailable in Linux containers → run Ollama natively, register over the tailnet), network patterns (same-host / LAN / WireGuard-Tailscale / reverse-proxy+`auth_header`) with the never-expose-bare-Ollama rule, and Ollama tuning + hot-model placement. Documentation-range addresses only.

## Verification (compose example booted for real)

- `docker compose build && up -d` → gateway ready (`/api/healthz/ready` 200, nodes check `total:2, healthy:2`).
- `GET /api/admin/nodes` → both config-sourced nodes discovered from `NODES_FILE`; ollama-b pinned to its static list.
- Pulled `smollm2:135m` into ollama-a; `POST /api/admin/nodes/1/refresh` → immediate probe returned `healthy` + the new model.
- Chat completion through the gateway → 200 with token usage (admin-created key: bypasses credit gate as designed, no pricing needed).
- Usage attribution: `usage_logs` row has `node_id=1` (direct DB check); `GET /api/admin/usage?node_id=1` returns it, `node_id=2` returns empty.
- `/v1/models` intersection: empty before pricing, lists `smollm2:135m` with `owned_by: "ollama-a"` after `POST /api/admin/pricing`.
- `docker compose down -v`; pulled images removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSYCn4mZxomD5Aauu5hJPr