### PR TITLE
feat(store): federated end-user accounts + monthly allowance (EUA-2)

### DIFF
--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -87,7 +87,10 @@ func buildUsageFilterClause(sb *strings.Builder, args []any, f UsageFilter, argI
 		argIdx++
 	}
 	if f.AccountID != nil {
-		fmt.Fprintf(sb, " AND k.account_id = $%d", argIdx)
+		// Billing attribution: prefer the per-row billing account (end-user
+		// accounts on trusted keys, EUA); fall back to the key's account for
+		// pre-attribution rows.
+		fmt.Fprintf(sb, " AND COALESCE(ul.account_id, k.account_id) = $%d", argIdx)
 		args = append(args, *f.AccountID)
 		argIdx++
 	}
@@ -194,7 +197,7 @@ func (s *Store) GetUsageByUser(f UsageFilter) ([]OwnerUsageRow, error) {
 		   k.user_id,
 		   usr.email,
 		   usr.name,
-		   k.account_id,
+		   COALESCE(ul.account_id, k.account_id),
 		   a.name,
 		   a.type,
 		   COUNT(*),
@@ -204,11 +207,11 @@ func (s *Store) GetUsageByUser(f UsageFilter) ([]OwnerUsageRow, error) {
 		 FROM usage_logs ul
 		 JOIN api_keys k ON ul.api_key_id = k.id
 		 LEFT JOIN users usr ON usr.id = k.user_id
-		 LEFT JOIN accounts a ON a.id = k.account_id
+		 LEFT JOIN accounts a ON a.id = COALESCE(ul.account_id, k.account_id)
 		 WHERE 1=1`)
 	args, _ := buildUsageFilterClause(&sb, nil, f, 1)
 	sb.WriteString(
-		` GROUP BY k.user_id, usr.email, usr.name, k.account_id, a.name, a.type
+		` GROUP BY k.user_id, usr.email, usr.name, COALESCE(ul.account_id, k.account_id), a.name, a.type
 		  ORDER BY COALESCE(SUM(ul.total_tokens), 0) DESC`)
 
 	rows, err := s.pool.Query(context.Background(), sb.String(), args...)

--- a/internal/store/federated.go
+++ b/internal/store/federated.go
@@ -1,0 +1,244 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// FederatedIdentity is an end-user identity forwarded by a trusted key
+// (docs/design/end-user-accounts.md). (Source, ExternalID) is the authority;
+// Email and DisplayName are display metadata refreshed on every sight.
+type FederatedIdentity struct {
+	Source      string
+	ExternalID  string
+	Email       string
+	DisplayName string
+}
+
+// EndUserResolution reports what ResolveEndUserAccount did.
+type EndUserResolution struct {
+	AccountID        int64
+	Provisioned      bool // account was created by this call
+	AllowanceGranted bool // monthly allowance was applied by this call
+}
+
+// accountName picks the display name for an auto-provisioned account:
+// email, else display name, else a source-qualified external id.
+func (f FederatedIdentity) accountName() string {
+	if f.Email != "" {
+		return f.Email
+	}
+	if f.DisplayName != "" {
+		return f.DisplayName
+	}
+	return fmt.Sprintf("%s:%s", f.Source, f.ExternalID)
+}
+
+// ResolveEndUserAccount maps a federated identity to its billing account,
+// provisioning the account on first sight and applying the monthly allowance
+// when due. Safe under concurrent first sight: the UNIQUE(source, external_id)
+// constraint elects one winner and losers adopt its account; the allowance
+// top-up is guarded so exactly one grant lands per account per month.
+//
+// defaultGrant is the env-level monthly allowance, overridden per account by
+// accounts.monthly_grant (explicit 0 = blocked). now is injected for
+// testability; callers pass time.Now().
+func (s *Store) ResolveEndUserAccount(id FederatedIdentity, defaultGrant float64, now time.Time) (EndUserResolution, error) {
+	var res EndUserResolution
+	ctx := context.Background()
+
+	accountID, err := s.lookupFederatedAccount(ctx, id)
+	if err != nil {
+		return res, err
+	}
+	if accountID == 0 {
+		accountID, res.Provisioned, err = s.provisionFederatedAccount(ctx, id)
+		if err != nil {
+			return res, err
+		}
+	}
+	res.AccountID = accountID
+
+	res.AllowanceGranted, err = s.applyMonthlyAllowance(ctx, accountID, defaultGrant, now)
+	if err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+// lookupFederatedAccount returns the existing account for an identity
+// (refreshing its metadata), or 0 when the identity is unknown.
+func (s *Store) lookupFederatedAccount(ctx context.Context, id FederatedIdentity) (int64, error) {
+	var accountID int64
+	err := s.pool.QueryRow(ctx,
+		`UPDATE federated_identities
+		 SET email = $3, display_name = $4, last_seen_at = NOW()
+		 WHERE source = $1 AND external_id = $2
+		 RETURNING account_id`,
+		id.Source, id.ExternalID, id.Email, id.DisplayName,
+	).Scan(&accountID)
+	if err == pgx.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return accountID, nil
+}
+
+// provisionFederatedAccount creates account + zero balance + identity +
+// registration event in one transaction. On an identity-insert conflict
+// (concurrent first sight) the whole transaction rolls back — discarding the
+// orphan account — and the winner's account is adopted.
+func (s *Store) provisionFederatedAccount(ctx context.Context, id FederatedIdentity) (accountID int64, provisioned bool, err error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, false, err
+	}
+	defer tx.Rollback(ctx)
+
+	err = tx.QueryRow(ctx,
+		`INSERT INTO accounts (name, type, allowance_managed) VALUES ($1, 'end_user', TRUE) RETURNING id`,
+		id.accountName(),
+	).Scan(&accountID)
+	if err != nil {
+		return 0, false, err
+	}
+	if _, err = tx.Exec(ctx,
+		`INSERT INTO credit_balances (account_id, balance, reserved) VALUES ($1, 0, 0)`,
+		accountID,
+	); err != nil {
+		return 0, false, err
+	}
+
+	var identityID int64
+	err = tx.QueryRow(ctx,
+		`INSERT INTO federated_identities (source, external_id, account_id, email, display_name)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (source, external_id) DO NOTHING
+		 RETURNING id`,
+		id.Source, id.ExternalID, accountID, id.Email, id.DisplayName,
+	).Scan(&identityID)
+	if err == pgx.ErrNoRows {
+		// Lost the race: roll back our provisional rows, adopt the winner's account.
+		if rbErr := tx.Rollback(ctx); rbErr != nil {
+			return 0, false, rbErr
+		}
+		winner, lookErr := s.lookupFederatedAccount(ctx, id)
+		if lookErr != nil {
+			return 0, false, lookErr
+		}
+		if winner == 0 {
+			return 0, false, fmt.Errorf("federated identity %s:%s vanished after conflict", id.Source, id.ExternalID)
+		}
+		return winner, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+
+	if _, err = tx.Exec(ctx,
+		`INSERT INTO registration_events (kind, account_id, source, metadata)
+		 VALUES ('user', $1, 'trusted_header', $2)`,
+		accountID,
+		map[string]any{"source": id.Source, "external_id": id.ExternalID, "email": id.Email},
+	); err != nil {
+		return 0, false, err
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return 0, false, err
+	}
+	return accountID, true, nil
+}
+
+// applyMonthlyAllowance resets the balance to the account's grant on its
+// first activity of a new UTC month. The guarded UPDATE elects exactly one
+// winner under concurrency; the reset (not +=) is what makes the grant a
+// monthly spend cap — unspent allowance does not roll over. In-flight holds
+// (reserved) are deliberately untouched.
+func (s *Store) applyMonthlyAllowance(ctx context.Context, accountID int64, defaultGrant float64, now time.Time) (bool, error) {
+	var managed bool
+	var override *float64
+	err := s.pool.QueryRow(ctx,
+		`SELECT allowance_managed, monthly_grant FROM accounts WHERE id = $1`,
+		accountID,
+	).Scan(&managed, &override)
+	if err != nil {
+		return false, err
+	}
+	if !managed {
+		return false, nil
+	}
+	grant := defaultGrant
+	if override != nil {
+		grant = *override
+	}
+	month := time.Date(now.UTC().Year(), now.UTC().Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback(ctx)
+
+	ct, err := tx.Exec(ctx,
+		`UPDATE credit_balances
+		 SET balance = $2, allowance_period = $3, updated_at = NOW()
+		 WHERE account_id = $1
+		   AND (allowance_period IS NULL OR allowance_period < $3)`,
+		accountID, grant, month,
+	)
+	if err != nil {
+		return false, err
+	}
+	if ct.RowsAffected() == 0 {
+		return false, nil // already granted this month (possibly by a concurrent request)
+	}
+	if _, err = tx.Exec(ctx,
+		`INSERT INTO credit_transactions (account_id, amount, balance_after, type, description)
+		 VALUES ($1, $2, $2, 'monthly_allowance', $3)`,
+		accountID, grant, fmt.Sprintf("monthly allowance %s", month.Format("2006-01")),
+	); err != nil {
+		return false, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SetMonthlyGrant sets (or, with nil, clears back to the env default) an
+// account's monthly allowance override. Takes effect at the next monthly
+// reset, not retroactively.
+func (s *Store) SetMonthlyGrant(accountID int64, grant *float64) error {
+	ct, err := s.pool.Exec(context.Background(),
+		`UPDATE accounts SET monthly_grant = $2 WHERE id = $1`,
+		accountID, grant,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return fmt.Errorf("account not found")
+	}
+	return nil
+}
+
+// SetTrustUserHeaders flips identity-header trust on a key. Admin API only.
+func (s *Store) SetTrustUserHeaders(keyID int64, trust bool) error {
+	ct, err := s.pool.Exec(context.Background(),
+		`UPDATE api_keys SET trust_user_headers = $2 WHERE id = $1`,
+		keyID, trust,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return ErrKeyNotFound
+	}
+	return nil
+}

--- a/internal/store/federated_test.go
+++ b/internal/store/federated_test.go
@@ -1,0 +1,338 @@
+package store
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func resolveArgs(extID string) FederatedIdentity {
+	return FederatedIdentity{
+		Source:      "openwebui",
+		ExternalID:  extID,
+		Email:       "alice@example.com",
+		DisplayName: "Alice",
+	}
+}
+
+func TestResolveEndUserAccount_ProvisionsAccountWithAllowance(t *testing.T) {
+	s := setupTestStore(t)
+
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	res, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, now)
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	if res.AccountID <= 0 {
+		t.Fatalf("expected positive account id, got %d", res.AccountID)
+	}
+	if !res.Provisioned {
+		t.Error("expected Provisioned=true on first sight")
+	}
+	if !res.AllowanceGranted {
+		t.Error("expected AllowanceGranted=true on first sight")
+	}
+
+	acct, err := s.GetAccountByID(res.AccountID)
+	if err != nil || acct == nil {
+		t.Fatalf("GetAccountByID: %v, acct=%v", err, acct)
+	}
+	if acct.Type != "end_user" {
+		t.Errorf("expected type end_user, got %q", acct.Type)
+	}
+	if acct.Name != "alice@example.com" {
+		t.Errorf("expected account named after email, got %q", acct.Name)
+	}
+
+	bal, err := s.GetCreditBalance(res.AccountID)
+	if err != nil || bal == nil {
+		t.Fatalf("GetCreditBalance: %v", err)
+	}
+	if bal.Balance != 5.0 {
+		t.Errorf("expected balance 5.0 after allowance grant, got %v", bal.Balance)
+	}
+
+	// Audit trail: a monthly_allowance transaction must exist.
+	txns, err := s.GetCreditTransactions(res.AccountID, 10, 0)
+	if err != nil {
+		t.Fatalf("GetCreditTransactions: %v", err)
+	}
+	found := false
+	for _, txn := range txns {
+		if txn.Type == "monthly_allowance" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a monthly_allowance credit transaction")
+	}
+
+	// Registration event recorded with the trusted_header source.
+	var evCount int
+	err = s.pool.QueryRow(t.Context(),
+		`SELECT COUNT(*) FROM registration_events WHERE account_id = $1 AND source = 'trusted_header'`,
+		res.AccountID).Scan(&evCount)
+	if err != nil || evCount != 1 {
+		t.Errorf("expected 1 trusted_header registration event, got %d (err %v)", evCount, err)
+	}
+}
+
+func TestResolveEndUserAccount_IdempotentAndUpdatesMetadata(t *testing.T) {
+	s := setupTestStore(t)
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	first, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, now)
+	if err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+
+	// Same identity, changed email: same account, refreshed metadata, no new grant.
+	changed := resolveArgs("owui-1")
+	changed.Email = "alice@new.example.com"
+	second, err := s.ResolveEndUserAccount(changed, 5.0, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if second.AccountID != first.AccountID {
+		t.Fatalf("identity must map to a stable account: %d vs %d", first.AccountID, second.AccountID)
+	}
+	if second.Provisioned {
+		t.Error("expected Provisioned=false on repeat sight")
+	}
+	if second.AllowanceGranted {
+		t.Error("expected no second grant within the same month")
+	}
+
+	var email string
+	if err := s.pool.QueryRow(t.Context(),
+		`SELECT email FROM federated_identities WHERE source='openwebui' AND external_id='owui-1'`).Scan(&email); err != nil {
+		t.Fatalf("identity lookup: %v", err)
+	}
+	if email != "alice@new.example.com" {
+		t.Errorf("expected refreshed email, got %q", email)
+	}
+}
+
+func TestResolveEndUserAccount_MonthlyReset_NoRollover(t *testing.T) {
+	s := setupTestStore(t)
+	july := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	res, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, july)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// Simulate spend: burn 4.5, leaving 0.5 unspent.
+	holdID, err := s.ReserveCredits(res.AccountID, 4.5)
+	if err != nil {
+		t.Fatalf("ReserveCredits: %v", err)
+	}
+	if _, err := s.SettleHold(holdID, 4.5); err != nil {
+		t.Fatalf("SettleHold: %v", err)
+	}
+
+	// New month: balance resets TO the grant (0.5 does not roll over into 5.5).
+	august := time.Date(2026, 8, 2, 9, 0, 0, 0, time.UTC)
+	res2, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, august)
+	if err != nil {
+		t.Fatalf("august resolve: %v", err)
+	}
+	if !res2.AllowanceGranted {
+		t.Error("expected AllowanceGranted=true in a new month")
+	}
+	bal, _ := s.GetCreditBalance(res.AccountID)
+	if bal.Balance != 5.0 {
+		t.Errorf("expected reset-to-grant balance 5.0, got %v", bal.Balance)
+	}
+
+	// Same month again: no double grant.
+	res3, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, august.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("third resolve: %v", err)
+	}
+	if res3.AllowanceGranted {
+		t.Error("expected no double grant within August")
+	}
+}
+
+func TestResolveEndUserAccount_MonthlyGrantOverride(t *testing.T) {
+	s := setupTestStore(t)
+	july := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	res, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, july)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// Admin raises the override; next month's grant uses it.
+	override := 100.0
+	if err := s.SetMonthlyGrant(res.AccountID, &override); err != nil {
+		t.Fatalf("SetMonthlyGrant: %v", err)
+	}
+	august := time.Date(2026, 8, 1, 0, 30, 0, 0, time.UTC)
+	if _, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, august); err != nil {
+		t.Fatalf("august resolve: %v", err)
+	}
+	bal, _ := s.GetCreditBalance(res.AccountID)
+	if bal.Balance != 100.0 {
+		t.Errorf("expected override grant 100.0, got %v", bal.Balance)
+	}
+
+	// Explicit zero blocks (balance resets to 0 next month).
+	zero := 0.0
+	if err := s.SetMonthlyGrant(res.AccountID, &zero); err != nil {
+		t.Fatalf("SetMonthlyGrant(0): %v", err)
+	}
+	september := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	res3, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, september)
+	if err != nil {
+		t.Fatalf("september resolve: %v", err)
+	}
+	if !res3.AllowanceGranted {
+		t.Error("expected a (zero) grant event in a new month")
+	}
+	bal, _ = s.GetCreditBalance(res.AccountID)
+	if bal.Balance != 0 {
+		t.Errorf("expected blocked balance 0, got %v", bal.Balance)
+	}
+
+	// SetMonthlyGrant(nil) reverts to the env default.
+	if err := s.SetMonthlyGrant(res.AccountID, nil); err != nil {
+		t.Fatalf("SetMonthlyGrant(nil): %v", err)
+	}
+	october := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, october); err != nil {
+		t.Fatalf("october resolve: %v", err)
+	}
+	bal, _ = s.GetCreditBalance(res.AccountID)
+	if bal.Balance != 5.0 {
+		t.Errorf("expected default grant 5.0 after revert, got %v", bal.Balance)
+	}
+}
+
+func TestResolveEndUserAccount_ConcurrentFirstSight(t *testing.T) {
+	s := setupTestStore(t)
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	const n = 8
+	ids := make([]int64, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			res, err := s.ResolveEndUserAccount(resolveArgs("owui-race"), 5.0, now)
+			if err == nil {
+				ids[i] = res.AccountID
+			}
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: %v", i, errs[i])
+		}
+		if ids[i] != ids[0] {
+			t.Fatalf("split-brain accounts: %v", ids)
+		}
+	}
+
+	// Exactly one identity, one grant — and no orphaned accounts/balances/events
+	// from losing provisioners (their transactions must have rolled back whole).
+	var identities, grants, accounts, events int
+	_ = s.pool.QueryRow(t.Context(),
+		`SELECT COUNT(*) FROM federated_identities WHERE external_id='owui-race'`).Scan(&identities)
+	_ = s.pool.QueryRow(t.Context(),
+		`SELECT COUNT(*) FROM credit_transactions WHERE account_id=$1 AND type='monthly_allowance'`, ids[0]).Scan(&grants)
+	_ = s.pool.QueryRow(t.Context(),
+		`SELECT COUNT(*) FROM accounts WHERE type='end_user'`).Scan(&accounts)
+	_ = s.pool.QueryRow(t.Context(),
+		`SELECT COUNT(*) FROM registration_events WHERE source='trusted_header'`).Scan(&events)
+	if identities != 1 {
+		t.Errorf("expected 1 identity row, got %d", identities)
+	}
+	if grants != 1 {
+		t.Errorf("expected exactly 1 allowance grant, got %d", grants)
+	}
+	if accounts != 1 {
+		t.Errorf("expected 1 end_user account (no orphans from race losers), got %d", accounts)
+	}
+	if events != 1 {
+		t.Errorf("expected 1 registration event, got %d", events)
+	}
+}
+
+func TestSetTrustUserHeaders_RoundTrip(t *testing.T) {
+	s := setupTestStore(t)
+
+	keyID, err := s.CreateKey("openwebui-shared", "hash-trust", "laip_tr", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	key, err := s.GetKeyByHash("hash-trust")
+	if err != nil || key == nil {
+		t.Fatalf("GetKeyByHash: %v", err)
+	}
+	if key.TrustUserHeaders {
+		t.Error("expected trust_user_headers to default to false")
+	}
+
+	if err := s.SetTrustUserHeaders(keyID, true); err != nil {
+		t.Fatalf("SetTrustUserHeaders: %v", err)
+	}
+	key, _ = s.GetKeyByHash("hash-trust")
+	if !key.TrustUserHeaders {
+		t.Error("expected trust_user_headers=true after set")
+	}
+
+	byID, err := s.GetKeyByID(keyID)
+	if err != nil || byID == nil || !byID.TrustUserHeaders {
+		t.Errorf("GetKeyByID must surface trust flag (err %v)", err)
+	}
+
+	if err := s.SetTrustUserHeaders(99999999, true); err != ErrKeyNotFound {
+		t.Errorf("expected ErrKeyNotFound for missing key, got %v", err)
+	}
+}
+
+func TestLogUsage_AccountAttribution(t *testing.T) {
+	s := setupTestStore(t)
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	keyID, err := s.CreateKey("openwebui-shared", "hash-attr", "laip_at", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	res, err := s.ResolveEndUserAccount(resolveArgs("owui-1"), 5.0, now)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	entry := UsageEntry{
+		APIKeyID:  keyID,
+		Model:     "gemma4:e4b",
+		Status:    "completed",
+		AccountID: &res.AccountID,
+	}
+	if err := s.LogUsage(entry); err != nil {
+		t.Fatalf("LogUsage: %v", err)
+	}
+
+	var got *int64
+	if err := s.pool.QueryRow(t.Context(),
+		`SELECT account_id FROM usage_logs WHERE api_key_id = $1`, keyID).Scan(&got); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if got == nil || *got != res.AccountID {
+		t.Errorf("expected usage row attributed to account %d, got %v", res.AccountID, got)
+	}
+
+	// Legacy path: nil AccountID stays NULL.
+	if err := s.LogUsage(UsageEntry{APIKeyID: keyID, Model: "gemma4:e4b", Status: "completed"}); err != nil {
+		t.Fatalf("LogUsage legacy: %v", err)
+	}
+}

--- a/internal/store/federated_test.go
+++ b/internal/store/federated_test.go
@@ -336,3 +336,100 @@ func TestLogUsage_AccountAttribution(t *testing.T) {
 		t.Fatalf("LogUsage legacy: %v", err)
 	}
 }
+
+// Analytics must attribute rows by the BILLING account (usage_logs.account_id)
+// with a fallback to the key's account for pre-attribution rows — the Codex P1
+// from the EUA-2 review.
+func TestAnalytics_BillingAccountAttribution(t *testing.T) {
+	s := setupTestStore(t)
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	sharedAcc, sharedUser, err := s.RegisterUser("shared-analytics@example.com", "hash", "Shared")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	keyID, err := s.CreateKeyForAccount(sharedUser, sharedAcc, "openwebui-shared", "hash-analytics", "laip_an", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForAccount: %v", err)
+	}
+
+	endUser, err := s.ResolveEndUserAccount(resolveArgs("owui-analytics"), 5.0, now)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// One end-user-attributed row, one legacy row (NULL account_id).
+	if err := s.LogUsage(UsageEntry{APIKeyID: keyID, Model: "gemma4:e4b", TotalTokens: 100,
+		CreditsCharged: 0.2, Status: "completed", AccountID: &endUser.AccountID}); err != nil {
+		t.Fatalf("LogUsage attributed: %v", err)
+	}
+	if err := s.LogUsage(UsageEntry{APIKeyID: keyID, Model: "gemma4:e4b", TotalTokens: 40,
+		CreditsCharged: 0.1, Status: "completed"}); err != nil {
+		t.Fatalf("LogUsage legacy: %v", err)
+	}
+
+	// Filter by end-user account: only the attributed row.
+	sum, err := s.GetUsageSummary(UsageFilter{AccountID: &endUser.AccountID})
+	if err != nil {
+		t.Fatalf("GetUsageSummary(end user): %v", err)
+	}
+	if sum.TotalTokens != 100 {
+		t.Errorf("end-user filter: expected 100 tokens, got %d", sum.TotalTokens)
+	}
+
+	// Filter by shared account: only the legacy row (fallback via key join).
+	sum, err = s.GetUsageSummary(UsageFilter{AccountID: &sharedAcc})
+	if err != nil {
+		t.Fatalf("GetUsageSummary(shared): %v", err)
+	}
+	if sum.TotalTokens != 40 {
+		t.Errorf("shared filter: expected 40 tokens (legacy fallback), got %d", sum.TotalTokens)
+	}
+
+	// By-user rollup: the end-user account appears as its own owner row.
+	rows, err := s.GetUsageByUser(UsageFilter{})
+	if err != nil {
+		t.Fatalf("GetUsageByUser: %v", err)
+	}
+	var foundEndUser bool
+	for _, r := range rows {
+		if r.AccountID != nil && *r.AccountID == endUser.AccountID {
+			foundEndUser = true
+			if r.TotalTokens != 100 {
+				t.Errorf("end-user owner row: expected 100 tokens, got %d", r.TotalTokens)
+			}
+		}
+	}
+	if !foundEndUser {
+		t.Error("expected an owner row for the end-user account")
+	}
+}
+
+// All key-listing paths must surface trust_user_headers consistently — the
+// Codex P2 from the EUA-2 review (ListKeysByUser dropped it).
+func TestListKeysByUser_SurfacesTrustFlag(t *testing.T) {
+	s := setupTestStore(t)
+
+	_, userID, err := s.RegisterUser("trust-list@example.com", "hash", "TrustList")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	keyID, err := s.CreateKeyForUser(userID, "user-key", "hash-user-trust", "laip_ut", 60)
+	if err != nil {
+		t.Fatalf("CreateKeyForUser: %v", err)
+	}
+	if err := s.SetTrustUserHeaders(keyID, true); err != nil {
+		t.Fatalf("SetTrustUserHeaders: %v", err)
+	}
+
+	keys, err := s.ListKeysByUser(userID)
+	if err != nil {
+		t.Fatalf("ListKeysByUser: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+	if !keys[0].TrustUserHeaders {
+		t.Error("ListKeysByUser must surface trust_user_headers=true")
+	}
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -256,3 +256,62 @@ UPDATE credit_pricing SET prompt_rate_mtok = prompt_rate * 1000000
     WHERE prompt_rate_mtok IS NULL;
 UPDATE credit_pricing SET completion_rate_mtok = completion_rate * 1000000
     WHERE completion_rate_mtok IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- End-user accounts (docs/design/end-user-accounts.md): per-user attribution
+-- and monthly allowance for identities forwarded on trusted keys.
+
+-- Only the admin API may set this; a key with the flag bills the end-user
+-- account resolved from X-OpenWebUI-User-Id instead of its own account.
+DO $$ BEGIN
+    ALTER TABLE api_keys ADD COLUMN trust_user_headers BOOLEAN NOT NULL DEFAULT FALSE;
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;
+
+-- allowance_managed marks auto-provisioned end-user accounts: only these get
+-- the monthly balance reset. monthly_grant NULL = use the env default
+-- (END_USER_MONTHLY_GRANT); explicit 0 = blocked.
+DO $$ BEGIN
+    ALTER TABLE accounts ADD COLUMN allowance_managed BOOLEAN NOT NULL DEFAULT FALSE;
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE accounts ADD COLUMN monthly_grant DECIMAL(15,6);
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;
+
+-- First day (UTC) of the month the allowance was last granted for.
+DO $$ BEGIN
+    ALTER TABLE credit_balances ADD COLUMN allowance_period DATE;
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;
+
+-- Identity authority is (source, external_id) — email is display metadata and
+-- may change without moving the account.
+CREATE TABLE IF NOT EXISTS federated_identities (
+    id           BIGSERIAL PRIMARY KEY,
+    source       TEXT NOT NULL,
+    external_id  TEXT NOT NULL,
+    account_id   BIGINT NOT NULL REFERENCES accounts(id),
+    email        TEXT,
+    display_name TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (source, external_id)
+);
+
+-- Billing-account attribution on usage rows (NULL = pre-feature history;
+-- analytics COALESCE through the api_keys join for those).
+DO $$ BEGIN
+    ALTER TABLE usage_logs ADD COLUMN account_id BIGINT REFERENCES accounts(id);
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_usage_logs_account_created
+    ON usage_logs(account_id, created_at);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -61,6 +61,7 @@ type APIKey struct {
 	AccountID         *int64     // nil = legacy key not on credit system
 	SessionTokenLimit *int       // nil = no session limit
 	LastUsedAt        *time.Time // nil = key has never served a request; derived from usage_logs
+	TrustUserHeaders  bool       // bill the forwarded end-user identity instead of the key's account
 }
 
 type Account struct {
@@ -81,6 +82,7 @@ type UsageEntry struct {
 	Status           string  // completed | partial | error
 	CreditsCharged   float64 // 0 when no hold/pricing was active
 	NodeID           *int64  // nil = request never resolved a node
+	AccountID        *int64  // billing account (end-user or key account); nil = legacy row
 }
 
 type UsageStat struct {
@@ -306,10 +308,10 @@ func (s *Store) GetKeyByHash(hash string) (*APIKey, error) {
 	var apiKey APIKey
 	err := s.pool.QueryRow(
 		context.Background(),
-		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit
+		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit, trust_user_headers
 		 FROM api_keys WHERE key_hash = $1 AND revoked = FALSE`, hash,
 	).Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyHash, &apiKey.KeyPrefix, &apiKey.RateLimit, &apiKey.CreatedAt, &apiKey.Revoked,
-		&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit)
+		&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.TrustUserHeaders)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -328,7 +330,7 @@ func (s *Store) ListKeys() ([]APIKey, error) {
 	rows, err := s.pool.Query(
 		context.Background(),
 		`SELECT k.id, k.name, k.key_prefix, k.rate_limit, k.created_at, k.revoked,
-		        k.user_id, k.account_id, k.session_token_limit, u.last_used_at
+		        k.user_id, k.account_id, k.session_token_limit, k.trust_user_headers, u.last_used_at
 		 FROM api_keys k
 		 LEFT JOIN (
 		     SELECT api_key_id, MAX(created_at) AS last_used_at
@@ -346,7 +348,7 @@ func (s *Store) ListKeys() ([]APIKey, error) {
 	for rows.Next() {
 		var apiKey APIKey
 		if err := rows.Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyPrefix, &apiKey.RateLimit, &apiKey.CreatedAt, &apiKey.Revoked,
-			&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.LastUsedAt); err != nil {
+			&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.TrustUserHeaders, &apiKey.LastUsedAt); err != nil {
 			return nil, err
 		}
 		keys = append(keys, apiKey)
@@ -361,11 +363,11 @@ func (s *Store) GetKeyByID(id int64) (*APIKey, error) {
 	var apiKey APIKey
 	err := s.pool.QueryRow(
 		context.Background(),
-		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit,
+		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit, trust_user_headers,
 		        (SELECT MAX(created_at) FROM usage_logs WHERE api_key_id = api_keys.id)
 		 FROM api_keys WHERE id = $1`, id,
 	).Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyHash, &apiKey.KeyPrefix, &apiKey.RateLimit,
-		&apiKey.CreatedAt, &apiKey.Revoked, &apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.LastUsedAt)
+		&apiKey.CreatedAt, &apiKey.Revoked, &apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.TrustUserHeaders, &apiKey.LastUsedAt)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -409,10 +411,10 @@ func (s *Store) RevokeKey(id int64) error {
 func (s *Store) LogUsage(entry UsageEntry) error {
 	_, err := s.pool.Exec(
 		context.Background(),
-		`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged, node_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged, node_id, account_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
 		entry.APIKeyID, entry.Model, entry.PromptTokens, entry.CompletionTokens,
-		entry.TotalTokens, entry.DurationMs, entry.Status, entry.CreditsCharged, entry.NodeID,
+		entry.TotalTokens, entry.DurationMs, entry.Status, entry.CreditsCharged, entry.NodeID, entry.AccountID,
 	)
 	return err
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -791,7 +791,7 @@ func (s *Store) CreateKeyForUser(userID int64, name, keyHash, keyPrefix string, 
 func (s *Store) ListKeysByUser(userID int64) ([]APIKey, error) {
 	rows, err := s.pool.Query(
 		context.Background(),
-		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit
+		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit, trust_user_headers
 		 FROM api_keys WHERE user_id = $1 ORDER BY id`, userID,
 	)
 	if err != nil {
@@ -803,7 +803,7 @@ func (s *Store) ListKeysByUser(userID int64) ([]APIKey, error) {
 	for rows.Next() {
 		var k APIKey
 		if err := rows.Scan(&k.ID, &k.Name, &k.KeyHash, &k.KeyPrefix, &k.RateLimit, &k.CreatedAt, &k.Revoked,
-			&k.UserID, &k.AccountID, &k.SessionTokenLimit); err != nil {
+			&k.UserID, &k.AccountID, &k.SessionTokenLimit, &k.TrustUserHeaders); err != nil {
 			return nil, err
 		}
 		keys = append(keys, k)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -36,6 +36,7 @@ func setupTestStore(t *testing.T) *Store {
 		_, _ = s.pool.Exec(c, "DELETE FROM user_sessions")
 		_, _ = s.pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = s.pool.Exec(c, "DELETE FROM users")
+		_, _ = s.pool.Exec(c, "DELETE FROM federated_identities")
 		_, _ = s.pool.Exec(c, "DELETE FROM accounts")
 	}
 
@@ -77,6 +78,7 @@ func TestNew(t *testing.T) {
 		_, _ = s.pool.Exec(c, "DELETE FROM user_sessions")
 		_, _ = s.pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = s.pool.Exec(c, "DELETE FROM users")
+		_, _ = s.pool.Exec(c, "DELETE FROM federated_identities")
 		_, _ = s.pool.Exec(c, "DELETE FROM accounts")
 		s.Close()
 	})


### PR DESCRIPTION
Store/schema layer for the end-user accounts initiative (design: #56).

- `federated_identities` table: (source, external_id) → auto-provisioned `end_user` account; concurrency-safe (losing provisioners roll back whole, adopt the winner — race-tested incl. no-orphan assertions)
- Monthly allowance: guarded reset-to-grant on first activity of a new UTC month, `monthly_allowance` audit transaction, per-account `monthly_grant` override (NULL=env default, 0=blocked)
- `api_keys.trust_user_headers` + `SetTrustUserHeaders` (admin-only mutation)
- `usage_logs.account_id` billing attribution + `LogUsage` support (NULL = legacy rows)

891 tests green locally with CI flags (`-race -p 1`). Proxy integration lands in EUA-3, admin API in EUA-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe