### PR TITLE
refactor(credits): admin keys attach to accounts, remove credit-gate bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Readiness = DB ok **and** usage writer ok **and** (*zero enabled nodes* **or** *
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/admin/keys` | Create API key (`{name, rate_limit}`) — returns full key once, never retrievable again |
+| `POST` | `/api/admin/keys` | Create API key (`{name, rate_limit, account_id?}`) — attaches to the given account (404 if unknown), or to the auto-created `admin-service` account when `account_id` is omitted; response includes `account_id`; returns full key once, never retrievable again |
 | `GET` | `/api/admin/keys` | List all keys (id, name, key_prefix, rate_limit, created_at, revoked) |
 | `GET` | `/api/admin/keys/{id}` | Key detail |
 | `PUT` | `/api/admin/keys/{id}/rate-limit` | Update a key's rate limit |
@@ -92,6 +92,14 @@ Readiness = DB ok **and** usage writer ok **and** (*zero enabled nodes* **or** *
 | `GET` | `/api/admin/config` | Effective config snapshot (includes `models_list_all`, `nodes_file`) |
 | `GET` | `/api/admin/health` | Component health: db, **nodes** (total/healthy counts), usage writer, uptime |
 | `POST` | `/api/admin/bootstrap` | One-time first-admin bootstrap (404 unless `ADMIN_BOOTSTRAP_TOKEN` is set) |
+
+#### Admin keys and the `admin-service` account
+
+Every API key is **account-backed and credit-gated** — there is no bypass. Admin-minted keys attach to an account like any other key:
+
+- `POST /api/admin/keys` with `account_id` binds the key to that existing account (same effect as `POST /api/admin/accounts/{id}/keys`).
+- Without `account_id`, the key attaches to the designated **`admin-service`** account, auto-created at startup with a one-time starting balance (`ADMIN_SERVICE_CREDIT_GRANT`, default 1,000,000 credits). Top it up any time via `POST /api/admin/accounts/{id}/credits`.
+- On upgrade, a startup backfill attaches all pre-existing NULL-account keys to their owner's account (user keys) or to `admin-service` (admin keys), so live keys keep working. Because those keys are now credit-gated, requests for **unpriced models return `400 unknown_model`** — add pricing for the models you serve (`POST /api/admin/pricing`).
 
 #### Node management
 
@@ -170,9 +178,9 @@ Pricing is also **required** for any credit-backed key (keys created for user or
 The middleware chain (auth → credit gate → rate limit) runs before routing, so `401`/`402`/`429` always precede `503 model_unavailable`. Within the proxy handler, order matters:
 
 1. Body read into memory (capped by `MAX_REQUEST_BODY`) and validated: malformed JSON or a missing/empty `model` → `400` (OpenAI-shaped `invalid_request_error`).
-2. Pricing check (credit-backed keys only): unpriced model → `400 unknown_model`; session token limit checked.
+2. Pricing check: unpriced model → `400 unknown_model`; session token limit checked. (All keys are credit-backed — the startup backfill attaches legacy NULL-account keys to the `admin-service` account.)
 3. **`Resolve(model)`** against the registry snapshot: no healthy node serving the model → `503 model_unavailable`. Resolution happens **before** any credit hold, so node outages cause zero hold churn.
-4. Credits reserved (credit-backed keys only).
+4. Credits reserved.
 5. Forward to `{node.base_url}/v1/chat/completions` with the node's `auth_header` (the client's own `Authorization` is stripped and never forwarded) under the node's timeout budget (`timeout_seconds`, default 5 minutes, applied as a per-request context deadline).
 
 The upstream client never follows redirects (a redirect with `auth_header` attached could exfiltrate node credentials — a redirecting upstream fails the request), and non-streaming/error response bodies are read through the `MAX_REQUEST_BODY` cap.
@@ -205,7 +213,7 @@ api_keys (
   created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   revoked     BOOLEAN NOT NULL DEFAULT FALSE,
   user_id     BIGINT REFERENCES users(id),  -- NULL = admin-created key
-  account_id  BIGINT REFERENCES accounts(id) -- NULL = key not credit-backed
+  account_id  BIGINT REFERENCES accounts(id) -- billing account; backfilled at startup, never NULL afterwards
 )
 
 usage_logs (
@@ -266,6 +274,7 @@ All configuration via environment variables:
 | `MODELS_LIST_ALL` | `false` | `GET /v1/models` lists every actively priced model instead of the priced-AND-served intersection |
 | `ADMIN_BOOTSTRAP_TOKEN` | *(none)* | Enables `POST /api/admin/bootstrap` (one-time first-admin creation) when set |
 | `DEFAULT_CREDIT_GRANT` | `0` | Credits granted to newly registered accounts |
+| `ADMIN_SERVICE_CREDIT_GRANT` | `1000000` | One-time starting balance for the auto-created `admin-service` account (applied at creation only — top up later via `POST /api/admin/accounts/{id}/credits`; must be >= 0) |
 | `PORT` | `8080` | Server listen port |
 | `CORS_ORIGINS` | `*` | Allowed CORS origins |
 | `MAX_REQUEST_BODY` | `52428800` (50MB) | Max request body size in bytes (chat proxy path); also caps upstream non-streaming/error response reads |

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -142,6 +142,24 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Ensure the admin service account exists and attach any remaining
+	// NULL-account API keys to it (idempotent). This removes the credit-gate
+	// bypass: every key — including admin-minted ones — is account-backed
+	// and metered. Live legacy keys keep working via the service account.
+	adminAccountID, err := db.EnsureAdminServiceAccount(cfg.AdminServiceCreditGrant)
+	if err != nil {
+		slog.Error("ensure admin service account error", "error", err)
+		os.Exit(1)
+	}
+	attached, err := db.BackfillAdminKeyAccounts(adminAccountID)
+	if err != nil {
+		slog.Error("backfill admin key accounts error", "error", err)
+		os.Exit(1)
+	}
+	if attached > 0 {
+		slog.Info("attached legacy API keys to accounts", "count", attached, "admin_account_id", adminAccountID)
+	}
+
 	// Backfill credit balances for accounts that lack one
 	if err := db.BackfillCreditBalances(); err != nil {
 		slog.Error("backfill credit balances error", "error", err)
@@ -246,6 +264,8 @@ func main() {
 		Metrics:   m,
 		Registry:  reg,
 		Refresher: nodePoller,
+
+		AdminServiceCreditGrant: cfg.AdminServiceCreditGrant,
 	})
 	bootstrapHandler := bootstrap.New(db, cfg.AdminBootstrapToken, m)
 	userHandler := user.NewHandler(db, cfg.DefaultCreditGrant, m, authGuard)

--- a/deploy/examples/README.md
+++ b/deploy/examples/README.md
@@ -58,7 +58,21 @@ with `static_models` the gateway trusts the list, it cannot verify it:
 docker compose exec ollama-b ollama pull llama3.2:1b
 ```
 
-## 3. Create an API key and chat
+## 3. Add pricing, create an API key, and chat
+
+Every key is credit-backed — including admin-created ones — so the model you
+want to chat with must be **priced** first:
+
+```bash
+curl -s -X POST -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
+  -d '{"model_id":"smollm2:135m","prompt_rate":0.001,"completion_rate":0.001,"typical_completion":300}' \
+  http://localhost:18080/api/admin/pricing
+```
+
+Now mint a key and chat. With no `account_id` in the request, the key attaches
+to the auto-created **`admin-service`** account, which starts with a generous
+balance (`ADMIN_SERVICE_CREDIT_GRANT`, default 1,000,000 credits) — so the
+smoke test needs no extra credit setup:
 
 ```bash
 KEY=$(curl -s -X POST -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
@@ -69,28 +83,25 @@ curl -s http://localhost:18080/api/v1/chat/completions \
   -d '{"model":"smollm2:135m","messages":[{"role":"user","content":"Say hi in five words."}]}' | jq
 ```
 
-Admin-created keys are not bound to a credit account, so they bypass the
-credit gate and the pricing allowlist — handy for smoke tests.
+To bind a key to a specific account instead (create the account via user or
+service registration, grant it credits, then mint), pass `"account_id": <id>`
+in the key request or use `POST /api/admin/accounts/{id}/keys`.
 
 ## 4. Pricing and `/v1/models`
 
 `GET /api/v1/models` lists the intersection of *actively priced* models and
 models *served by a healthy node*. The pricing catalog starts **empty** —
 nothing is seeded, and the gateway logs a startup warning while it stays
-that way — so add pricing for your model to make it show up:
+that way. Step 3 already added pricing for `smollm2:135m`, so it shows up:
 
 ```bash
-curl -s -X POST -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
-  -d '{"model_id":"smollm2:135m","prompt_rate":0.001,"completion_rate":0.001,"typical_completion":300}' \
-  http://localhost:18080/api/admin/pricing
-
 curl -s -H "Authorization: Bearer $KEY" http://localhost:18080/api/v1/models | jq
 ```
 
-Pricing is also **required** for any credit-backed key (keys created for user
-or service accounts): requests for unpriced models are rejected with `400
-unknown_model`, and the account needs a positive credit balance
-(`POST /api/admin/accounts/{id}/credits`, or set `DEFAULT_CREDIT_GRANT`).
+Pricing is **required** for every key: requests for unpriced models are
+rejected with `400 unknown_model`, and the key's account needs a positive
+credit balance (`POST /api/admin/accounts/{id}/credits`, or set
+`DEFAULT_CREDIT_GRANT` for newly registered accounts).
 
 ## 5. Per-node usage attribution
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -57,6 +57,12 @@ type handler struct {
 	// node mutations skip the synchronous probe.
 	nodeRegistry  NodeSnapshotter
 	nodeRefresher NodeRefresher
+
+	// OSS-2: initial credit grant applied if createKey has to create the
+	// admin service account (normally main.go creates it at startup, making
+	// this a no-op lookup). Zero in tests is fine — grants can be added via
+	// POST /api/admin/accounts/{id}/credits.
+	adminServiceCreditGrant float64
 }
 
 // NodeSnapshotter exposes the node registry's current routing state.
@@ -85,6 +91,10 @@ type Options struct {
 	// BE 7: node routing registry + poller for /api/admin/nodes.
 	Registry  NodeSnapshotter
 	Refresher NodeRefresher
+
+	// OSS-2: initial grant for the admin service account when created on
+	// demand (see handler.adminServiceCreditGrant).
+	AdminServiceCreditGrant float64
 }
 
 type adminSessionCtxKey struct{}
@@ -99,6 +109,11 @@ func AdminSessionFromContext(ctx context.Context) *store.Session {
 type createKeyRequest struct {
 	Name      string `json:"name"`
 	RateLimit int    `json:"rate_limit"`
+	// AccountID optionally attaches the key to an existing account. When
+	// omitted, the key attaches to the auto-created admin service account
+	// ("admin-service") — keys are always account-backed. Ignored by
+	// createAccountKey, where the path's account ID is authoritative.
+	AccountID *int64 `json:"account_id"`
 }
 
 type createKeyResponse struct {
@@ -107,6 +122,7 @@ type createKeyResponse struct {
 	Key       string `json:"key"`
 	KeyPrefix string `json:"key_prefix"`
 	RateLimit int    `json:"rate_limit"`
+	AccountID int64  `json:"account_id"`
 }
 
 type keyResponse struct {
@@ -132,6 +148,8 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 		metrics:           opts.Metrics,
 		nodeRegistry:      opts.Registry,
 		nodeRefresher:     opts.Refresher,
+
+		adminServiceCreditGrant: opts.AdminServiceCreditGrant,
 	}
 
 	mux := http.NewServeMux()
@@ -320,7 +338,33 @@ func (h *handler) createKey(w http.ResponseWriter, r *http.Request) {
 	keyPrefix := rawKey[:11] // "sk-" + first 8 hex chars
 	keyHash := auth.HashKey(rawKey)
 
-	id, err := h.store.CreateKey(req.Name, keyHash, keyPrefix, req.RateLimit)
+	// Every admin-minted key attaches to an account so the credit gate can
+	// meter it: an explicit account_id wins; otherwise the designated admin
+	// service account (created on demand, idempotent).
+	var accountID int64
+	if req.AccountID != nil {
+		acct, err := h.store.GetAccountByID(*req.AccountID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "account lookup error", "error", err, "account_id", *req.AccountID)
+			proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to look up account")
+			return
+		}
+		if acct == nil {
+			proxy.WriteError(w, r, http.StatusNotFound, "account_not_found", "invalid_request_error", "Account not found")
+			return
+		}
+		accountID = acct.ID
+	} else {
+		var err error
+		accountID, err = h.store.EnsureAdminServiceAccount(h.adminServiceCreditGrant)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "ensure admin service account error", "error", err)
+			proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to resolve admin service account")
+			return
+		}
+	}
+
+	id, err := h.store.CreateKeyForAccountOnly(accountID, req.Name, keyHash, keyPrefix, req.RateLimit)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "create key error", "error", err)
 		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to create key")
