### PR TITLE
refactor(credits): pricing rates per million tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Readiness = DB ok **and** usage writer ok **and** (*zero enabled nodes* **or** *
 | `GET` | `/api/admin/accounts` | List accounts (credit balances) |
 | `POST` | `/api/admin/accounts/{id}/credits` | Grant credits |
 | `POST` | `/api/admin/accounts/{id}/keys` | Create a key bound to an account |
-| `GET`/`POST` | `/api/admin/pricing` | List / upsert model pricing (`{model_id, prompt_rate, completion_rate, typical_completion}`) |
+| `GET`/`POST` | `/api/admin/pricing` | List / upsert model pricing (`{model_id, prompt_rate_per_mtok, completion_rate_per_mtok, typical_completion}`) |
 | `DELETE` | `/api/admin/pricing/{id}` | Deactivate pricing |
 | `GET`/`POST`/`DELETE` | `/api/admin/registration-tokens` | Manage service-registration tokens |
 | `GET` | `/api/admin/registrations` | Registration audit feed |
@@ -166,12 +166,13 @@ Nodes come from two coexisting sources: a static JSON file (`NODES_FILE`, the co
 The pricing catalog starts **empty** — nothing is seeded. `GET /api/v1/models` lists the intersection of *actively priced* models and models *served by a healthy node*, so after registering nodes you must price each model you want to expose (the gateway logs a warn-level reminder at startup while the catalog is empty):
 
 ```bash
+# Rates are credits per MILLION tokens (2000/MTok below = 0.002 credits per token).
 curl -s -X POST -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
-  -d '{"model_id":"llama3.1:8b","prompt_rate":0.002,"completion_rate":0.002,"typical_completion":500}' \
+  -d '{"model_id":"llama3.1:8b","prompt_rate_per_mtok":2000,"completion_rate_per_mtok":2000,"typical_completion":500}' \
   http://localhost:8080/api/admin/pricing
 ```
 
-Pricing is also **required** for any credit-backed key (keys created for user or service accounts): requests for unpriced models are rejected with `400 unknown_model`. Rates are in credits per token; `typical_completion` feeds the completion-token estimate that sizes per-request credit holds when the client sends no `max_tokens` and the account has little usage history.
+Pricing is also **required** for any credit-backed key (keys created for user or service accounts): requests for unpriced models are rejected with `400 unknown_model`. Rates are in credits per **million** tokens (per-MTok, the industry convention; the old per-token field names `prompt_rate`/`completion_rate` are rejected with `400 unknown_field`); `typical_completion` feeds the completion-token estimate that sizes per-request credit holds when the client sends no `max_tokens` and the account has little usage history.
 
 ## Request Flow
 

--- a/deploy/examples/README.md
+++ b/deploy/examples/README.md
@@ -64,8 +64,9 @@ Every key is credit-backed — including admin-created ones — so the model you
 want to chat with must be **priced** first:
 
 ```bash
+# Rates are credits per MILLION tokens (1000/MTok = 0.001 credits per token).
 curl -s -X POST -H "X-Admin-Key: $ADMIN_KEY" -H 'Content-Type: application/json' \
-  -d '{"model_id":"smollm2:135m","prompt_rate":0.001,"completion_rate":0.001,"typical_completion":300}' \
+  -d '{"model_id":"smollm2:135m","prompt_rate_per_mtok":1000,"completion_rate_per_mtok":1000,"typical_completion":300}' \
   http://localhost:18080/api/admin/pricing
 ```
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -973,28 +973,33 @@ func (h *handler) listPricing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) upsertPricing(w http.ResponseWriter, r *http.Request) {
+	// Rates are credits per MILLION tokens (per-MTok). Strict decoding makes
+	// the re-denomination break loud: the old per-token field names
+	// (prompt_rate / completion_rate) — or any other unknown field — get a
+	// 400 naming the field instead of being silently dropped and then
+	// misreported as missing per-MTok rates.
 	var req struct {
-		ModelID           string  `json:"model_id"`
-		PromptRate        float64 `json:"prompt_rate"`
-		CompletionRate    float64 `json:"completion_rate"`
-		TypicalCompletion int     `json:"typical_completion"`
+		ModelID               string  `json:"model_id"`
+		PromptRatePerMTok     float64 `json:"prompt_rate_per_mtok"`
+		CompletionRatePerMTok float64 `json:"completion_rate_per_mtok"`
+		TypicalCompletion     int     `json:"typical_completion"`
 	}
-	if !apierror.DecodeJSON(w, r, &req) {
+	if !apierror.DecodeJSONStrict(w, r, &req) {
 		return
 	}
 	if req.ModelID == "" {
 		proxy.WriteError(w, r, http.StatusBadRequest, "missing_model_id", "invalid_request_error", "model_id is required")
 		return
 	}
-	if req.PromptRate <= 0 || req.CompletionRate <= 0 {
-		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_rates", "invalid_request_error", "prompt_rate and completion_rate must be positive")
+	if req.PromptRatePerMTok <= 0 || req.CompletionRatePerMTok <= 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_rates", "invalid_request_error", "prompt_rate_per_mtok and completion_rate_per_mtok (credits per million tokens) must be positive")
 		return
 	}
 	if req.TypicalCompletion <= 0 {
 		req.TypicalCompletion = 500
 	}
 
-	if err := h.store.UpsertPricing(req.ModelID, req.PromptRate, req.CompletionRate, req.TypicalCompletion); err != nil {
+	if err := h.store.UpsertPricing(req.ModelID, req.PromptRatePerMTok, req.CompletionRatePerMTok, req.TypicalCompletion); err != nil {
 		slog.ErrorContext(r.Context(), "upsert pricing error", "error", err)
 		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to update pricing")
 		return

--- a/internal/admin/coverage_test.go
+++ b/internal/admin/coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -333,7 +334,7 @@ func TestAdmin_RevokeRegistrationToken_InvalidID(t *testing.T) {
 func TestAdmin_UpsertListDeletePricing(t *testing.T) {
 	h, _ := setupAdminTest(t)
 
-	upsert := `{"model_id":"llama3","prompt_rate":0.001,"completion_rate":0.002,"typical_completion":200}`
+	upsert := `{"model_id":"llama3","prompt_rate_per_mtok":1000,"completion_rate_per_mtok":2000,"typical_completion":200}`
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/pricing", bytes.NewBufferString(upsert))
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	req.Header.Set("Content-Type", "application/json")
@@ -369,7 +370,7 @@ func TestAdmin_UpsertListDeletePricing(t *testing.T) {
 
 func TestAdmin_UpsertPricing_MissingModelID(t *testing.T) {
 	h, _ := setupAdminTest(t)
-	body := `{"prompt_rate":0.001,"completion_rate":0.002}`
+	body := `{"prompt_rate_per_mtok":1000,"completion_rate_per_mtok":2000}`
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/pricing", bytes.NewBufferString(body))
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	req.Header.Set("Content-Type", "application/json")
@@ -382,7 +383,7 @@ func TestAdmin_UpsertPricing_MissingModelID(t *testing.T) {
 
 func TestAdmin_UpsertPricing_InvalidRates(t *testing.T) {
 	h, _ := setupAdminTest(t)
-	body := `{"model_id":"x","prompt_rate":0,"completion_rate":0.001}`
+	body := `{"model_id":"x","prompt_rate_per_mtok":0,"completion_rate_per_mtok":1000}`
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/pricing", bytes.NewBufferString(body))
 	req.Header.Set("X-Admin-Key", testAdminKey)
 	req.Header.Set("Content-Type", "application/json")
@@ -390,6 +391,26 @@ func TestAdmin_UpsertPricing_InvalidRates(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+// TestAdmin_UpsertPricing_OldPerTokenFieldNames400 pins the re-denomination
+// break: the pre-per-MTok field names (prompt_rate / completion_rate,
+// credits per TOKEN) — and any other unknown field — must be rejected with a
+// 400 naming the field, never silently ignored and misinterpreted.
+func TestAdmin_UpsertPricing_OldPerTokenFieldNames400(t *testing.T) {
+	h, _ := setupAdminTest(t)
+	body := `{"model_id":"x","prompt_rate":0.002,"completion_rate":0.002}`
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/pricing", bytes.NewBufferString(body))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for old per-token field names, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "prompt_rate") {
+		t.Errorf("expected error to name the offending field, got: %s", rec.Body.String())
 	}
 }
 
@@ -666,7 +687,7 @@ func TestAdmin_Internal_ListPricing(t *testing.T) {
 }
 func TestAdmin_Internal_UpsertPricing(t *testing.T) {
 	withBrokenStore(t, func(h http.Handler, _ *store.Store, _, _, _ int64) {
-		expect5xx(t, h, http.MethodPost, "/api/admin/pricing", `{"model_id":"m","prompt_rate":0.001,"completion_rate":0.001}`)
+		expect5xx(t, h, http.MethodPost, "/api/admin/pricing", `{"model_id":"m","prompt_rate_per_mtok":1000,"completion_rate_per_mtok":1000}`)
 	})
 }
 func TestAdmin_Internal_SetSessionLimit(t *testing.T) {

--- a/internal/admin/list_envelope_test.go
+++ b/internal/admin/list_envelope_test.go
@@ -359,8 +359,8 @@ func TestListAccounts_InvalidType_400(t *testing.T) {
 
 func TestListPricing_LegacyShape(t *testing.T) {
 	h, s := setupAdminTest(t)
-	_ = s.UpsertPricing("m1", 0.001, 0.002, 500)
-	_ = s.UpsertPricing("m2", 0.003, 0.004, 500)
+	_ = s.UpsertPricing("m1", 1000, 2000, 500)
+	_ = s.UpsertPricing("m2", 3000, 4000, 500)
 
 	rec := doAdminGET(t, h, "/api/admin/pricing?envelope=0")
 	if rec.Code != http.StatusOK {
@@ -381,9 +381,9 @@ func TestListPricing_LegacyShape(t *testing.T) {
 
 func TestListPricing_Envelope_Pagination(t *testing.T) {
 	h, s := setupAdminTest(t)
-	_ = s.UpsertPricing("m1", 0.001, 0.002, 500)
-	_ = s.UpsertPricing("m2", 0.003, 0.004, 500)
-	_ = s.UpsertPricing("m3", 0.005, 0.006, 500)
+	_ = s.UpsertPricing("m1", 1000, 2000, 500)
+	_ = s.UpsertPricing("m2", 3000, 4000, 500)
+	_ = s.UpsertPricing("m3", 5000, 6000, 500)
 
 	rec := doAdminGET(t, h, "/api/admin/pricing?envelope=1&limit=2&offset=0")
 	if rec.Code != http.StatusOK {
@@ -401,13 +401,15 @@ func TestListPricing_Envelope_Pagination(t *testing.T) {
 
 func assertPricingSnakeCaseKeys(t *testing.T, row map[string]any) {
 	t.Helper()
-	want := []string{"id", "model_id", "prompt_rate", "completion_rate", "typical_completion", "effective_from", "active"}
+	want := []string{"id", "model_id", "prompt_rate_per_mtok", "completion_rate_per_mtok", "typical_completion", "effective_from", "active"}
 	for _, k := range want {
 		if _, ok := row[k]; !ok {
 			t.Errorf("missing snake_case key %q in pricing row: %+v", k, row)
 		}
 	}
-	forbidden := []string{"ID", "ModelID", "PromptRate", "CompletionRate", "TypicalCompletion", "EffectiveFrom", "Active"}
+	// prompt_rate / completion_rate are the pre-per-MTok (credits per token)
+	// names — they must never reappear on the wire.
+	forbidden := []string{"prompt_rate", "completion_rate", "ID", "ModelID", "PromptRatePerMTok", "CompletionRatePerMTok", "TypicalCompletion", "EffectiveFrom", "Active"}
 	for _, k := range forbidden {
 		if _, ok := row[k]; ok {
 			t.Errorf("PascalCase key %q leaked into pricing wire shape: %+v", k, row)

--- a/internal/apierror/decode.go
+++ b/internal/apierror/decode.go
@@ -3,8 +3,10 @@ package apierror
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // DecodeJSON decodes the request body into dst and requires it to be a
@@ -13,7 +15,23 @@ import (
 // 400 for anything else — and returns false, in which case the handler must
 // return without writing a response.
 func DecodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	return decodeJSON(w, r, dst, false)
+}
+
+// DecodeJSONStrict behaves like DecodeJSON but additionally rejects unknown
+// fields with a 400 that names the offending field. Use it on endpoints
+// where a silently dropped field would change semantics — e.g. the pricing
+// endpoint after the per-token → per-MTok rate re-denomination, where the
+// old field names must fail loudly instead of being ignored.
+func DecodeJSONStrict(w http.ResponseWriter, r *http.Request, dst any) bool {
+	return decodeJSON(w, r, dst, true)
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any, strict bool) bool {
 	dec := json.NewDecoder(r.Body)
+	if strict {
+		dec.DisallowUnknownFields()
+	}
 	if err := dec.Decode(dst); err != nil {
 		writeDecodeError(w, r, err)
 		return false
@@ -41,5 +59,21 @@ func writeDecodeError(w http.ResponseWriter, r *http.Request, err error) {
 		WriteError(w, r, http.StatusRequestEntityTooLarge, "request_too_large", "invalid_request_error", "Request body too large")
 		return
 	}
+	if field, ok := unknownField(err); ok {
+		WriteError(w, r, http.StatusBadRequest, "unknown_field", "invalid_request_error",
+			fmt.Sprintf("Unknown field %s", field))
+		return
+	}
 	WriteError(w, r, http.StatusBadRequest, "invalid_json", "invalid_request_error", "Invalid JSON body")
+}
+
+// unknownField extracts the field name (with quotes) from encoding/json's
+// unknown-field error. The stdlib exposes no typed error for it, so match
+// the stable message prefix.
+func unknownField(err error) (string, bool) {
+	const prefix = `json: unknown field `
+	if msg := err.Error(); strings.HasPrefix(msg, prefix) {
+		return strings.TrimPrefix(msg, prefix), true
+	}
+	return "", false
 }

--- a/internal/credits/catalog_test.go
+++ b/internal/credits/catalog_test.go
@@ -44,7 +44,7 @@ func TestWarnIfPricingEmpty_EmptyCatalogWarns(t *testing.T) {
 func TestWarnIfPricingEmpty_PricedCatalogSilent(t *testing.T) {
 	s := setupTestStore(t)
 
-	if err := s.UpsertPricing("test-model:1b", 0.001, 0.001, 300); err != nil {
+	if err := s.UpsertPricing("test-model:1b", 1000, 1000, 300); err != nil {
 		t.Fatalf("UpsertPricing: %v", err)
 	}
 

--- a/internal/credits/estimator.go
+++ b/internal/credits/estimator.go
@@ -30,11 +30,15 @@ func EstimateCompletionTokens(maxTokens *int, stats *store.AccountUsageStats, pr
 }
 
 // EstimateCost calculates the credit cost from token counts and pricing.
+// Rates are credits per MILLION tokens: cost = tokens × rate / 1_000_000.
+// The single division at the end keeps the float64 result within 1 ulp of
+// the old per-token math, far inside the 6 decimal places the database
+// stores (see TestEstimateCost_PerMTokMatchesOldPerTokenMath).
 func EstimateCost(pricing *store.CreditPricing, promptTokens, completionTokens int) float64 {
 	if pricing == nil {
 		return 0
 	}
-	return float64(promptTokens)*pricing.PromptRate + float64(completionTokens)*pricing.CompletionRate
+	return (float64(promptTokens)*pricing.PromptRatePerMTok + float64(completionTokens)*pricing.CompletionRatePerMTok) / 1e6
 }
 
 // EstimateFromResponseBytes estimates tokens from response body size.

--- a/internal/credits/estimator_test.go
+++ b/internal/credits/estimator_test.go
@@ -68,10 +68,11 @@ func TestEstimateCompletionTokens_Cascade(t *testing.T) {
 }
 
 func TestEstimateCost(t *testing.T) {
-	pricing := &store.CreditPricing{PromptRate: 0.002, CompletionRate: 0.002}
+	// Rates are credits per MILLION tokens: cost = tokens × rate / 1e6.
+	pricing := &store.CreditPricing{PromptRatePerMTok: 2000, CompletionRatePerMTok: 2000}
 
 	cost := EstimateCost(pricing, 100, 200)
-	expected := 100*0.002 + 200*0.002 // 0.6
+	expected := (100*2000 + 200*2000) / 1e6 // 0.6
 	if !almostEqual(cost, expected) {
 		t.Errorf("EstimateCost = %f, want %f", cost, expected)
 	}

--- a/internal/credits/redenomination_test.go
+++ b/internal/credits/redenomination_test.go
@@ -1,0 +1,271 @@
+package credits
+
+// Proof tests for the OSS-5 pricing re-denomination: rates changed from
+// credits per TOKEN to credits per MILLION tokens (per-MTok). The migration
+// and the new charge math must be provably cost-neutral — effective prices,
+// reserves, and settled charges are identical to the old per-token world.
+
+import (
+	"context"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// equalAt6dp reports whether two credit amounts are equal at the 6 decimal
+// places the database stores (credit_balances / credit_holds /
+// credit_transactions are all DECIMAL(15,6)).
+func equalAt6dp(a, b float64) bool {
+	return math.Round(a*1e6) == math.Round(b*1e6)
+}
+
+// TestEstimateCost_PerMTokMatchesOldPerTokenMath is the unit-level
+// equal-cost proof. Expected costs are HARDCODED from the old per-token
+// math (cost = tokens × per-token rate); the new math (cost = tokens ×
+// per-MTok rate / 1e6) on ×1e6-migrated rates must reproduce them exactly
+// at the database's 6-decimal precision (and to 1e-9 in float64).
+func TestEstimateCost_PerMTokMatchesOldPerTokenMath(t *testing.T) {
+	cases := []struct {
+		name                   string
+		promptTokens           int
+		completionTokens       int
+		oldPromptRatePerToken  float64
+		oldCompletionRatePerTk float64
+		// wantCost is the OLD math's result, hardcoded — not computed here.
+		wantCost float64
+	}{
+		// Production pricing row at migration time: gemma4:e4b at 0.004/token.
+		{"prod gemma4:e4b", 1234, 567, 0.004, 0.004, 7.204},
+		// Asymmetric rates catch a prompt/completion column swap.
+		{"asymmetric rates", 1234, 567, 0.004, 0.001, 5.503},
+		{"small request", 10, 5, 0.002, 0.002, 0.03},
+		{"long-tail decimal rate", 100, 200, 0.0000123456789, 0.0000123456789, 0.00370370367},
+		{"large volume", 100000, 50000, 0.01, 0.005, 1250},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Guard: the hardcoded expectation really is what the old math
+			// (tokens × per-token rate) produced.
+			oldCost := float64(c.promptTokens)*c.oldPromptRatePerToken +
+				float64(c.completionTokens)*c.oldCompletionRatePerTk
+			if math.Abs(oldCost-c.wantCost) > 1e-9 {
+				t.Fatalf("fixture error: old math gives %.12f, hardcoded want %.12f", oldCost, c.wantCost)
+			}
+
+			// The migration backfill is rate_mtok = rate * 1e6.
+			p := &store.CreditPricing{
+				PromptRatePerMTok:     c.oldPromptRatePerToken * 1e6,
+				CompletionRatePerMTok: c.oldCompletionRatePerTk * 1e6,
+			}
+			got := EstimateCost(p, c.promptTokens, c.completionTokens)
+
+			if math.Abs(got-c.wantCost) > 1e-9 {
+				t.Errorf("EstimateCost = %.12f, want %.12f (old per-token math)", got, c.wantCost)
+			}
+			if !equalAt6dp(got, c.wantCost) {
+				t.Errorf("EstimateCost = %.6f differs from old math %.6f at DB precision", got, c.wantCost)
+			}
+		})
+	}
+}
+
+// TestRedenomination_MigrationIdempotent proves the schema.sql migration is
+// safe under the "re-run the whole schema on every boot" pattern: a legacy
+// row (per-token columns set, *_mtok columns NULL) is backfilled ×1e6
+// exactly once, and repeated boots never multiply the value again. It also
+// proves the backfill never clobbers a rate that was later re-priced
+// through the new per-MTok API.
+func TestRedenomination_MigrationIdempotent(t *testing.T) {
+	s := setupTestStore(t)
+	dbURL := os.Getenv("DATABASE_URL")
+	ctx := context.Background()
+
+	// Simulate a row written by the previous (per-token) release: only the
+	// legacy columns are populated; the *_mtok columns stay NULL.
+	if _, err := s.Pool().Exec(ctx,
+		`INSERT INTO credit_pricing (model_id, prompt_rate, completion_rate, typical_completion)
+		 VALUES ('oss5-legacy:test', 0.004, 0.001, 500)`); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+	if _, err := s.Pool().Exec(ctx,
+		`UPDATE credit_pricing
+		 SET prompt_rate_mtok = NULL, completion_rate_mtok = NULL
+		 WHERE model_id = 'oss5-legacy:test'`); err != nil {
+		t.Fatalf("clear mtok columns: %v", err)
+	}
+
+	readRaw := func(t *testing.T, model string) (prompt, completion string) {
+		t.Helper()
+		if err := s.Pool().QueryRow(ctx,
+			`SELECT prompt_rate_mtok::text, completion_rate_mtok::text
+			 FROM credit_pricing WHERE model_id = $1`, model).Scan(&prompt, &completion); err != nil {
+			t.Fatalf("read raw mtok columns: %v", err)
+		}
+		return prompt, completion
+	}
+
+	// Boot the app three more times. store.New re-applies the embedded
+	// schema.sql in full — exactly what production does on every deploy.
+	for boot := 1; boot <= 3; boot++ {
+		s2, err := store.New(context.Background(), dbURL)
+		if err != nil {
+			t.Fatalf("boot %d: %v", boot, err)
+		}
+		s2.Close()
+
+		prompt, completion := readRaw(t, "oss5-legacy:test")
+		if prompt != "4000.000000" {
+			t.Fatalf("boot %d: prompt_rate_mtok = %s, want 4000.000000 (backfill compounded or mis-scaled)", boot, prompt)
+		}
+		if completion != "1000.000000" {
+			t.Fatalf("boot %d: completion_rate_mtok = %s, want 1000.000000", boot, completion)
+		}
+	}
+
+	// A rate written through the new per-MTok API must survive further
+	// boots untouched, even when it has more precision than the deprecated
+	// per-token column can mirror (2000.000001 / 1e6 rounds at 10dp).
+	if err := s.UpsertPricing("oss5-repriced:test", 2000.000001, 3000, 500); err != nil {
+		t.Fatalf("UpsertPricing: %v", err)
+	}
+	s3, err := store.New(context.Background(), dbURL)
+	if err != nil {
+		t.Fatalf("boot after reprice: %v", err)
+	}
+	s3.Close()
+	prompt, completion := readRaw(t, "oss5-repriced:test")
+	if prompt != "2000.000001" {
+		t.Fatalf("prompt_rate_mtok = %s after reboot, want 2000.000001 (backfill clobbered a repriced row)", prompt)
+	}
+	if completion != "3000.000000" {
+		t.Fatalf("completion_rate_mtok = %s after reboot, want 3000.000000", completion)
+	}
+}
+
+// TestRedenomination_EqualCostProof is the end-to-end equal-cost proof:
+// a legacy per-token pricing row is migrated by re-running the schema, and
+// then BOTH money paths — the reserve estimate (EstimateCost sizing
+// ReserveCredits) and the settle charge (EstimateCost feeding SettleHold) —
+// produce, on the migrated ×1e6 rates, exactly the credits_charged that the
+// old per-token math produced. Expected values are hardcoded from the old
+// math: reserve = 1234×0.004 + 567×0.001 = 5.503, settle = 903×0.004 +
+// 411×0.001 = 4.023.
+func TestRedenomination_EqualCostProof(t *testing.T) {
+	s := setupTestStore(t)
+	dbURL := os.Getenv("DATABASE_URL")
+	ctx := context.Background()
+
+	const (
+		reservePromptTokens    = 1234
+		reserveCompletionToks  = 567
+		settlePromptTokens     = 903
+		settleCompletionTokens = 411
+		// Old per-token rates and the costs the OLD math charged for them.
+		wantReserve = 5.503 // 1234×0.004 + 567×0.001
+		wantSettle  = 4.023 // 903×0.004 + 411×0.001
+	)
+
+	// Legacy row exactly as the per-token release left it, then one "boot"
+	// to run the ×1e6 backfill.
+	if _, err := s.Pool().Exec(ctx,
+		`INSERT INTO credit_pricing (model_id, prompt_rate, completion_rate, typical_completion)
+		 VALUES ('oss5-cost:test', 0.004, 0.001, 500)`); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+	if _, err := s.Pool().Exec(ctx,
+		`UPDATE credit_pricing SET prompt_rate_mtok = NULL, completion_rate_mtok = NULL
+		 WHERE model_id = 'oss5-cost:test'`); err != nil {
+		t.Fatalf("clear mtok columns: %v", err)
+	}
+	s2, err := store.New(context.Background(), dbURL)
+	if err != nil {
+		t.Fatalf("migration boot: %v", err)
+	}
+	s2.Close()
+
+	p, err := s.GetPricingByModel("oss5-cost:test")
+	if err != nil || p == nil {
+		t.Fatalf("GetPricingByModel: %v (pricing=%v)", err, p)
+	}
+	if !equalAt6dp(p.PromptRatePerMTok, 4000) || !equalAt6dp(p.CompletionRatePerMTok, 1000) {
+		t.Fatalf("migrated rates = %.6f/%.6f per MTok, want 4000/1000", p.PromptRatePerMTok, p.CompletionRatePerMTok)
+	}
+
+	// Reserve estimate — same code path the proxy uses to size the hold.
+	reserve := EstimateCost(p, reservePromptTokens, reserveCompletionToks)
+	if !equalAt6dp(reserve, wantReserve) || math.Abs(reserve-wantReserve) > 1e-9 {
+		t.Fatalf("reserve estimate = %.12f, want %.12f (old per-token math)", reserve, wantReserve)
+	}
+
+	// Settle charge — same code path settleCredits/settleStreamCredits use.
+	settleCost := EstimateCost(p, settlePromptTokens, settleCompletionTokens)
+	if !equalAt6dp(settleCost, wantSettle) || math.Abs(settleCost-wantSettle) > 1e-9 {
+		t.Fatalf("settle cost = %.12f, want %.12f (old per-token math)", settleCost, wantSettle)
+	}
+
+	// Drive the amounts through the real reserve/settle flow and verify the
+	// database-recorded charge is identical to the old world.
+	accID, err := s.CreateAccount("oss5-cost-proof", "personal")
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if err := s.InitCreditBalance(accID); err != nil {
+		t.Fatalf("InitCreditBalance: %v", err)
+	}
+	if err := s.AddCredits(accID, 1000, "test grant"); err != nil {
+		t.Fatalf("AddCredits: %v", err)
+	}
+
+	holdID, err := s.ReserveCredits(accID, reserve)
+	if err != nil {
+		t.Fatalf("ReserveCredits: %v", err)
+	}
+	var heldAmount float64
+	if err := s.Pool().QueryRow(ctx,
+		`SELECT amount FROM credit_holds WHERE id = $1`, holdID).Scan(&heldAmount); err != nil {
+		t.Fatalf("read hold: %v", err)
+	}
+	if !equalAt6dp(heldAmount, wantReserve) {
+		t.Errorf("hold amount = %.6f, want %.6f", heldAmount, wantReserve)
+	}
+
+	charged, err := s.SettleHold(holdID, settleCost)
+	if err != nil {
+		t.Fatalf("SettleHold: %v", err)
+	}
+	if !equalAt6dp(charged, wantSettle) {
+		t.Errorf("charged = %.6f, want %.6f", charged, wantSettle)
+	}
+
+	bal, err := s.GetCreditBalance(accID)
+	if err != nil || bal == nil {
+		t.Fatalf("GetCreditBalance: %v", err)
+	}
+	if !equalAt6dp(bal.Balance, 1000-wantSettle) {
+		t.Errorf("balance = %.6f, want %.6f", bal.Balance, 1000-wantSettle)
+	}
+	if !equalAt6dp(bal.Reserved, 0) {
+		t.Errorf("reserved = %.6f, want 0", bal.Reserved)
+	}
+
+	txns, err := s.GetCreditTransactions(accID, 10, 0)
+	if err != nil {
+		t.Fatalf("GetCreditTransactions: %v", err)
+	}
+	var usageAmount *float64
+	for i := range txns {
+		if txns[i].Type == "usage" {
+			usageAmount = &txns[i].Amount
+			break
+		}
+	}
+	if usageAmount == nil {
+		t.Fatal("no usage transaction recorded")
+	}
+	if !equalAt6dp(*usageAmount, -wantSettle) {
+		t.Errorf("usage transaction amount = %.6f, want %.6f", *usageAmount, -wantSettle)
+	}
+}

--- a/internal/proxy/admin_key_upgrade_test.go
+++ b/internal/proxy/admin_key_upgrade_test.go
@@ -29,7 +29,7 @@ func TestLegacyAdminKey_ChatsAfterBackfill(t *testing.T) {
 	defer upstream.Close()
 
 	const model = "llama3:latest"
-	if err := db.UpsertPricing(model, 0.001, 0.001, 100); err != nil {
+	if err := db.UpsertPricing(model, 1000, 1000, 100); err != nil {
 		t.Fatalf("UpsertPricing: %v", err)
 	}
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1488,8 +1488,8 @@ func listModels(t *testing.T, h http.Handler) map[string]string {
 
 func TestModels_IntersectionWithHealthyNodes(t *testing.T) {
 	db := setupTestDB(t)
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
-	_ = db.UpsertPricing("qwen2.5-coder:7b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
+	_ = db.UpsertPricing("qwen2.5-coder:7b", 2000, 2000, 500)
 
 	// Only llama3.1:8b is served by a healthy node.
 	reg := testRegistry(t, testNode{ID: 1, Name: "m5-max", URL: "http://n1:11434", Models: []string{"llama3.1:8b"}})
@@ -1507,7 +1507,7 @@ func TestModels_IntersectionWithHealthyNodes(t *testing.T) {
 
 func TestModels_OwnedByMultiple(t *testing.T) {
 	db := setupTestDB(t)
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	reg := testRegistry(t,
 		testNode{ID: 1, Name: "n1", URL: "http://n1:11434", Models: []string{"llama3.1:8b"}},
@@ -1524,8 +1524,8 @@ func TestModels_OwnedByMultiple(t *testing.T) {
 
 func TestModels_ListAllIncludesUnavailable(t *testing.T) {
 	db := setupTestDB(t)
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
-	_ = db.UpsertPricing("qwen2.5-coder:7b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
+	_ = db.UpsertPricing("qwen2.5-coder:7b", 2000, 2000, 500)
 
 	reg := testRegistry(t, testNode{ID: 1, Name: "n1", URL: "http://n1:11434", Models: []string{"llama3.1:8b"}})
 	usageCh := make(chan store.UsageEntry, 10)
@@ -1545,7 +1545,7 @@ func TestModels_ListAllIncludesUnavailable(t *testing.T) {
 
 func TestModels_UnhealthyNodeExcluded(t *testing.T) {
 	db := setupTestDB(t)
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	reg := testRegistry(t, testNode{ID: 1, Name: "n1", URL: "http://n1:11434", Models: []string{"llama3.1:8b"}, Unhealthy: true})
 	usageCh := make(chan store.UsageEntry, 10)
@@ -1563,7 +1563,7 @@ func TestCreditIntegration_UnknownModel_Returns400(t *testing.T) {
 	db := setupTestDB(t)
 	accID, _, _ := db.RegisterUser("model-test@example.com", "hash", "ModelTest")
 	_ = db.AddCredits(accID, 1000, "grant")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	upstream := mockOllamaChatNonStreaming(http.StatusOK, map[string]any{"id": "test"})
 	defer upstream.Close()
@@ -1592,7 +1592,7 @@ func TestCreditIntegration_ModelUnavailable_NoHoldCreated(t *testing.T) {
 	db := setupTestDB(t)
 	accID, _, _ := db.RegisterUser("unavail-test@example.com", "hash", "UnavailTest")
 	_ = db.AddCredits(accID, 1000, "grant")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	// The model is priced but NO healthy node serves it.
 	usageCh := make(chan store.UsageEntry, 10)
@@ -1631,7 +1631,7 @@ func TestCreditIntegration_ModelUnavailable_NoHoldCreated(t *testing.T) {
 func TestCreditIntegration_InsufficientCredits_Returns402(t *testing.T) {
 	db := setupTestDB(t)
 	accID, _, _ := db.RegisterUser("insuff-test@example.com", "hash", "InsuffTest")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	upstream := mockOllamaChatNonStreaming(http.StatusOK, map[string]any{"id": "test"})
 	defer upstream.Close()
@@ -1657,7 +1657,7 @@ func TestCreditIntegration_SettlesAfterResponse(t *testing.T) {
 	db := setupTestDB(t)
 	accID, _, _ := db.RegisterUser("settle-test@example.com", "hash", "SettleTest")
 	_ = db.AddCredits(accID, 1000, "grant")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	ollamaResp := map[string]any{
 		"id": "chatcmpl-123", "object": "chat.completion", "model": "llama3.1:8b",
@@ -1753,7 +1753,7 @@ func TestCreditIntegration_UpstreamError_ReleasesHold(t *testing.T) {
 	db := setupTestDB(t)
 	accID, _, _ := db.RegisterUser("release-test@example.com", "hash", "ReleaseTest")
 	_ = db.AddCredits(accID, 1000, "grant")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	upstream := mockOllamaChatNonStreaming(http.StatusInternalServerError, map[string]any{"error": "internal error"})
 	defer upstream.Close()
@@ -1778,8 +1778,8 @@ func TestCreditIntegration_UpstreamError_ReleasesHold(t *testing.T) {
 
 func TestCreditIntegration_Models_WithDB(t *testing.T) {
 	db := setupTestDB(t)
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
-	_ = db.UpsertPricing("qwen2.5-coder:7b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
+	_ = db.UpsertPricing("qwen2.5-coder:7b", 2000, 2000, 500)
 
 	// Both priced models are served by a healthy node, so both appear.
 	reg := testRegistry(t, testNode{ID: 1, Name: "n1", URL: "http://localhost:11434", Models: []string{"llama3.1:8b", "qwen2.5-coder:7b"}})
@@ -1796,7 +1796,7 @@ func TestCreditIntegration_SessionLimit_Returns429(t *testing.T) {
 	db := setupTestDB(t)
 	accID, userID, _ := db.RegisterUser("session-limit@example.com", "hash", "SessLimit")
 	_ = db.AddCredits(accID, 10000, "grant")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	keyID, _ := db.CreateKeyForAccount(userID, accID, "limited-key", "hash-limited", "sk-lim00", 60)
 
@@ -1830,7 +1830,7 @@ func TestCreditIntegration_NonStreaming_NoUsageTokens_EstimatesFromBody(t *testi
 	db := setupTestDB(t)
 	accID, _, _ := db.RegisterUser("estimate-body@example.com", "hash", "EstBody")
 	_ = db.AddCredits(accID, 1000, "grant")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	// Response without usage data — tokens will be estimated from body size
 	ollamaResp := map[string]any{
@@ -1867,7 +1867,7 @@ func TestCreditIntegration_WithMaxTokens(t *testing.T) {
 	db := setupTestDB(t)
 	accID, _, _ := db.RegisterUser("maxtok@example.com", "hash", "MaxTok")
 	_ = db.AddCredits(accID, 1000, "grant")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	ollamaResp := map[string]any{
 		"id": "chatcmpl-mt", "object": "chat.completion", "model": "llama3.1:8b",
@@ -1899,7 +1899,7 @@ func TestCreditIntegration_StreamingSettlement(t *testing.T) {
 	db := setupTestDB(t)
 	accID, _, _ := db.RegisterUser("stream-credit@example.com", "hash", "StreamCredit")
 	_ = db.AddCredits(accID, 1000, "grant")
-	_ = db.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500)
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
 
 	upstream := mockOllamaChatStreaming()
 	defer upstream.Close()

--- a/internal/store/credits.go
+++ b/internal/store/credits.go
@@ -308,14 +308,20 @@ func (s *Store) GetCreditTransactions(accountID int64, limit, offset int) ([]Cre
 	return txns, rows.Err()
 }
 
-// GetPricingByModel returns pricing for a specific model ID.
+// GetPricingByModel returns pricing for a specific model ID. Rates are
+// credits per million tokens. The COALESCE covers rows written by a
+// pre-per-MTok binary that the boot-time backfill has not converted yet
+// (mixed-version rollout window).
 func (s *Store) GetPricingByModel(modelID string) (*CreditPricing, error) {
 	var p CreditPricing
 	err := s.pool.QueryRow(
 		context.Background(),
-		`SELECT id, model_id, prompt_rate, completion_rate, typical_completion, effective_from, active
+		`SELECT id, model_id,
+		        COALESCE(prompt_rate_mtok, prompt_rate * 1000000),
+		        COALESCE(completion_rate_mtok, completion_rate * 1000000),
+		        typical_completion, effective_from, active
 		 FROM credit_pricing WHERE model_id = $1 AND active = TRUE`, modelID,
-	).Scan(&p.ID, &p.ModelID, &p.PromptRate, &p.CompletionRate, &p.TypicalCompletion, &p.EffectiveFrom, &p.Active)
+	).Scan(&p.ID, &p.ModelID, &p.PromptRatePerMTok, &p.CompletionRatePerMTok, &p.TypicalCompletion, &p.EffectiveFrom, &p.Active)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -325,11 +331,15 @@ func (s *Store) GetPricingByModel(modelID string) (*CreditPricing, error) {
 	return &p, nil
 }
 
-// ListActivePricing returns all active pricing rules.
+// ListActivePricing returns all active pricing rules. Rates are credits per
+// million tokens (see GetPricingByModel for the COALESCE rationale).
 func (s *Store) ListActivePricing() ([]CreditPricing, error) {
 	rows, err := s.pool.Query(
 		context.Background(),
-		`SELECT id, model_id, prompt_rate, completion_rate, typical_completion, effective_from, active
+		`SELECT id, model_id,
+		        COALESCE(prompt_rate_mtok, prompt_rate * 1000000),
+		        COALESCE(completion_rate_mtok, completion_rate * 1000000),
+		        typical_completion, effective_from, active
 		 FROM credit_pricing WHERE active = TRUE ORDER BY model_id`,
 	)
 	if err != nil {
@@ -340,7 +350,7 @@ func (s *Store) ListActivePricing() ([]CreditPricing, error) {
 	var pricing []CreditPricing
 	for rows.Next() {
 		var p CreditPricing
-		if err := rows.Scan(&p.ID, &p.ModelID, &p.PromptRate, &p.CompletionRate,
+		if err := rows.Scan(&p.ID, &p.ModelID, &p.PromptRatePerMTok, &p.CompletionRatePerMTok,
 			&p.TypicalCompletion, &p.EffectiveFrom, &p.Active); err != nil {
 			return nil, err
 		}
@@ -349,18 +359,26 @@ func (s *Store) ListActivePricing() ([]CreditPricing, error) {
 	return pricing, rows.Err()
 }
 
-// UpsertPricing creates or updates a pricing rule.
-func (s *Store) UpsertPricing(modelID string, promptRate, completionRate float64, typicalCompletion int) error {
+// UpsertPricing creates or updates a pricing rule. Rates are credits per
+// MILLION tokens. The deprecated per-token columns (prompt_rate,
+// completion_rate) are kept in sync (= rate / 1e6, computed in numeric so
+// the decimal shift is exact, then rounded to their 10-decimal scale) so a
+// rolled-back binary still reads correct prices; they are dropped in a
+// later release.
+func (s *Store) UpsertPricing(modelID string, promptRatePerMTok, completionRatePerMTok float64, typicalCompletion int) error {
 	_, err := s.pool.Exec(
 		context.Background(),
-		`INSERT INTO credit_pricing (model_id, prompt_rate, completion_rate, typical_completion)
-		 VALUES ($1, $2, $3, $4)
+		`INSERT INTO credit_pricing
+		   (model_id, prompt_rate, completion_rate, prompt_rate_mtok, completion_rate_mtok, typical_completion)
+		 VALUES ($1, $2::numeric / 1000000, $3::numeric / 1000000, $2, $3, $4)
 		 ON CONFLICT (model_id) DO UPDATE SET
 		   prompt_rate = EXCLUDED.prompt_rate,
 		   completion_rate = EXCLUDED.completion_rate,
+		   prompt_rate_mtok = EXCLUDED.prompt_rate_mtok,
+		   completion_rate_mtok = EXCLUDED.completion_rate_mtok,
 		   typical_completion = EXCLUDED.typical_completion,
 		   active = TRUE`,
-		modelID, promptRate, completionRate, typicalCompletion,
+		modelID, promptRatePerMTok, completionRatePerMTok, typicalCompletion,
 	)
 	return err
 }

--- a/internal/store/credits_test.go
+++ b/internal/store/credits_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"math"
 	"sync"
 	"testing"
@@ -442,7 +443,8 @@ func TestCleanupSettledHolds(t *testing.T) {
 func TestUpsertAndGetPricing(t *testing.T) {
 	s := setupTestStore(t)
 
-	if err := s.UpsertPricing("llama3.1:8b", 0.002, 0.002, 500); err != nil {
+	// Rates are credits per MILLION tokens (2000/MTok = old 0.002/token).
+	if err := s.UpsertPricing("llama3.1:8b", 2000, 2000, 500); err != nil {
 		t.Fatalf("UpsertPricing: %v", err)
 	}
 
@@ -453,11 +455,25 @@ func TestUpsertAndGetPricing(t *testing.T) {
 	if p == nil {
 		t.Fatal("expected pricing, got nil")
 	}
-	if !almostEqual(p.PromptRate, 0.002) {
-		t.Errorf("expected prompt_rate 0.002, got %f", p.PromptRate)
+	if !almostEqual(p.PromptRatePerMTok, 2000) {
+		t.Errorf("expected prompt_rate_per_mtok 2000, got %f", p.PromptRatePerMTok)
 	}
 	if p.TypicalCompletion != 500 {
 		t.Errorf("expected typical_completion 500, got %d", p.TypicalCompletion)
+	}
+
+	// The deprecated per-token columns must be kept in sync (= mtok / 1e6)
+	// so a rolled-back binary still reads correct prices until the columns
+	// are dropped in a later release.
+	var legacyPrompt, legacyCompletion float64
+	err = s.Pool().QueryRow(context.Background(),
+		`SELECT prompt_rate, completion_rate FROM credit_pricing WHERE model_id = 'llama3.1:8b'`,
+	).Scan(&legacyPrompt, &legacyCompletion)
+	if err != nil {
+		t.Fatalf("read legacy columns: %v", err)
+	}
+	if !almostEqual(legacyPrompt, 0.002) || !almostEqual(legacyCompletion, 0.002) {
+		t.Errorf("legacy per-token columns = %f/%f, want 0.002/0.002 (kept in sync)", legacyPrompt, legacyCompletion)
 	}
 }
 
@@ -476,8 +492,8 @@ func TestGetPricingByModel_NotFound(t *testing.T) {
 func TestListActivePricing(t *testing.T) {
 	s := setupTestStore(t)
 
-	_ = s.UpsertPricing("model-a", 0.001, 0.001, 300)
-	_ = s.UpsertPricing("model-b", 0.002, 0.002, 500)
+	_ = s.UpsertPricing("model-a", 1000, 1000, 300)
+	_ = s.UpsertPricing("model-b", 2000, 2000, 500)
 
 	pricing, err := s.ListActivePricing()
 	if err != nil {
@@ -491,7 +507,7 @@ func TestListActivePricing(t *testing.T) {
 func TestDeletePricing(t *testing.T) {
 	s := setupTestStore(t)
 
-	_ = s.UpsertPricing("delete-me", 0.001, 0.001, 300)
+	_ = s.UpsertPricing("delete-me", 1000, 1000, 300)
 	p, _ := s.GetPricingByModel("delete-me")
 
 	if err := s.DeletePricing(p.ID); err != nil {
@@ -507,19 +523,19 @@ func TestDeletePricing(t *testing.T) {
 func TestUpsertPricing_Reactivates(t *testing.T) {
 	s := setupTestStore(t)
 
-	_ = s.UpsertPricing("reactivate", 0.001, 0.001, 300)
+	_ = s.UpsertPricing("reactivate", 1000, 1000, 300)
 	p, _ := s.GetPricingByModel("reactivate")
 	_ = s.DeletePricing(p.ID)
 
 	// Upsert should reactivate
-	_ = s.UpsertPricing("reactivate", 0.003, 0.003, 600)
+	_ = s.UpsertPricing("reactivate", 3000, 3000, 600)
 
 	p2, _ := s.GetPricingByModel("reactivate")
 	if p2 == nil {
 		t.Fatal("expected pricing to be reactivated")
 	}
-	if !almostEqual(p2.PromptRate, 0.003) {
-		t.Errorf("expected updated prompt_rate 0.003, got %f", p2.PromptRate)
+	if !almostEqual(p2.PromptRatePerMTok, 3000) {
+		t.Errorf("expected updated prompt_rate_per_mtok 3000, got %f", p2.PromptRatePerMTok)
 	}
 }
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -219,3 +219,40 @@ END $$;
 
 CREATE INDEX IF NOT EXISTS idx_usage_logs_node_created
     ON usage_logs(node_id, created_at);
+
+-- ---------------------------------------------------------------------------
+-- Pricing re-denomination (OSS-5): canonical rates are credits per MILLION
+-- tokens (per-MTok, the industry convention). Charge math everywhere is
+--   cost = tokens * rate_mtok / 1_000_000
+-- and application code reads/writes ONLY the *_mtok columns below.
+--
+-- The old per-token columns (prompt_rate, completion_rate) are DEPRECATED:
+-- application writes keep them in sync (= rate_mtok / 1e6, rounded to their
+-- 10-decimal scale) purely so a rolled-back binary still reads correct
+-- prices during the transition. They will be DROPPED in a later release.
+--
+-- Idempotency (production-critical): this file is re-executed in full on
+-- EVERY boot. The duplicate_column guards make the ADD COLUMNs no-ops after
+-- the first run, and the backfill only touches rows whose *_mtok value is
+-- still NULL — so re-running the schema can never multiply an
+-- already-converted rate again, and never clobbers a rate later re-priced
+-- through the per-MTok admin API. The x1e6 backfill itself is lossless:
+-- DECIMAL(15,10) * 1e6 needs at most 4 fractional digits, which
+-- DECIMAL(15,6) stores exactly. Pinned by TestRedenomination_MigrationIdempotent
+-- and TestRedenomination_EqualCostProof.
+DO $$ BEGIN
+    ALTER TABLE credit_pricing ADD COLUMN prompt_rate_mtok DECIMAL(15,6);
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE credit_pricing ADD COLUMN completion_rate_mtok DECIMAL(15,6);
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;
+
+UPDATE credit_pricing SET prompt_rate_mtok = prompt_rate * 1000000
+    WHERE prompt_rate_mtok IS NULL;
+UPDATE credit_pricing SET completion_rate_mtok = completion_rate * 1000000
+    WHERE completion_rate_mtok IS NULL;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -132,14 +132,17 @@ type CreditHold struct {
 	SettledAt *time.Time
 }
 
+// CreditPricing rates are denominated in credits per MILLION tokens
+// (per-MTok, the industry convention): cost = tokens × rate / 1_000_000.
+// Backed by credit_pricing.prompt_rate_mtok / completion_rate_mtok.
 type CreditPricing struct {
-	ID                int64     `json:"id"`
-	ModelID           string    `json:"model_id"`
-	PromptRate        float64   `json:"prompt_rate"`
-	CompletionRate    float64   `json:"completion_rate"`
-	TypicalCompletion int       `json:"typical_completion"`
-	EffectiveFrom     time.Time `json:"effective_from"`
-	Active            bool      `json:"active"`
+	ID                    int64     `json:"id"`
+	ModelID               string    `json:"model_id"`
+	PromptRatePerMTok     float64   `json:"prompt_rate_per_mtok"`
+	CompletionRatePerMTok float64   `json:"completion_rate_per_mtok"`
+	TypicalCompletion     int       `json:"typical_completion"`
+	EffectiveFrom         time.Time `json:"effective_from"`
+	Active                bool      `json:"active"`
 }
 
 type AccountUsageStats struct {


### PR DESCRIPTION
## Semantics change (loud on purpose)

**Pricing rates are re-denominated from credits per TOKEN to credits per MILLION tokens (per-MTok, the industry convention).** This is a re-denomination ONLY: effective prices, balances, usage history, and credit transactions are provably unchanged. Existing rates are migrated ×1e6 automatically (e.g. the live `gemma4:e4b` row at `0.004`/token becomes `4000`/MTok — same price).

## API field renames (old names now 400)

`POST /api/admin/pricing` requests and all pricing responses:

| Old (per token) | New (per million tokens) |
|---|---|
| `prompt_rate` | `prompt_rate_per_mtok` |
| `completion_rate` | `completion_rate_per_mtok` |

The endpoint now uses **strict JSON decoding**: the old field names — or any unknown field — are rejected with `400 unknown_field` naming the offending field, so a stale client can never have its per-token value silently misread as per-MTok. `GET /api/v1/models` is unaffected (no rates exposed).

## Migration behavior (production-critical: schema.sql re-runs on every boot)

- New nullable columns `credit_pricing.prompt_rate_mtok` / `completion_rate_mtok DECIMAL(15,6)`, added via the repo's `duplicate_column` DO-block pattern.
- Backfill `SET *_mtok = old * 1e6 WHERE *_mtok IS NULL` — the NULL guard (plus old→new being a copy between *separate columns*, never in-place) makes re-running the whole schema on every boot a no-op after the first conversion. **It can never compound**, and it never clobbers a row later re-priced via the new API.
- The backfill is lossless: `DECIMAL(15,10) × 1e6` needs at most 4 fractional digits; `DECIMAL(15,6)` stores them exactly.
- **Old-column policy:** `prompt_rate`/`completion_rate` are deprecated but kept write-synced (`= mtok / 1e6`, computed in numeric) so a rolled-back binary still reads correct prices; reads use `COALESCE(mtok, old × 1e6)` to survive mixed-version windows. The old columns get dropped in a later release (documented in schema.sql).

## Charge math

`credits.EstimateCost` — the single place a rate meets a token count (reserve sizing and both settle paths) — is now `cost = (promptTokens × promptRatePerMTok + completionTokens × completionRatePerMTok) / 1e6`. One division at the end keeps the float64 result within 1 ulp of the old per-token math, far inside the 6 decimal places the DB stores.

## Equal-cost proof (effective prices unchanged)

- **`TestRedenomination_EqualCostProof`** (`internal/credits/redenomination_test.go`): a legacy per-token row (`0.004`/`0.001`) is migrated by re-running the real schema, then driven through the real `ReserveCredits` → `SettleHold` flow; the hold amount, settled charge, balance delta, and `credit_transactions` row all equal the **hardcoded old-math costs** (reserve `5.503`, settle `4.023`) at the DB's 6-decimal precision.
- **`TestRedenomination_MigrationIdempotent`**: schema applied on 3 additional simulated boots — backfilled values are byte-identical each time (`4000.000000`), and a row re-priced through the new API (`2000.000001`/MTok) survives reboots untouched.
- **`TestEstimateCost_PerMTokMatchesOldPerTokenMath`**: unit fixtures (incl. the production `0.004`/token rate) hardcoding old-math expectations; new math on ×1e6 rates matches to 1e-9 and exactly at 6dp.

## Test results

`go test -race -count=1 -p 1 ./...` — **881 passed, 0 failed** (against Postgres 16). `gofmt` clean, `go vet` clean, `CGO_ENABLED=0 go build ./cmd/proxy` OK. No new dependencies.

## Notes for FE-3

- Zod schemas / forms must switch to `prompt_rate_per_mtok` / `completion_rate_per_mtok` (requests AND responses); sending the old names now 400s with code `unknown_field`.
- Validation: rates must be `> 0`; server stores 6 decimal places, `DECIMAL(15,6)` (values up to ~1e9). `typical_completion` unchanged (`<= 0` defaults to 500).
- Operator repricing in the UI is manual and follows separately (values migrate ×1e6 automatically, so nothing breaks meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSYCn4mZxomD5Aauu5hJPr