### PR TITLE
feat(admin): derive last_used_at for API keys from usage_logs

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -132,6 +132,10 @@ type keyResponse struct {
 	RateLimit int       `json:"rate_limit"`
 	CreatedAt time.Time `json:"created_at"`
 	Revoked   bool      `json:"revoked"`
+	// LastUsedAt is the most recent request time derived from usage_logs,
+	// RFC3339-formatted. nil (JSON null) means the key has never served a
+	// request — the FE renders that as "Never".
+	LastUsedAt *string `json:"last_used_at"`
 }
 
 func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.UsageEntry, opts Options) http.Handler {
@@ -415,12 +419,13 @@ func (h *handler) listKeys(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		resp = append(resp, keyResponse{
-			ID:        apiKey.ID,
-			Name:      apiKey.Name,
-			KeyPrefix: apiKey.KeyPrefix,
-			RateLimit: apiKey.RateLimit,
-			CreatedAt: apiKey.CreatedAt,
-			Revoked:   apiKey.Revoked,
+			ID:         apiKey.ID,
+			Name:       apiKey.Name,
+			KeyPrefix:  apiKey.KeyPrefix,
+			RateLimit:  apiKey.RateLimit,
+			CreatedAt:  apiKey.CreatedAt,
+			Revoked:    apiKey.Revoked,
+			LastUsedAt: formatRFC3339Ptr(apiKey.LastUsedAt),
 		})
 	}
 
@@ -1156,15 +1161,16 @@ func (h *handler) updateUserRole(w http.ResponseWriter, r *http.Request) {
 }
 
 type keyDetailDTO struct {
-	ID                int64  `json:"id"`
-	Name              string `json:"name"`
-	KeyPrefix         string `json:"key_prefix"`
-	RateLimit         int    `json:"rate_limit"`
-	Revoked           bool   `json:"revoked"`
-	UserID            *int64 `json:"user_id"`
-	AccountID         *int64 `json:"account_id"`
-	SessionTokenLimit *int   `json:"session_token_limit"`
-	CreatedAt         string `json:"created_at"`
+	ID                int64   `json:"id"`
+	Name              string  `json:"name"`
+	KeyPrefix         string  `json:"key_prefix"`
+	RateLimit         int     `json:"rate_limit"`
+	Revoked           bool    `json:"revoked"`
+	UserID            *int64  `json:"user_id"`
+	AccountID         *int64  `json:"account_id"`
+	SessionTokenLimit *int    `json:"session_token_limit"`
+	CreatedAt         string  `json:"created_at"`
+	LastUsedAt        *string `json:"last_used_at"`
 }
 
 func toKeyDetailDTO(k *store.APIKey) keyDetailDTO {
@@ -1178,7 +1184,18 @@ func toKeyDetailDTO(k *store.APIKey) keyDetailDTO {
 		AccountID:         k.AccountID,
 		SessionTokenLimit: k.SessionTokenLimit,
 		CreatedAt:         k.CreatedAt.Format(time.RFC3339),
+		LastUsedAt:        formatRFC3339Ptr(k.LastUsedAt),
 	}
+}
+
+// formatRFC3339Ptr renders a nullable timestamp as an RFC3339 string pointer,
+// preserving nil so the JSON field serializes to null (never a zero time).
+func formatRFC3339Ptr(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.Format(time.RFC3339)
+	return &s
 }
 
 func (h *handler) getKey(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/admin_keys_last_used_test.go
+++ b/internal/admin/admin_keys_last_used_test.go
@@ -1,0 +1,84 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestAdmin_ListKeys_IncludesLastUsedAt verifies GET /api/admin/keys surfaces
+// last_used_at derived from usage_logs: a key with usage carries an RFC3339
+// timestamp, an unused key carries JSON null.
+func TestAdmin_ListKeys_IncludesLastUsedAt(t *testing.T) {
+	h, s := setupAdminTest(t)
+	ctx := context.Background()
+
+	acctID, err := s.CreateAccount("svc-http-lastused", "service")
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	usedKey, err := s.CreateKeyForAccountOnly(acctID, "used-key", "hash-http-used", "sk-huse", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccountOnly used: %v", err)
+	}
+	unusedKey, err := s.CreateKeyForAccountOnly(acctID, "unused-key", "hash-http-unused", "sk-hunu", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccountOnly unused: %v", err)
+	}
+
+	ts := time.Now().UTC().Add(-90 * time.Minute).Truncate(time.Second)
+	if _, err := s.Pool().Exec(ctx,
+		`INSERT INTO usage_logs (api_key_id, model, total_tokens, status, created_at)
+		 VALUES ($1, 'llama3.1:8b', 12, 'completed', $2)`, usedKey, ts,
+	); err != nil {
+		t.Fatalf("insert usage row: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/keys", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// GET /api/admin/keys defaults to the enveloped shape (envelope="" → true).
+	var body struct {
+		Data []keyResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+
+	byID := make(map[int64]keyResponse, len(body.Data))
+	for _, k := range body.Data {
+		byID[k.ID] = k
+	}
+
+	used, ok := byID[usedKey]
+	if !ok {
+		t.Fatalf("used key %d missing from response", usedKey)
+	}
+	if used.LastUsedAt == nil {
+		t.Fatal("expected last_used_at for a key with usage, got null")
+	}
+	parsed, err := time.Parse(time.RFC3339, *used.LastUsedAt)
+	if err != nil {
+		t.Fatalf("last_used_at is not RFC3339: %q (%v)", *used.LastUsedAt, err)
+	}
+	if !parsed.Equal(ts) {
+		t.Errorf("expected last_used_at %v, got %v", ts, parsed)
+	}
+
+	unused, ok := byID[unusedKey]
+	if !ok {
+		t.Fatalf("unused key %d missing from response", unusedKey)
+	}
+	if unused.LastUsedAt != nil {
+		t.Errorf("expected null last_used_at for unused key, got %q", *unused.LastUsedAt)
+	}
+}

--- a/internal/store/list_keys_last_used_test.go
+++ b/internal/store/list_keys_last_used_test.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestListKeys_LastUsedAt verifies that ListKeys derives last_used_at from the
+// usage_logs table via a MAX(created_at) join: a key with usage reports the
+// most recent request time, and a key that never served traffic reports nil.
+func TestListKeys_LastUsedAt(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	acctID, err := s.CreateAccount("svc-lastused", "service")
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	usedKey, err := s.CreateKeyForAccountOnly(acctID, "used-key", "hash-used", "sk-used", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccountOnly used: %v", err)
+	}
+	unusedKey, err := s.CreateKeyForAccountOnly(acctID, "unused-key", "hash-unused", "sk-unus", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccountOnly unused: %v", err)
+	}
+
+	// Two usage rows for the used key — the newer timestamp must win. Truncate
+	// to whole seconds so the Postgres round-trip compares cleanly with .Equal.
+	older := time.Now().UTC().Add(-3 * time.Hour).Truncate(time.Second)
+	newest := time.Now().UTC().Add(-30 * time.Minute).Truncate(time.Second)
+	for _, ts := range []time.Time{older, newest} {
+		if _, err := s.pool.Exec(ctx,
+			`INSERT INTO usage_logs (api_key_id, model, total_tokens, status, created_at)
+			 VALUES ($1, 'llama3.1:8b', 10, 'completed', $2)`, usedKey, ts,
+		); err != nil {
+			t.Fatalf("insert usage row: %v", err)
+		}
+	}
+
+	keys, err := s.ListKeys()
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+
+	byID := make(map[int64]APIKey, len(keys))
+	for _, k := range keys {
+		byID[k.ID] = k
+	}
+
+	used, ok := byID[usedKey]
+	if !ok {
+		t.Fatalf("used key %d missing from ListKeys result", usedKey)
+	}
+	if used.LastUsedAt == nil {
+		t.Fatal("expected LastUsedAt to be set for a key with usage, got nil")
+	}
+	if !used.LastUsedAt.Equal(newest) {
+		t.Errorf("expected LastUsedAt %v (the most recent usage), got %v", newest, *used.LastUsedAt)
+	}
+
+	unused, ok := byID[unusedKey]
+	if !ok {
+		t.Fatalf("unused key %d missing from ListKeys result", unusedKey)
+	}
+	if unused.LastUsedAt != nil {
+		t.Errorf("expected nil LastUsedAt for a key with no usage, got %v", *unused.LastUsedAt)
+	}
+}
+
+// TestGetKeyByID_LastUsedAt verifies the single-key detail path derives
+// last_used_at the same way the list path does.
+func TestGetKeyByID_LastUsedAt(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	acctID, err := s.CreateAccount("svc-detail-lastused", "service")
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	keyID, err := s.CreateKeyForAccountOnly(acctID, "detail-key", "hash-detail", "sk-det", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccountOnly: %v", err)
+	}
+
+	ts := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO usage_logs (api_key_id, model, total_tokens, status, created_at)
+		 VALUES ($1, 'llama3.1:8b', 5, 'completed', $2)`, keyID, ts,
+	); err != nil {
+		t.Fatalf("insert usage row: %v", err)
+	}
+
+	k, err := s.GetKeyByID(keyID)
+	if err != nil {
+		t.Fatalf("GetKeyByID: %v", err)
+	}
+	if k == nil {
+		t.Fatal("expected key, got nil")
+	}
+	if k.LastUsedAt == nil {
+		t.Fatal("expected LastUsedAt to be set, got nil")
+	}
+	if !k.LastUsedAt.Equal(ts) {
+		t.Errorf("expected LastUsedAt %v, got %v", ts, *k.LastUsedAt)
+	}
+
+	// A freshly created key with no usage reports nil.
+	freshID, err := s.CreateKeyForAccountOnly(acctID, "fresh-key", "hash-fresh", "sk-frs", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccountOnly fresh: %v", err)
+	}
+	fresh, err := s.GetKeyByID(freshID)
+	if err != nil {
+		t.Fatalf("GetKeyByID fresh: %v", err)
+	}
+	if fresh.LastUsedAt != nil {
+		t.Errorf("expected nil LastUsedAt for unused key, got %v", *fresh.LastUsedAt)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -57,9 +57,10 @@ type APIKey struct {
 	RateLimit         int
 	CreatedAt         time.Time
 	Revoked           bool
-	UserID            *int64 // nil = legacy admin-created key
-	AccountID         *int64 // nil = legacy key not on credit system
-	SessionTokenLimit *int   // nil = no session limit
+	UserID            *int64     // nil = legacy admin-created key
+	AccountID         *int64     // nil = legacy key not on credit system
+	SessionTokenLimit *int       // nil = no session limit
+	LastUsedAt        *time.Time // nil = key has never served a request; derived from usage_logs
 }
 
 type Account struct {
@@ -318,11 +319,23 @@ func (s *Store) GetKeyByHash(hash string) (*APIKey, error) {
 	return &apiKey, nil
 }
 
-// ListKeys returns all API keys (for admin display).
+// ListKeys returns all API keys (for admin display). last_used_at is derived
+// from usage_logs as MAX(created_at) per key — a LEFT JOIN over the aggregate
+// so keys that never served a request report NULL rather than being dropped.
+// The idx_usage_logs_key_created (api_key_id, created_at) index makes the
+// grouped max a cheap index-only scan.
 func (s *Store) ListKeys() ([]APIKey, error) {
 	rows, err := s.pool.Query(
 		context.Background(),
-		`SELECT id, name, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit FROM api_keys ORDER BY id`,
+		`SELECT k.id, k.name, k.key_prefix, k.rate_limit, k.created_at, k.revoked,
+		        k.user_id, k.account_id, k.session_token_limit, u.last_used_at
+		 FROM api_keys k
+		 LEFT JOIN (
+		     SELECT api_key_id, MAX(created_at) AS last_used_at
+		     FROM usage_logs
+		     GROUP BY api_key_id
+		 ) u ON u.api_key_id = k.id
+		 ORDER BY k.id`,
 	)
 	if err != nil {
 		return nil, err
@@ -333,7 +346,7 @@ func (s *Store) ListKeys() ([]APIKey, error) {
 	for rows.Next() {
 		var apiKey APIKey
 		if err := rows.Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyPrefix, &apiKey.RateLimit, &apiKey.CreatedAt, &apiKey.Revoked,
-			&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit); err != nil {
+			&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.LastUsedAt); err != nil {
 			return nil, err
 		}
 		keys = append(keys, apiKey)
@@ -342,15 +355,17 @@ func (s *Store) ListKeys() ([]APIKey, error) {
 }
 
 // GetKeyByID looks up an API key by ID, including revoked keys so admin UI
-// can display their history.
+// can display their history. last_used_at is derived from usage_logs as the
+// most recent request time (NULL when the key has never served traffic).
 func (s *Store) GetKeyByID(id int64) (*APIKey, error) {
 	var apiKey APIKey
 	err := s.pool.QueryRow(
 		context.Background(),
-		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit
+		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit,
+		        (SELECT MAX(created_at) FROM usage_logs WHERE api_key_id = api_keys.id)
 		 FROM api_keys WHERE id = $1`, id,
 	).Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyHash, &apiKey.KeyPrefix, &apiKey.RateLimit,
-		&apiKey.CreatedAt, &apiKey.Revoked, &apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit)
+		&apiKey.CreatedAt, &apiKey.Revoked, &apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.LastUsedAt)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}


### PR DESCRIPTION
## What & why

Part of the P3 data-hygiene bundle from the 2026-07-08 live UX review
([Notion task](https://app.notion.com/p/3974e3037849811382b3e19da3cad28e)).

The Keys table couldn't show which keys are stale. This adds `last_used_at` to
the admin keys list and detail responses so the frontend can render a "Last used"
column.

## Deriving last_used_at (no new tracking)

`last_used_at` is **derived** from the existing `usage_logs` table — no new
column, table, or write-path tracking. Every proxied request already writes a
`usage_logs` row (`api_key_id`, `created_at`), and `idx_usage_logs_key_created
(api_key_id, created_at)` already exists, so per-key `MAX(created_at)` is a cheap
index scan.

- `ListKeys`: `LEFT JOIN` over a grouped `MAX(created_at)` aggregate — keys that
  never served a request keep a `NULL` value rather than being dropped.
- `GetKeyByID`: correlated subquery for the single-row detail path.
- `GetKeyByHash` (the hot auth path) is intentionally left untouched.

Wire shape: `last_used_at` is RFC3339, or JSON `null` for an unused key (the FE
renders that as "Never").

## Tests

- `store.TestListKeys_LastUsedAt` — MAX wins across multiple usage rows; unused
  key reports nil.
- `store.TestGetKeyByID_LastUsedAt` — detail path derives the same value; nil case.
- `admin.TestAdmin_ListKeys_IncludesLastUsedAt` — HTTP response carries the
  RFC3339 field and `null` for an unused key.

`go test ./...` passes (serially, `-p 1`, matching CI; the shared-DB parallel run
has unrelated cross-package contention). `go vet` clean.

## Related

Frontend PR (consumes this field + the pricing/keys UX work):
**skrx7392/local-ai-proxy-admin-frontend — feat/ux-p3-pricing-keys-hygiene**
(link added in comment once open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rE1EhKeQamPB8zT5MvbuV