@@ -335,6 +379,7 @@ func (h *handler) createKey(w http.ResponseWriter, r *http.Request) {
 		Key:       rawKey,
 		KeyPrefix: keyPrefix,
 		RateLimit: req.RateLimit,
+		AccountID: accountID,
 	})
 }
 
@@ -743,6 +788,7 @@ func (h *handler) createAccountKey(w http.ResponseWriter, r *http.Request) {
 		Key:       rawKey,
 		KeyPrefix: keyPrefix,
 		RateLimit: req.RateLimit,
+		AccountID: accountID,
 	})
 }
 

--- a/internal/admin/admin_keys_account_test.go
+++ b/internal/admin/admin_keys_account_test.go
@@ -1,0 +1,139 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// postAdminKey issues POST /api/admin/keys with the given JSON body.
+func postAdminKey(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/keys", bytes.NewBufferString(body))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAdmin_CreateKey_DefaultsToAdminServiceAccount(t *testing.T) {
+	h, s := setupAdminTest(t)
+
+	rec := postAdminKey(t, h, `{"name":"svc-default","rate_limit":30}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp createKeyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.AccountID <= 0 {
+		t.Fatalf("expected positive account_id in response, got %d", resp.AccountID)
+	}
+
+	acct, err := s.GetAccountByID(resp.AccountID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if acct == nil {
+		t.Fatal("expected account to exist")
+	}
+	if acct.Name != store.AdminServiceAccountName || acct.Type != "service" {
+		t.Errorf("expected the admin service account, got name=%q type=%q", acct.Name, acct.Type)
+	}
+
+	key, err := s.GetKeyByID(resp.ID)
+	if err != nil {
+		t.Fatalf("GetKeyByID: %v", err)
+	}
+	if key.AccountID == nil || *key.AccountID != resp.AccountID {
+		t.Errorf("expected key attached to account %d, got %v", resp.AccountID, key.AccountID)
+	}
+
+	// A second key without account_id reuses the same service account.
+	rec2 := postAdminKey(t, h, `{"name":"svc-default-2"}`)
+	if rec2.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+	var resp2 createKeyResponse
+	if err := json.Unmarshal(rec2.Body.Bytes(), &resp2); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp2.AccountID != resp.AccountID {
+		t.Errorf("expected same service account %d, got %d", resp.AccountID, resp2.AccountID)
+	}
+}
+
+func TestAdmin_CreateKey_WithExplicitAccountID(t *testing.T) {
+	h, s := setupAdminTest(t)
+
+	accID, _, err := s.RegisterUser("keyowner@example.com", "hash", "KeyOwner")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+
+	rec := postAdminKey(t, h, fmt.Sprintf(`{"name":"explicit","account_id":%d}`, accID))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp createKeyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.AccountID != accID {
+		t.Errorf("expected account_id %d, got %d", accID, resp.AccountID)
+	}
+
+	key, err := s.GetKeyByID(resp.ID)
+	if err != nil {
+		t.Fatalf("GetKeyByID: %v", err)
+	}
+	if key.AccountID == nil || *key.AccountID != accID {
+		t.Errorf("expected key attached to account %d, got %v", accID, key.AccountID)
+	}
+}
+
+func TestAdmin_CreateKey_UnknownAccountID_Returns404(t *testing.T) {
+	h, _ := setupAdminTest(t)
+
+	rec := postAdminKey(t, h, `{"name":"nope","account_id":999999}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown account, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdmin_CreateAccountKey_ResponseIncludesAccountID(t *testing.T) {
+	h, s := setupAdminTest(t)
+
+	accID, _, err := s.RegisterUser("acctkey@example.com", "hash", "AcctKey")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/api/admin/accounts/%d/keys", accID),
+		bytes.NewBufferString(`{"name":"bound"}`))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp createKeyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.AccountID != accID {
+		t.Errorf("expected account_id %d in response, got %d", accID, resp.AccountID)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,12 @@ type Config struct {
 	DefaultCreditGrant  float64
 	LogLevel            string
 
+	// AdminServiceCreditGrant is the credit balance the auto-created
+	// "admin-service" account starts with (applied once, at creation).
+	// Generous by default so upgrading deployments' legacy admin keys keep
+	// working; operators can lower it via ADMIN_SERVICE_CREDIT_GRANT.
+	AdminServiceCreditGrant float64
+
 	// Public auth-surface rate limits (requests per minute) and the global
 	// bcrypt concurrency cap. See internal/authlimit.
 	AuthLoginPerMinIP     int
@@ -87,6 +93,21 @@ func Load() (Config, error) {
 			return Config{}, fmt.Errorf("invalid DEFAULT_CREDIT_GRANT: %w", err)
 		}
 		defaultCreditGrant = n
+	}
+
+	// Initial balance for the auto-created admin service account. Defaults
+	// high (1M credits) so admin/smoke-test keys work out of the box; a
+	// negative value is a configuration error.
+	adminServiceCreditGrant := float64(1000000)
+	if v := os.Getenv("ADMIN_SERVICE_CREDIT_GRANT"); v != "" {
+		n, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid ADMIN_SERVICE_CREDIT_GRANT: %w", err)
+		}
+		if n < 0 {
+			return Config{}, fmt.Errorf("invalid ADMIN_SERVICE_CREDIT_GRANT: must be >= 0, got %v", n)
+		}
+		adminServiceCreditGrant = n
 	}
 
 	authLoginIP, err := intEnvOrDefault("AUTH_RATELIMIT_LOGIN_PER_MIN", 5)
@@ -145,6 +166,8 @@ func Load() (Config, error) {
 		MaxJSONBody:         maxJSONBody,
 		DefaultCreditGrant:  defaultCreditGrant,
 		LogLevel:            envOrDefault("LOG_LEVEL", "info"),
+
+		AdminServiceCreditGrant: adminServiceCreditGrant,
 
 		AuthLoginPerMinIP:     authLoginIP,
 		AuthLoginPerMinEmail:  authLoginEmail,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -382,3 +382,45 @@ func TestLoad_AuthRateLimitRejectsInvalid(t *testing.T) {
 		})
 	}
 }
+
+func TestLoad_AdminServiceCreditGrant_Default(t *testing.T) {
+	t.Setenv("ADMIN_KEY", "key")
+	t.Setenv("DATABASE_URL", "postgres://localhost/db")
+	t.Setenv("ADMIN_SERVICE_CREDIT_GRANT", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AdminServiceCreditGrant != 1000000 {
+		t.Errorf("expected default admin service grant 1000000, got %v", cfg.AdminServiceCreditGrant)
+	}
+}
+
+func TestLoad_AdminServiceCreditGrant_Custom(t *testing.T) {
+	t.Setenv("ADMIN_KEY", "key")
+	t.Setenv("DATABASE_URL", "postgres://localhost/db")
+	t.Setenv("ADMIN_SERVICE_CREDIT_GRANT", "2500.5")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AdminServiceCreditGrant != 2500.5 {
+		t.Errorf("expected admin service grant 2500.5, got %v", cfg.AdminServiceCreditGrant)
+	}
+}
+
+func TestLoad_AdminServiceCreditGrant_RejectsInvalid(t *testing.T) {
+	for _, v := range []string{"not-a-number", "-5"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("ADMIN_KEY", "key")
+			t.Setenv("DATABASE_URL", "postgres://localhost/db")
+			t.Setenv("ADMIN_SERVICE_CREDIT_GRANT", v)
+
+			if _, err := Load(); err == nil {
+				t.Fatalf("expected error for ADMIN_SERVICE_CREDIT_GRANT=%s", v)
+			}
+		})
+	}
+}

--- a/internal/credits/middleware.go
+++ b/internal/credits/middleware.go
@@ -11,13 +11,23 @@ import (
 
 // CreditGate is a fast pre-check middleware that rejects requests from
 // inactive accounts or accounts with zero/negative effective balance.
-// Keys without AccountID (legacy admin keys) pass through.
+// Every key must be attached to an account — there is no bypass. The
+// startup backfill (BackfillAdminKeyAccounts) attaches legacy NULL-account
+// keys to the admin service account, so a nil AccountID can only mean a
+// misprovisioned key; the gate fails closed on it.
 func CreditGate(db *store.Store, m *metrics.Metrics) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			key := auth.KeyFromContext(r.Context())
-			if key == nil || key.AccountID == nil {
+			if key == nil {
+				// No key in context: nothing to gate — authentication is the
+				// auth middleware's responsibility, not the credit gate's.
 				next.ServeHTTP(w, r)
+				return
+			}
+			if key.AccountID == nil {
+				m.RecordCreditGateReject()
+				apierror.WriteError(w, r, http.StatusForbidden, "account_required", "invalid_request_error", "API key is not attached to an account")
 				return
 			}
 

--- a/internal/credits/middleware_test.go
+++ b/internal/credits/middleware_test.go
@@ -74,14 +74,15 @@ func TestCreditGate_ErrorResponseFormat(t *testing.T) {
 	}
 }
 
-func TestCreditGate_NilAccountID_PassesThrough(t *testing.T) {
+func TestCreditGate_NilAccountID_Returns403(t *testing.T) {
+	// The legacy NULL-account bypass is gone: a key without an account is
+	// rejected, never waved through. Startup backfill guarantees this state
+	// cannot occur in a healthy deployment, so rejecting is fail-closed.
 	db := setupTestStore(t)
 	gate := CreditGate(db, nil)
 
-	called := false
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusOK)
+		t.Error("handler should not be called for nil AccountID")
 	}))
 
 	// Key without AccountID
@@ -91,11 +92,64 @@ func TestCreditGate_NilAccountID_PassesThrough(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
-	if !called {
-		t.Error("expected handler to be called for nil AccountID")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rec.Code)
 	}
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", rec.Code)
+	if rec.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("expected application/json content type")
+	}
+}
+
+func TestCreditGate_LegacyAdminKey_UpgradePath(t *testing.T) {
+	// Production upgrade scenario: a live admin-created key with NULL
+	// account_id (pre-upgrade it chatted via the old bypass). After the
+	// startup backfill it must chat again — attached to the admin service
+	// account, metered like every other key.
+	db := setupTestStore(t)
+	gate := CreditGate(db, nil)
+
+	rawHash := "legacy-hash-upgrade"
+	if _, err := db.CreateKey("legacy-admin", rawHash, "sk-legacy", 60); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	serve := func() (int, bool) {
+		called := false
+		handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		key, err := db.GetKeyByHash(rawHash)
+		if err != nil {
+			t.Fatalf("GetKeyByHash: %v", err)
+		}
+		if key == nil {
+			t.Fatal("expected key to exist")
+		}
+		req := httptest.NewRequest("GET", "/test", nil)
+		req = req.WithContext(auth.WithKey(req.Context(), key))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code, called
+	}
+
+	// Before the backfill runs, the gate fails closed.
+	if code, called := serve(); code != http.StatusForbidden || called {
+		t.Errorf("pre-backfill: expected 403 and handler not called, got %d called=%v", code, called)
+	}
+
+	// Startup migration: ensure the admin service account, attach legacy keys.
+	adminAccID, err := db.EnsureAdminServiceAccount(1000)
+	if err != nil {
+		t.Fatalf("EnsureAdminServiceAccount: %v", err)
+	}
+	if _, err := db.BackfillAdminKeyAccounts(adminAccID); err != nil {
+		t.Fatalf("BackfillAdminKeyAccounts: %v", err)
+	}
+
+	// The same key now passes the gate via the service account.
+	if code, called := serve(); code != http.StatusOK || !called {
+		t.Errorf("post-backfill: expected 200 and handler called, got %d called=%v", code, called)
 	}
 }
 

--- a/internal/proxy/admin_key_upgrade_test.go
+++ b/internal/proxy/admin_key_upgrade_test.go
@@ -1,0 +1,135 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/krishna/local-ai-proxy/internal/credits"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// TestLegacyAdminKey_ChatsAfterBackfill reproduces the exact production
+// upgrade scenario for OSS-2: a live admin-created API key with NULL
+// account_id (which chatted via the old credit-gate bypass) must keep
+// chatting after the startup migration attaches it to the admin service
+// account. It exercises the real chain the request travels in main.go:
+// CreditGate -> proxy handler -> upstream node.
+func TestLegacyAdminKey_ChatsAfterBackfill(t *testing.T) {
+	db := setupTestDB(t)
+
+	upstream := mockOllamaChatNonStreaming(http.StatusOK, map[string]any{
+		"id":      "chatcmpl-legacy",
+		"object":  "chat.completion",
+		"choices": []map[string]any{{"message": map[string]any{"role": "assistant", "content": "hi"}}},
+		"usage":   map[string]any{"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+	})
+	defer upstream.Close()
+
+	const model = "llama3:latest"
+	if err := db.UpsertPricing(model, 0.001, 0.001, 100); err != nil {
+		t.Fatalf("UpsertPricing: %v", err)
+	}
+
+	// The pre-upgrade production state: an admin-minted key with no account.
+	const keyHash = "legacy-prod-key-hash"
+	if _, err := db.CreateKey("prod-legacy", keyHash, "sk-prodleg", 60); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	usageCh := make(chan store.UsageEntry, 10)
+	proxyHandler := NewHandler(singleNodeRegistry(t, upstream.URL, model), usageCh, 52428800, db, nil, Options{})
+	chain := credits.CreditGate(db, nil)(proxyHandler)
+
+	chat := func(reqModel string) *httptest.ResponseRecorder {
+		key, err := db.GetKeyByHash(keyHash)
+		if err != nil {
+			t.Fatalf("GetKeyByHash: %v", err)
+		}
+		if key == nil {
+			t.Fatal("expected key to exist")
+		}
+		body := `{"model":"` + reqModel + `","messages":[{"role":"user","content":"hello"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = addKeyToRequest(req, key)
+		rec := httptest.NewRecorder()
+		chain.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Pre-backfill the gate fails closed — the bypass is gone.
+	if rec := chat(model); rec.Code != http.StatusForbidden {
+		t.Fatalf("pre-backfill: expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The startup migration (same calls main.go makes).
+	adminAccID, err := db.EnsureAdminServiceAccount(1000)
+	if err != nil {
+		t.Fatalf("EnsureAdminServiceAccount: %v", err)
+	}
+	if _, err := db.BackfillAdminKeyAccounts(adminAccID); err != nil {
+		t.Fatalf("BackfillAdminKeyAccounts: %v", err)
+	}
+
+	// The very same key chats successfully again.
+	rec := chat(model)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("post-backfill: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse chat response: %v", err)
+	}
+	if resp["id"] != "chatcmpl-legacy" {
+		t.Errorf("expected upstream response to pass through, got %v", resp)
+	}
+
+	// And it is metered now: the request settled credits against the account.
+	bal, err := db.GetCreditBalance(adminAccID)
+	if err != nil {
+		t.Fatalf("GetCreditBalance: %v", err)
+	}
+	if bal == nil {
+		t.Fatal("expected balance row for admin service account")
+	}
+	if bal.Balance >= 1000 {
+		t.Errorf("expected credits to be charged (balance < 1000), got %v", bal.Balance)
+	}
+
+	// Behavior change called out in the PR: formerly-bypassing keys are now
+	// subject to the pricing allowlist — unpriced models 400.
+	if rec := chat("unpriced-model:latest"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unpriced model, got %d: %s", rec.Code, rec.Body.String())
+	} else {
+		assertErrorCode(t, rec, "unknown_model", "invalid_request_error")
+	}
+}
+
+// TestCreditGateChain_NoBypassForNilAccount pins the invariant at the chain
+// level: no request from a keyed client reaches the proxy without an
+// account-backed credit check.
+func TestCreditGateChain_NoBypassForNilAccount(t *testing.T) {
+	db := setupTestDB(t)
+
+	upstream := mockOllamaChatNonStreaming(http.StatusOK, map[string]any{"id": "x"})
+	defer upstream.Close()
+
+	usageCh := make(chan store.UsageEntry, 10)
+	proxyHandler := NewHandler(singleNodeRegistry(t, upstream.URL, "m"), usageCh, 52428800, db, nil, Options{})
+	chain := credits.CreditGate(db, nil)(proxyHandler)
+
+	key := &store.APIKey{ID: 42, Name: "detached"} // AccountID nil
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions",
+		strings.NewReader(`{"model":"m","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = addKeyToRequest(req, key)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for NULL-account key, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/store/admin_service_account.go
+++ b/internal/store/admin_service_account.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// AdminServiceAccountName is the well-known name of the service account that
+// admin-minted API keys attach to when no explicit account_id is given, and
+// that legacy NULL-account keys are backfilled onto at startup.
+const AdminServiceAccountName = "admin-service"
+
+// adminServiceAccountLockKey serializes concurrent EnsureAdminServiceAccount
+// calls (e.g. two pods booting at once) so exactly one account is created.
+// Distinct from the migrate lock key in store.go.
+const adminServiceAccountLockKey int64 = 917230424
+
+// EnsureAdminServiceAccount returns the ID of the designated admin service
+// account, creating it on first call with a credit balance and the given
+// initial grant. The grant applies only at creation time — subsequent calls
+// never re-grant or top up. Idempotent and safe under concurrent startup.
+func (s *Store) EnsureAdminServiceAccount(initialGrant float64) (int64, error) {
+	ctx := context.Background()
+
+	// Fast path: the account almost always exists already.
+	id, err := s.findAdminServiceAccount(ctx)
+	if err == nil {
+		return id, nil
+	}
+	if err != pgx.ErrNoRows {
+		return 0, fmt.Errorf("lookup admin service account: %w", err)
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Serialize creation across processes, then re-check under the lock.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, adminServiceAccountLockKey); err != nil {
+		return 0, fmt.Errorf("acquire admin account lock: %w", err)
+	}
+	err = tx.QueryRow(ctx,
+		`SELECT id FROM accounts WHERE name = $1 AND type = 'service' ORDER BY id LIMIT 1`,
+		AdminServiceAccountName,
+	).Scan(&id)
+	if err == nil {
+		return id, tx.Commit(ctx)
+	}
+	if err != pgx.ErrNoRows {
+		return 0, fmt.Errorf("re-check admin service account: %w", err)
+	}
+
+	err = tx.QueryRow(ctx,
+		`INSERT INTO accounts (name, type) VALUES ($1, 'service') RETURNING id`,
+		AdminServiceAccountName,
+	).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("create admin service account: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO credit_balances (account_id, balance) VALUES ($1, $2)`,
+		id, initialGrant,
+	); err != nil {
+		return 0, fmt.Errorf("init admin service balance: %w", err)
+	}
+
+	if initialGrant > 0 {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO credit_transactions (account_id, amount, balance_after, type, description)
+			 VALUES ($1, $2, $2, 'grant', 'admin service account initial grant')`,
+			id, initialGrant,
+		); err != nil {
+			return 0, fmt.Errorf("insert admin service grant transaction: %w", err)
+		}
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO registration_events (kind, account_id, source)
+		 VALUES ('service', $1, 'admin_service')`,
+		id,
+	); err != nil {
+		return 0, fmt.Errorf("record admin service registration_event: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit admin service account: %w", err)
+	}
+	return id, nil
+}
+
+func (s *Store) findAdminServiceAccount(ctx context.Context) (int64, error) {
+	var id int64
+	err := s.pool.QueryRow(ctx,
+		`SELECT id FROM accounts WHERE name = $1 AND type = 'service' ORDER BY id LIMIT 1`,
+		AdminServiceAccountName,
+	).Scan(&id)
+	return id, err
+}
+
+// BackfillAdminKeyAccounts attaches every api_key that still has a NULL
+// account_id to an account, so the credit gate can meter it: keys owned by a
+// user go to that user's account; the rest (legacy admin-created keys) go to
+// the admin service account. Returns the number of keys attached.
+// Idempotent — safe to call on every startup. Runs after BackfillAccounts,
+// which guarantees every user has an account.
+func (s *Store) BackfillAdminKeyAccounts(adminAccountID int64) (int64, error) {
+	ctx := context.Background()
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// User-owned keys reattach to their owner's account.
+	ctUser, err := tx.Exec(ctx,
+		`UPDATE api_keys k SET account_id = u.account_id
+		 FROM users u
+		 WHERE k.user_id = u.id AND k.account_id IS NULL AND u.account_id IS NOT NULL`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("attach user keys to owner accounts: %w", err)
+	}
+
+	// Everything left over (admin-created keys, user_id IS NULL) goes to the
+	// admin service account.
+	ctAdmin, err := tx.Exec(ctx,
+		`UPDATE api_keys SET account_id = $1 WHERE account_id IS NULL`,
+		adminAccountID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("attach legacy keys to admin service account: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit backfill: %w", err)
+	}
+	return ctUser.RowsAffected() + ctAdmin.RowsAffected(), nil
+}

--- a/internal/store/admin_service_account_test.go
+++ b/internal/store/admin_service_account_test.go
@@ -1,0 +1,235 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEnsureAdminServiceAccount_CreatesWithGrant(t *testing.T) {
+	s := setupTestStore(t)
+
+	id, err := s.EnsureAdminServiceAccount(1000)
+	if err != nil {
+		t.Fatalf("EnsureAdminServiceAccount: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("expected positive account id, got %d", id)
+	}
+
+	acct, err := s.GetAccountByID(id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if acct == nil {
+		t.Fatal("expected account to exist")
+	}
+	if acct.Name != AdminServiceAccountName {
+		t.Errorf("expected name %q, got %q", AdminServiceAccountName, acct.Name)
+	}
+	if acct.Type != "service" {
+		t.Errorf("expected type 'service', got %q", acct.Type)
+	}
+	if !acct.IsActive {
+		t.Error("expected account to be active")
+	}
+
+	bal, err := s.GetCreditBalance(id)
+	if err != nil {
+		t.Fatalf("GetCreditBalance: %v", err)
+	}
+	if bal == nil {
+		t.Fatal("expected credit balance row")
+	}
+	if bal.Balance != 1000 {
+		t.Errorf("expected balance 1000, got %v", bal.Balance)
+	}
+
+	// Grant must leave an audit trail.
+	txs, err := s.GetCreditTransactions(id, 10, 0)
+	if err != nil {
+		t.Fatalf("GetCreditTransactions: %v", err)
+	}
+	if len(txs) != 1 {
+		t.Fatalf("expected exactly 1 grant transaction, got %d", len(txs))
+	}
+	if txs[0].Type != "grant" || txs[0].Amount != 1000 {
+		t.Errorf("expected grant of 1000, got type=%q amount=%v", txs[0].Type, txs[0].Amount)
+	}
+}
+
+func TestEnsureAdminServiceAccount_Idempotent(t *testing.T) {
+	s := setupTestStore(t)
+
+	id1, err := s.EnsureAdminServiceAccount(500)
+	if err != nil {
+		t.Fatalf("first EnsureAdminServiceAccount: %v", err)
+	}
+	// Second call with a different grant must NOT create another account or
+	// re-grant credits — the grant applies only at creation time.
+	id2, err := s.EnsureAdminServiceAccount(999999)
+	if err != nil {
+		t.Fatalf("second EnsureAdminServiceAccount: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("expected same account id, got %d and %d", id1, id2)
+	}
+
+	var count int
+	err = s.pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM accounts WHERE name = $1 AND type = 'service'`,
+		AdminServiceAccountName,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("count accounts: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 admin service account, got %d", count)
+	}
+
+	bal, err := s.GetCreditBalance(id1)
+	if err != nil {
+		t.Fatalf("GetCreditBalance: %v", err)
+	}
+	if bal.Balance != 500 {
+		t.Errorf("expected balance to stay 500 (no re-grant), got %v", bal.Balance)
+	}
+
+	txs, err := s.GetCreditTransactions(id1, 10, 0)
+	if err != nil {
+		t.Fatalf("GetCreditTransactions: %v", err)
+	}
+	if len(txs) != 1 {
+		t.Errorf("expected exactly 1 grant transaction after repeat calls, got %d", len(txs))
+	}
+}
+
+func TestEnsureAdminServiceAccount_ZeroGrant(t *testing.T) {
+	s := setupTestStore(t)
+
+	id, err := s.EnsureAdminServiceAccount(0)
+	if err != nil {
+		t.Fatalf("EnsureAdminServiceAccount: %v", err)
+	}
+	bal, err := s.GetCreditBalance(id)
+	if err != nil {
+		t.Fatalf("GetCreditBalance: %v", err)
+	}
+	if bal == nil {
+		t.Fatal("expected credit balance row even with zero grant")
+	}
+	if bal.Balance != 0 {
+		t.Errorf("expected zero balance, got %v", bal.Balance)
+	}
+	txs, err := s.GetCreditTransactions(id, 10, 0)
+	if err != nil {
+		t.Fatalf("GetCreditTransactions: %v", err)
+	}
+	if len(txs) != 0 {
+		t.Errorf("expected no grant transaction for zero grant, got %d", len(txs))
+	}
+}
+
+func TestBackfillAdminKeyAccounts_AttachesLegacyKeys(t *testing.T) {
+	s := setupTestStore(t)
+
+	// Legacy admin-created key: no user, no account — exactly what a
+	// pre-upgrade production database contains.
+	legacyID, err := s.CreateKey("legacy-admin", "hash-legacy", "sk-legacy", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	// User-owned key whose account link was lost: must reattach to the
+	// OWNER's account, not the admin service account.
+	userAccID, userID, err := s.RegisterUser("owner@example.com", "hash", "Owner")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	orphanID, err := s.CreateKeyForUser(userID, "orphan-user-key", "hash-orphan", "sk-orphan", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForUser: %v", err)
+	}
+
+	// A properly attached key must not be touched.
+	attachedID, err := s.CreateKeyForAccount(userID, userAccID, "attached", "hash-attached", "sk-attach", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccount: %v", err)
+	}
+
+	adminAccID, err := s.EnsureAdminServiceAccount(1000)
+	if err != nil {
+		t.Fatalf("EnsureAdminServiceAccount: %v", err)
+	}
+
+	n, err := s.BackfillAdminKeyAccounts(adminAccID)
+	if err != nil {
+		t.Fatalf("BackfillAdminKeyAccounts: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2 keys backfilled, got %d", n)
+	}
+
+	legacy, err := s.GetKeyByID(legacyID)
+	if err != nil {
+		t.Fatalf("GetKeyByID(legacy): %v", err)
+	}
+	if legacy.AccountID == nil || *legacy.AccountID != adminAccID {
+		t.Errorf("expected legacy key attached to admin account %d, got %v", adminAccID, legacy.AccountID)
+	}
+
+	orphan, err := s.GetKeyByID(orphanID)
+	if err != nil {
+		t.Fatalf("GetKeyByID(orphan): %v", err)
+	}
+	if orphan.AccountID == nil || *orphan.AccountID != userAccID {
+		t.Errorf("expected user key attached to owner account %d, got %v", userAccID, orphan.AccountID)
+	}
+
+	attached, err := s.GetKeyByID(attachedID)
+	if err != nil {
+		t.Fatalf("GetKeyByID(attached): %v", err)
+	}
+	if attached.AccountID == nil || *attached.AccountID != userAccID {
+		t.Errorf("expected attached key to keep account %d, got %v", userAccID, attached.AccountID)
+	}
+}
+
+func TestBackfillAdminKeyAccounts_Idempotent(t *testing.T) {
+	s := setupTestStore(t)
+
+	if _, err := s.CreateKey("legacy", "hash-1", "sk-1", 60); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	adminAccID, err := s.EnsureAdminServiceAccount(100)
+	if err != nil {
+		t.Fatalf("EnsureAdminServiceAccount: %v", err)
+	}
+
+	n1, err := s.BackfillAdminKeyAccounts(adminAccID)
+	if err != nil {
+		t.Fatalf("first BackfillAdminKeyAccounts: %v", err)
+	}
+	if n1 != 1 {
+		t.Errorf("expected 1 key backfilled on first run, got %d", n1)
+	}
+
+	n2, err := s.BackfillAdminKeyAccounts(adminAccID)
+	if err != nil {
+		t.Fatalf("second BackfillAdminKeyAccounts: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("expected 0 keys backfilled on second run, got %d", n2)
+	}
+
+	// No NULL-account keys may remain.
+	var remaining int
+	err = s.pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM api_keys WHERE account_id IS NULL`).Scan(&remaining)
+	if err != nil {
+		t.Fatalf("count NULL-account keys: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("expected 0 NULL-account keys after backfill, got %d", remaining)
+	}
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -158,6 +158,7 @@ CREATE INDEX IF NOT EXISTS idx_usage_logs_key_created
 --   'registration_token'   — service account via POST /api/accounts/register
 --   'admin_bootstrap'      — first admin or DR admin via /api/admin/bootstrap
 --   'admin_create'         — admin-created user via POST /api/admin/users (future)
+--   'admin_service'        — the auto-created "admin-service" account (OSS-2)
 --   'backfill'             — rows inserted by the PR 1 backfill for historical data
 -- The column is TEXT (not an enum) so new sources don't require a migration.
 CREATE TABLE IF NOT EXISTS registration_events (

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -279,7 +279,11 @@ func isTransientMigrateError(err error) bool {
 	return false
 }
 
-// CreateKey inserts a new API key and returns its ID.
+// CreateKey inserts a new API key with no account attached and returns its
+// ID. No production path calls this anymore — every minted key is
+// account-backed (see CreateKeyForAccountOnly / CreateKeyForAccount) and the
+// credit gate rejects NULL-account keys. It is kept for tests that simulate
+// the pre-OSS-2 legacy state exercised by BackfillAdminKeyAccounts.
 func (s *Store) CreateKey(name, keyHash, keyPrefix string, rateLimit int) (int64, error) {
 	var id int64
 	err := s.pool.QueryRow(


### PR DESCRIPTION
Implements Notion task **OSS-2: Unify admin key semantics (no credit-gate bypass)**.

## Problem

Admin-created API keys (`POST /api/admin/keys`) had no account, and the credit gate waved NULL-account keys through — skipping metering **and** the pricing allowlist, including for unpriced models. Decision (2026-07-07): one code path — admin keys attach to accounts and are metered like every other key.

## ⚠️ Behavior change (the one to read)

**Formerly-bypassing admin keys are now subject to the pricing allowlist: requests for unpriced models return `400 unknown_model`.**

Operator action: add pricing for every model you serve — `POST /api/admin/pricing {"model_id": "...", "prompt_rate": ..., "completion_rate": ...}`. Everything else about live keys keeps working (see upgrade safety below).

## Design

### `POST /api/admin/keys` request/response

- Request gains optional `account_id`:
  - **present** → key attaches to that existing account (`404 account_not_found` if unknown);
  - **omitted** → key attaches to the designated **`admin-service`** account (auto-created, `type='service'`). This preserves back-compat for existing callers: the same request body keeps working.
- Response gains `account_id` (also added to the `POST /api/admin/accounts/{id}/keys` response).

### The `admin-service` account

- `EnsureAdminServiceAccount(grant)` — idempotent, advisory-lock-serialized (two pods booting concurrently create exactly one account). Creates the account + credit balance + grant audit transaction + `registration_events` row (`source='admin_service'`).
- Initial balance comes from **`ADMIN_SERVICE_CREDIT_GRANT`** (new env, default **1,000,000 credits**, must be >= 0). Applied **once at creation** — never topped up on later boots; use `POST /api/admin/accounts/{id}/credits` to add more. Default is deliberately generous so upgrades and smoke tests work out of the box (`DEFAULT_CREDIT_GRANT` defaults to 0, which would have bricked upgraded keys).

### Credit gate: bypass deleted

`CreditGate` no longer passes NULL-account keys. A key without an account is rejected `403 account_required` — fail-closed, and unreachable in a healthy deployment because of the backfill. (`key == nil` still passes through: authentication is the auth middleware's job, and `/api/v1/` mounts auth ahead of the gate.)

### Startup backfill (upgrade safety)

`BackfillAdminKeyAccounts` follows the existing `Backfill*` pattern (runs right after `BackfillAccounts`, idempotent, one transaction):

1. user-owned NULL-account keys reattach to their **owner's** account;
2. remaining NULL-account keys (admin-created) attach to **`admin-service`**.

After startup, no NULL-account key exists. **Production scenario tested end-to-end** (`internal/proxy/admin_key_upgrade_test.go`): a legacy NULL-account key → startup migration → the same key chats `200` through the real `CreditGate → proxy → upstream` chain, is metered (credits visibly deducted from `admin-service`), and gets `400 unknown_model` on unpriced models. Backfill idempotency is pinned in `internal/store/admin_service_account_test.go` (second run touches 0 rows, no duplicate account, no re-grant).

## Docs

- README: admin API table row for `POST /api/admin/keys`, new "Admin keys and the `admin-service` account" section, `ADMIN_SERVICE_CREDIT_GRANT` env row, request-flow + schema comments updated (no more "credit-backed keys only").
- `deploy/examples/README.md`: smoke-test flow rewritten — pricing first, then mint + chat via the `admin-service` account (no bypass note).

## Tests

`go test -race -count=1 -p 1 ./...` — **852 passed, 20 packages**. gofmt clean, `go vet` clean, `CGO_ENABLED=0 go build ./cmd/proxy` OK. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSYCn4mZxomD5Aauu5hJPr