### PR TITLE
feat: proxy billing resolution + admin API for end-user accounts (EUA-3/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Readiness = DB ok **and** usage writer ok **and** (*zero enabled nodes* **or** *
 | `GET` | `/api/admin/keys/{id}` | Key detail |
 | `PUT` | `/api/admin/keys/{id}/rate-limit` | Update a key's rate limit |
 | `PUT` | `/api/admin/keys/{id}/session-limit` | Set/clear a key's session token limit |
+| `PUT` | `/api/admin/keys/{id}/trust-user-headers` | Trust forwarded end-user identity headers on this key (`{trust_user_headers: bool}`) — requests then bill auto-provisioned per-user accounts (see docs/design/end-user-accounts.md) |
 | `DELETE` | `/api/admin/keys/{id}` | Revoke (soft-delete) a key |
 | `GET` | `/api/admin/usage` | Aggregated usage stats (filterable by `key_id`, `since`, and `node_id`) |
 | `GET` | `/api/admin/usage/summary` \| `/by-model` \| `/by-user` \| `/timeseries` | Usage analytics |
@@ -85,6 +86,7 @@ Readiness = DB ok **and** usage writer ok **and** (*zero enabled nodes* **or** *
 | `GET` | `/api/admin/accounts` | List accounts (credit balances) |
 | `POST` | `/api/admin/accounts/{id}/credits` | Grant credits |
 | `POST` | `/api/admin/accounts/{id}/keys` | Create a key bound to an account |
+| `PUT` | `/api/admin/accounts/{id}/allowance` | Set (`{monthly_grant: 12.5}`) or clear (`{monthly_grant: null}` → env default) an end-user account's monthly allowance override |
 | `GET`/`POST` | `/api/admin/pricing` | List / upsert model pricing (`{model_id, prompt_rate_per_mtok, completion_rate_per_mtok, typical_completion}`) |
 | `DELETE` | `/api/admin/pricing/{id}` | Deactivate pricing |
 | `GET`/`POST`/`DELETE` | `/api/admin/registration-tokens` | Manage service-registration tokens |
@@ -276,6 +278,7 @@ All configuration via environment variables:
 | `ADMIN_BOOTSTRAP_TOKEN` | *(none)* | Enables `POST /api/admin/bootstrap` (one-time first-admin creation) when set |
 | `DEFAULT_CREDIT_GRANT` | `0` | Credits granted to newly registered accounts |
 | `ADMIN_SERVICE_CREDIT_GRANT` | `1000000` | One-time starting balance for the auto-created `admin-service` account (applied at creation only — top up later via `POST /api/admin/accounts/{id}/credits`; must be >= 0) |
+| `END_USER_MONTHLY_GRANT` | `5.0` | Monthly allowance (reset-to-grant, no rollover) for auto-provisioned end-user accounts on trusted keys; per-account override via `PUT /api/admin/accounts/{id}/allowance`; must be >= 0 |
 | `PORT` | `8080` | Server listen port |
 | `CORS_ORIGINS` | `*` | Allowed CORS origins |
 | `MAX_REQUEST_BODY` | `52428800` (50MB) | Max request body size in bytes (chat proxy path); also caps upstream non-streaming/error response reads |

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/krishna/local-ai-proxy/internal/admin"
 	"github.com/krishna/local-ai-proxy/internal/auth"
 	"github.com/krishna/local-ai-proxy/internal/authlimit"
+	"github.com/krishna/local-ai-proxy/internal/billing"
 	"github.com/krishna/local-ai-proxy/internal/bootstrap"
 	"github.com/krishna/local-ai-proxy/internal/config"
 	"github.com/krishna/local-ai-proxy/internal/credits"
@@ -209,6 +210,7 @@ func main() {
 	proxyHandler := proxy.NewHandler(reg, usageCh, cfg.MaxRequestBody, db, m,
 		proxy.Options{ModelsListAll: cfg.ModelsListAll})
 	authMiddleware := auth.Middleware(db)
+	billingResolver := billing.Middleware(db, cfg.EndUserMonthlyGrant)
 	creditGate := credits.CreditGate(db, m)
 	rateLimitMiddleware := ratelimit.Middleware(limiter, m)
 	cors := middleware.CORS(cfg.CORSOrigins)
@@ -277,8 +279,11 @@ func main() {
 	mux.HandleFunc("GET /api/healthz/ready", hc.ReadyHandler)
 	mux.HandleFunc("GET /api/healthz", hc.LiveHandler) // backward compat alias
 
-	// Client API — CORS + auth + credit gate + rate limit + proxy (instrumented)
-	mux.Handle("/api/v1/", m.InstrumentHandler(cors(authMiddleware(creditGate(rateLimitMiddleware(proxyHandler))))))
+	// Client API — CORS + auth + billing resolution + credit gate + rate limit
+	// + proxy (instrumented). Billing MUST precede the credit gate: the gate
+	// pre-checks the resolved billing account, not the key's own account
+	// (docs/design/end-user-accounts.md §4).
+	mux.Handle("/api/v1/", m.InstrumentHandler(cors(authMiddleware(billingResolver(creditGate(rateLimitMiddleware(proxyHandler)))))))
 
 	// Metrics endpoint — unauthenticated, cluster-internal only
 	mux.Handle("GET /metrics", m.Handler())

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -135,7 +135,8 @@ type keyResponse struct {
 	// LastUsedAt is the most recent request time derived from usage_logs,
 	// RFC3339-formatted. nil (JSON null) means the key has never served a
 	// request — the FE renders that as "Never".
-	LastUsedAt *string `json:"last_used_at"`
+	LastUsedAt       *string `json:"last_used_at"`
+	TrustUserHeaders bool    `json:"trust_user_headers"`
 }
 
 func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.UsageEntry, opts Options) http.Handler {
@@ -421,13 +422,14 @@ func (h *handler) listKeys(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		resp = append(resp, keyResponse{
-			ID:         apiKey.ID,
-			Name:       apiKey.Name,
-			KeyPrefix:  apiKey.KeyPrefix,
-			RateLimit:  apiKey.RateLimit,
-			CreatedAt:  apiKey.CreatedAt,
-			Revoked:    apiKey.Revoked,
-			LastUsedAt: formatRFC3339Ptr(apiKey.LastUsedAt),
+			ID:               apiKey.ID,
+			Name:             apiKey.Name,
+			KeyPrefix:        apiKey.KeyPrefix,
+			RateLimit:        apiKey.RateLimit,
+			CreatedAt:        apiKey.CreatedAt,
+			Revoked:          apiKey.Revoked,
+			LastUsedAt:       formatRFC3339Ptr(apiKey.LastUsedAt),
+			TrustUserHeaders: apiKey.TrustUserHeaders,
 		})
 	}
 
@@ -1118,18 +1120,30 @@ func (h *handler) setAccountAllowance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// json.RawMessage distinguishes an ABSENT field from explicit null:
+	// null is the destructive "clear the override" operation, so it must be
+	// spelled out — {} is a 400, never a silent clear.
 	var req struct {
-		MonthlyGrant *float64 `json:"monthly_grant"` // null = revert to env default
+		MonthlyGrant json.RawMessage `json:"monthly_grant"`
 	}
 	if !apierror.DecodeJSON(w, r, &req) {
 		return
 	}
-	if req.MonthlyGrant != nil && *req.MonthlyGrant < 0 {
+	if len(req.MonthlyGrant) == 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "missing_field", "invalid_request_error", "monthly_grant is required (number to set, null to clear)")
+		return
+	}
+	var grant *float64
+	if err := json.Unmarshal(req.MonthlyGrant, &grant); err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_amount", "invalid_request_error", "monthly_grant must be a number or null")
+		return
+	}
+	if grant != nil && *grant < 0 {
 		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_amount", "invalid_request_error", "monthly_grant must be >= 0")
 		return
 	}
 
-	if err := h.store.SetMonthlyGrant(accountID, req.MonthlyGrant); err != nil {
+	if err := h.store.SetMonthlyGrant(accountID, grant); err != nil {
 		if err.Error() == "account not found" {
 			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Account not found")
 			return
@@ -1140,7 +1154,7 @@ func (h *handler) setAccountAllowance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"status": "updated", "monthly_grant": req.MonthlyGrant})
+	json.NewEncoder(w).Encode(map[string]any{"status": "updated", "monthly_grant": grant})
 }
 
 func min(a, b float64) float64 {
@@ -1249,6 +1263,7 @@ type keyDetailDTO struct {
 	SessionTokenLimit *int    `json:"session_token_limit"`
 	CreatedAt         string  `json:"created_at"`
 	LastUsedAt        *string `json:"last_used_at"`
+	TrustUserHeaders  bool    `json:"trust_user_headers"`
 }
 
 func toKeyDetailDTO(k *store.APIKey) keyDetailDTO {
@@ -1263,6 +1278,7 @@ func toKeyDetailDTO(k *store.APIKey) keyDetailDTO {
 		SessionTokenLimit: k.SessionTokenLimit,
 		CreatedAt:         k.CreatedAt.Format(time.RFC3339),
 		LastUsedAt:        formatRFC3339Ptr(k.LastUsedAt),
+		TrustUserHeaders:  k.TrustUserHeaders,
 	}
 }
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -182,6 +182,7 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 	mux.HandleFunc("GET /api/admin/accounts", handler.listAccounts)
 	mux.HandleFunc("POST /api/admin/accounts/{id}/credits", handler.grantCredits)
 	mux.HandleFunc("POST /api/admin/accounts/{id}/keys", handler.createAccountKey)
+	mux.HandleFunc("PUT /api/admin/accounts/{id}/allowance", handler.setAccountAllowance)
 
 	// Registration tokens
 	mux.HandleFunc("POST /api/admin/registration-tokens", handler.createRegistrationToken)
@@ -195,6 +196,7 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 
 	// Session limits
 	mux.HandleFunc("PUT /api/admin/keys/{id}/session-limit", handler.setSessionLimit)
+	mux.HandleFunc("PUT /api/admin/keys/{id}/trust-user-headers", handler.setTrustUserHeaders)
 
 	// Config + health (BE 5)
 	mux.HandleFunc("GET /api/admin/config", handler.getConfig)
@@ -672,14 +674,17 @@ func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type accountResponse struct {
-		ID        int64   `json:"id"`
-		Name      string  `json:"name"`
-		Type      string  `json:"type"`
-		IsActive  bool    `json:"is_active"`
-		Balance   float64 `json:"balance"`
-		Reserved  float64 `json:"reserved"`
-		Available float64 `json:"available"`
-		CreatedAt string  `json:"created_at"`
+		ID               int64    `json:"id"`
+		Name             string   `json:"name"`
+		Type             string   `json:"type"`
+		IsActive         bool     `json:"is_active"`
+		Balance          float64  `json:"balance"`
+		Reserved         float64  `json:"reserved"`
+		Available        float64  `json:"available"`
+		CreatedAt        string   `json:"created_at"`
+		AllowanceManaged bool     `json:"allowance_managed"`
+		MonthlyGrant     *float64 `json:"monthly_grant"`
+		Email            *string  `json:"email"`
 	}
 
 	resp := make([]accountResponse, 0, len(accounts))
@@ -691,14 +696,17 @@ func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		resp = append(resp, accountResponse{
-			ID:        a.ID,
-			Name:      a.Name,
-			Type:      a.Type,
-			IsActive:  a.IsActive,
-			Balance:   a.Balance,
-			Reserved:  a.Reserved,
-			Available: a.Balance - a.Reserved,
-			CreatedAt: a.CreatedAt.Format(time.RFC3339),
+			ID:               a.ID,
+			Name:             a.Name,
+			Type:             a.Type,
+			IsActive:         a.IsActive,
+			Balance:          a.Balance,
+			Reserved:         a.Reserved,
+			Available:        a.Balance - a.Reserved,
+			CreatedAt:        a.CreatedAt.Format(time.RFC3339),
+			AllowanceManaged: a.AllowanceManaged,
+			MonthlyGrant:     a.MonthlyGrant,
+			Email:            a.FederatedEmail,
 		})
 	}
 
@@ -1063,6 +1071,76 @@ func (h *handler) setSessionLimit(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"status": "updated", "limit": req.Limit})
+}
+
+// setTrustUserHeaders flips identity-header trust on a key
+// (docs/design/end-user-accounts.md §1). The field is required — an absent
+// value is a 400, never an implicit false.
+func (h *handler) setTrustUserHeaders(w http.ResponseWriter, r *http.Request) {
+	keyID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid key ID")
+		return
+	}
+
+	var req struct {
+		Trust *bool `json:"trust_user_headers"`
+	}
+	if !apierror.DecodeJSON(w, r, &req) {
+		return
+	}
+	if req.Trust == nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "missing_field", "invalid_request_error", "trust_user_headers is required")
+		return
+	}
+
+	if err := h.store.SetTrustUserHeaders(keyID, *req.Trust); err != nil {
+		if err == store.ErrKeyNotFound {
+			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Key not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "set trust user headers error", "error", err, "key_id", keyID)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to set trust flag")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"status": "updated", "trust_user_headers": *req.Trust})
+}
+
+// setAccountAllowance sets (value) or clears (null → env default) an
+// account's monthly allowance override. Takes effect at the next monthly
+// reset (docs/design/end-user-accounts.md §3).
+func (h *handler) setAccountAllowance(w http.ResponseWriter, r *http.Request) {
+	accountID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid account ID")
+		return
+	}
+
+	var req struct {
+		MonthlyGrant *float64 `json:"monthly_grant"` // null = revert to env default
+	}
+	if !apierror.DecodeJSON(w, r, &req) {
+		return
+	}
+	if req.MonthlyGrant != nil && *req.MonthlyGrant < 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_amount", "invalid_request_error", "monthly_grant must be >= 0")
+		return
+	}
+
+	if err := h.store.SetMonthlyGrant(accountID, req.MonthlyGrant); err != nil {
+		if err.Error() == "account not found" {
+			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Account not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "set monthly grant error", "error", err, "account_id", accountID)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to set allowance")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"status": "updated", "monthly_grant": req.MonthlyGrant})
 }
 
 func min(a, b float64) float64 {

--- a/internal/admin/admin_metrics_test.go
+++ b/internal/admin/admin_metrics_test.go
@@ -44,6 +44,7 @@ func setupAdminMetricsTest(t *testing.T) (http.Handler, *store.Store, *metrics.M
 		_, _ = p.Exec(c, "DELETE FROM user_sessions")
 		_, _ = p.Exec(c, "DELETE FROM api_keys")
 		_, _ = p.Exec(c, "DELETE FROM users")
+		_, _ = p.Exec(c, "DELETE FROM federated_identities")
 		_, _ = p.Exec(c, "DELETE FROM accounts")
 	}
 

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -44,6 +44,7 @@ func setupAdminTest(t *testing.T) (http.Handler, *store.Store) {
 		_, _ = p.Exec(c, "DELETE FROM user_sessions")
 		_, _ = p.Exec(c, "DELETE FROM api_keys")
 		_, _ = p.Exec(c, "DELETE FROM users")
+		_, _ = p.Exec(c, "DELETE FROM federated_identities")
 		_, _ = p.Exec(c, "DELETE FROM accounts")
 	}
 

--- a/internal/admin/config_health_test.go
+++ b/internal/admin/config_health_test.go
@@ -50,6 +50,7 @@ func setupAdminWithObservability(
 		_, _ = p.Exec(c, "DELETE FROM user_sessions")
 		_, _ = p.Exec(c, "DELETE FROM api_keys")
 		_, _ = p.Exec(c, "DELETE FROM users")
+		_, _ = p.Exec(c, "DELETE FROM federated_identities")
 		_, _ = p.Exec(c, "DELETE FROM accounts")
 	}
 	wipe(s.Pool())

--- a/internal/admin/eua_admin_test.go
+++ b/internal/admin/eua_admin_test.go
@@ -143,3 +143,52 @@ func TestAdmin_ListAccounts_IncludesAllowanceFields(t *testing.T) {
 		t.Errorf("expected federated email, got %v", row.Email)
 	}
 }
+
+func TestAdmin_SetAccountAllowance_AbsentFieldRejected(t *testing.T) {
+	h, s := setupAdminTest(t)
+	res, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "admin-eua-3", Email: "absent@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	override := 42.0
+	if err := s.SetMonthlyGrant(res.AccountID, &override); err != nil {
+		t.Fatalf("SetMonthlyGrant: %v", err)
+	}
+
+	// {} must NOT silently clear the override (null is the explicit clear).
+	rec := adminPut(t, h, "/api/admin/accounts/"+strconv.FormatInt(res.AccountID, 10)+"/allowance", `{}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("absent field: expected 400, got %d", rec.Code)
+	}
+	var grant *float64
+	_ = s.Pool().QueryRow(t.Context(), `SELECT monthly_grant FROM accounts WHERE id=$1`, res.AccountID).Scan(&grant)
+	if grant == nil || *grant != 42.0 {
+		t.Errorf("override must survive a rejected request, got %v", grant)
+	}
+}
+
+func TestAdmin_KeyReads_SurfaceTrustFlag(t *testing.T) {
+	h, s := setupAdminTest(t)
+	keyID, err := s.CreateKey("openwebui", "hash-trust-read", "laip_tr2", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	if err := s.SetTrustUserHeaders(keyID, true); err != nil {
+		t.Fatalf("SetTrustUserHeaders: %v", err)
+	}
+
+	for _, path := range []string{"/api/admin/keys?envelope=0", "/api/admin/keys/" + strconv.FormatInt(keyID, 10)} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("X-Admin-Key", testAdminKey)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d", path, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), `"trust_user_headers":true`) {
+			t.Errorf("%s: response must surface trust_user_headers=true: %s", path, rec.Body.String()[:200])
+		}
+	}
+}

--- a/internal/admin/eua_admin_test.go
+++ b/internal/admin/eua_admin_test.go
@@ -1,0 +1,145 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+func adminPut(t *testing.T, h http.Handler, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(body))
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAdmin_SetTrustUserHeaders(t *testing.T) {
+	h, s := setupAdminTest(t)
+	keyID, err := s.CreateKey("openwebui", "hash-trust-admin", "laip_ta", 60)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	rec := adminPut(t, h, "/api/admin/keys/"+strconv.FormatInt(keyID, 10)+"/trust-user-headers",
+		`{"trust_user_headers":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	key, _ := s.GetKeyByID(keyID)
+	if key == nil || !key.TrustUserHeaders {
+		t.Error("expected trust_user_headers=true after PUT")
+	}
+
+	// Flip back off.
+	rec = adminPut(t, h, "/api/admin/keys/"+strconv.FormatInt(keyID, 10)+"/trust-user-headers",
+		`{"trust_user_headers":false}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on unset, got %d", rec.Code)
+	}
+	key, _ = s.GetKeyByID(keyID)
+	if key.TrustUserHeaders {
+		t.Error("expected trust_user_headers=false after unset")
+	}
+}
+
+func TestAdmin_SetTrustUserHeaders_Errors(t *testing.T) {
+	h, _ := setupAdminTest(t)
+
+	if rec := adminPut(t, h, "/api/admin/keys/999999/trust-user-headers", `{"trust_user_headers":true}`); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown key: expected 404, got %d", rec.Code)
+	}
+	if rec := adminPut(t, h, "/api/admin/keys/abc/trust-user-headers", `{"trust_user_headers":true}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("bad id: expected 400, got %d", rec.Code)
+	}
+	if rec := adminPut(t, h, "/api/admin/keys/1/trust-user-headers", `{}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing field: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestAdmin_SetAccountAllowance(t *testing.T) {
+	h, s := setupAdminTest(t)
+	res, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "admin-eua-1", Email: "allow@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	idStr := strconv.FormatInt(res.AccountID, 10)
+
+	if rec := adminPut(t, h, "/api/admin/accounts/"+idStr+"/allowance", `{"monthly_grant":25.5}`); rec.Code != http.StatusOK {
+		t.Fatalf("set: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var grant *float64
+	_ = s.Pool().QueryRow(t.Context(), `SELECT monthly_grant FROM accounts WHERE id=$1`, res.AccountID).Scan(&grant)
+	if grant == nil || *grant != 25.5 {
+		t.Errorf("expected monthly_grant 25.5, got %v", grant)
+	}
+
+	// null clears back to env default.
+	if rec := adminPut(t, h, "/api/admin/accounts/"+idStr+"/allowance", `{"monthly_grant":null}`); rec.Code != http.StatusOK {
+		t.Fatalf("clear: expected 200, got %d", rec.Code)
+	}
+	grant = nil
+	_ = s.Pool().QueryRow(t.Context(), `SELECT monthly_grant FROM accounts WHERE id=$1`, res.AccountID).Scan(&grant)
+	if grant != nil {
+		t.Errorf("expected cleared monthly_grant, got %v", *grant)
+	}
+
+	if rec := adminPut(t, h, "/api/admin/accounts/"+idStr+"/allowance", `{"monthly_grant":-1}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("negative: expected 400, got %d", rec.Code)
+	}
+	if rec := adminPut(t, h, "/api/admin/accounts/999999/allowance", `{"monthly_grant":1}`); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown account: expected 404, got %d", rec.Code)
+	}
+}
+
+func TestAdmin_ListAccounts_IncludesAllowanceFields(t *testing.T) {
+	h, s := setupAdminTest(t)
+	res, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "admin-eua-2", Email: "list@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/accounts?envelope=0&type=end_user", nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var rows []struct {
+		ID               int64    `json:"id"`
+		Type             string   `json:"type"`
+		AllowanceManaged bool     `json:"allowance_managed"`
+		MonthlyGrant     *float64 `json:"monthly_grant"`
+		Email            *string  `json:"email"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly 1 end_user account, got %d", len(rows))
+	}
+	row := rows[0]
+	if row.ID != res.AccountID || !row.AllowanceManaged || row.Type != "end_user" {
+		t.Errorf("unexpected row: %+v", row)
+	}
+	if row.MonthlyGrant != nil {
+		t.Errorf("expected nil monthly_grant (env default), got %v", *row.MonthlyGrant)
+	}
+	if row.Email == nil || *row.Email != "list@example.com" {
+		t.Errorf("expected federated email, got %v", row.Email)
+	}
+}

--- a/internal/admin/list_filters.go
+++ b/internal/admin/list_filters.go
@@ -56,15 +56,15 @@ func parseRoleFilter(r *http.Request) (string, string, string, error) {
 	}
 }
 
-// parseAccountTypeFilter parses `?type=personal|service`. Empty returns "".
+// parseAccountTypeFilter parses `?type=personal|service|end_user`. Empty returns "".
 func parseAccountTypeFilter(r *http.Request) (string, string, string, error) {
 	raw := r.URL.Query().Get("type")
 	switch raw {
 	case "":
 		return "", "", "", nil
-	case "personal", "service":
+	case "personal", "service", "end_user":
 		return raw, "", "", nil
 	default:
-		return "", "invalid_type", "type must be 'personal' or 'service'", strconv.ErrSyntax
+		return "", "invalid_type", "type must be 'personal', 'service' or 'end_user'", strconv.ErrSyntax
 	}
 }

--- a/internal/admin/nodes_test.go
+++ b/internal/admin/nodes_test.go
@@ -43,6 +43,7 @@ func setupNodesTest(t *testing.T) (http.Handler, *store.Store, *registry.Registr
 		_, _ = s.Pool().Exec(c, "DELETE FROM nodes")
 		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
 		_, _ = s.Pool().Exec(c, "DELETE FROM users")
+		_, _ = s.Pool().Exec(c, "DELETE FROM federated_identities")
 		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/billing/billing.go
+++ b/internal/billing/billing.go
@@ -1,0 +1,97 @@
+// Package billing resolves which account a proxied request is billed to.
+//
+// It sits between auth and the credit gate (docs/design/end-user-accounts.md):
+// for a key with trust_user_headers, a forwarded OpenWebUI identity is mapped
+// to its own auto-provisioned end-user account (with monthly allowance);
+// every other request bills the key's account. Downstream consumers
+// (CreditGate, the chat handler) read the Resolution from the request context
+// instead of key.AccountID so the pre-check, reserve, settle, and usage row
+// all follow the same billing account.
+package billing
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/apierror"
+	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// Headers forwarded by OpenWebUI when ENABLE_FORWARD_USER_INFO_HEADERS is on.
+// User-Id is the identity authority; the others are display metadata.
+const (
+	HeaderUserID    = "X-OpenWebUI-User-Id"
+	HeaderUserEmail = "X-OpenWebUI-User-Email"
+	HeaderUserName  = "X-OpenWebUI-User-Name"
+)
+
+// SourceOpenWebUI is the federated_identities.source for OpenWebUI users.
+const SourceOpenWebUI = "openwebui"
+
+// Resolution is the billing decision for one request.
+type Resolution struct {
+	AccountID        int64
+	AllowanceManaged bool // true for auto-provisioned end-user accounts (drives 402 wording)
+}
+
+type ctxKey struct{}
+
+// WithResolution returns a context carrying the billing resolution.
+func WithResolution(ctx context.Context, res Resolution) context.Context {
+	return context.WithValue(ctx, ctxKey{}, res)
+}
+
+// FromContext returns the billing resolution, if one was attached.
+func FromContext(ctx context.Context) (Resolution, bool) {
+	res, ok := ctx.Value(ctxKey{}).(Resolution)
+	return res, ok
+}
+
+// Middleware attaches a billing Resolution to every authenticated request.
+// Identity headers are honored ONLY on keys with trust_user_headers —
+// spoofed headers on any other key are inert (billing unchanged).
+// Resolution failure for a trusted identity fails closed: billing an end
+// user against the shared account instead would breach account isolation.
+func Middleware(db *store.Store, defaultGrant float64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := auth.KeyFromContext(r.Context())
+			if key == nil || db == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if key.TrustUserHeaders {
+				if extID := strings.TrimSpace(r.Header.Get(HeaderUserID)); extID != "" {
+					res, err := db.ResolveEndUserAccount(store.FederatedIdentity{
+						Source:      SourceOpenWebUI,
+						ExternalID:  extID,
+						Email:       strings.TrimSpace(r.Header.Get(HeaderUserEmail)),
+						DisplayName: strings.TrimSpace(r.Header.Get(HeaderUserName)),
+					}, defaultGrant, time.Now())
+					if err != nil {
+						slog.ErrorContext(r.Context(), "end-user billing resolution failed",
+							"error", err, "external_id", extID)
+						apierror.WriteError(w, r, http.StatusInternalServerError,
+							"internal_error", "server_error", "Failed to resolve billing account")
+						return
+					}
+					next.ServeHTTP(w, r.WithContext(WithResolution(r.Context(), Resolution{
+						AccountID:        res.AccountID,
+						AllowanceManaged: true,
+					})))
+					return
+				}
+			}
+
+			if key.AccountID != nil {
+				r = r.WithContext(WithResolution(r.Context(), Resolution{AccountID: *key.AccountID}))
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/billing/middleware_test.go
+++ b/internal/billing/middleware_test.go
@@ -1,0 +1,158 @@
+package billing
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+func setupBillingTest(t *testing.T) *store.Store {
+	t.Helper()
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("DATABASE_URL not set, skipping billing integration test")
+	}
+	s, err := store.New(context.Background(), dbURL)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	wipe := func() {
+		c := context.Background()
+		for _, table := range []string{
+			"registration_events", "credit_holds", "credit_transactions",
+			"account_usage_stats", "credit_balances", "usage_logs",
+			"user_sessions", "api_keys", "users", "federated_identities", "accounts",
+		} {
+			_, _ = s.Pool().Exec(c, "DELETE FROM "+table)
+		}
+	}
+	wipe()
+	t.Cleanup(func() {
+		wipe()
+		s.Close()
+	})
+	return s
+}
+
+// serve runs the middleware over a request carrying the given key and headers,
+// and returns the captured billing resolution (nil if none) plus the recorder.
+func serve(t *testing.T, db *store.Store, key *store.APIKey, headers map[string]string) (*Resolution, *httptest.ResponseRecorder) {
+	t.Helper()
+	var captured *Resolution
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if res, ok := FromContext(r.Context()); ok {
+			captured = &res
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", nil)
+	if key != nil {
+		req = req.WithContext(auth.WithKey(req.Context(), key))
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	Middleware(db, 5.0)(next).ServeHTTP(rec, req)
+	return captured, rec
+}
+
+func owuiHeaders() map[string]string {
+	return map[string]string{
+		HeaderUserID:    "owui-user-1",
+		HeaderUserEmail: "bob@example.com",
+		HeaderUserName:  "Bob",
+	}
+}
+
+func TestMiddleware_TrustedKeyWithHeaders_ResolvesEndUser(t *testing.T) {
+	db := setupBillingTest(t)
+	sharedAcc, _, _ := db.RegisterUser("shared@example.com", "hash", "Shared")
+
+	key := &store.APIKey{ID: 1, AccountID: &sharedAcc, TrustUserHeaders: true}
+	res, rec := serve(t, db, key, owuiHeaders())
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if res == nil {
+		t.Fatal("expected a billing resolution in context")
+	}
+	if !res.AllowanceManaged {
+		t.Error("end-user resolution must be allowance-managed")
+	}
+	if res.AccountID == sharedAcc {
+		t.Error("end user must NOT bill the shared key account")
+	}
+
+	// Provisioned with the default grant, ready to pass the credit gate.
+	bal, err := db.GetCreditBalance(res.AccountID)
+	if err != nil || bal == nil {
+		t.Fatalf("GetCreditBalance: %v", err)
+	}
+	if bal.Balance != 5.0 {
+		t.Errorf("expected allowance-funded balance 5.0, got %v", bal.Balance)
+	}
+
+	// Same identity again: same account (stable mapping).
+	res2, _ := serve(t, db, key, owuiHeaders())
+	if res2 == nil || res2.AccountID != res.AccountID {
+		t.Errorf("expected stable account mapping, got %v then %v", res, res2)
+	}
+}
+
+func TestMiddleware_UntrustedKeyWithHeaders_BillsKeyAccount(t *testing.T) {
+	db := setupBillingTest(t)
+	accID, _, _ := db.RegisterUser("untrusted@example.com", "hash", "Untrusted")
+
+	key := &store.APIKey{ID: 1, AccountID: &accID, TrustUserHeaders: false}
+	res, rec := serve(t, db, key, owuiHeaders())
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if res == nil {
+		t.Fatal("expected a billing resolution in context")
+	}
+	if res.AccountID != accID || res.AllowanceManaged {
+		t.Errorf("spoofed headers on an untrusted key must be inert, got %+v", res)
+	}
+
+	// No end-user account may have been provisioned.
+	var count int
+	_ = db.Pool().QueryRow(t.Context(), `SELECT COUNT(*) FROM federated_identities`).Scan(&count)
+	if count != 0 {
+		t.Errorf("expected no federated identities for untrusted key, got %d", count)
+	}
+}
+
+func TestMiddleware_TrustedKeyNoHeaders_BillsKeyAccount(t *testing.T) {
+	db := setupBillingTest(t)
+	accID, _, _ := db.RegisterUser("system@example.com", "hash", "System")
+
+	key := &store.APIKey{ID: 1, AccountID: &accID, TrustUserHeaders: true}
+	res, rec := serve(t, db, key, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if res == nil || res.AccountID != accID || res.AllowanceManaged {
+		t.Errorf("trusted key without headers must bill its own account, got %+v", res)
+	}
+}
+
+func TestMiddleware_NoKey_PassesThroughWithoutResolution(t *testing.T) {
+	db := setupBillingTest(t)
+	res, rec := serve(t, db, nil, owuiHeaders())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if res != nil {
+		t.Errorf("expected no resolution without a key, got %+v", res)
+	}
+}

--- a/internal/bootstrap/handler_metrics_test.go
+++ b/internal/bootstrap/handler_metrics_test.go
@@ -32,6 +32,7 @@ func TestBootstrap_Success_IncrementsRegistrationCounter(t *testing.T) {
 		_, _ = p.Exec(c, "DELETE FROM user_sessions")
 		_, _ = p.Exec(c, "DELETE FROM api_keys")
 		_, _ = p.Exec(c, "DELETE FROM users")
+		_, _ = p.Exec(c, "DELETE FROM federated_identities")
 		_, _ = p.Exec(c, "DELETE FROM accounts")
 	}
 	wipe(s.Pool())

--- a/internal/bootstrap/handler_test.go
+++ b/internal/bootstrap/handler_test.go
@@ -41,6 +41,7 @@ func setupBootstrapTest(t *testing.T, tokenOverride *string) (http.Handler, *sto
 		_, _ = pool.Exec(c, "DELETE FROM user_sessions")
 		_, _ = pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = pool.Exec(c, "DELETE FROM users")
+		_, _ = pool.Exec(c, "DELETE FROM federated_identities")
 		_, _ = pool.Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 )
@@ -125,8 +126,11 @@ func Load() (Config, error) {
 		if err != nil {
 			return Config{}, fmt.Errorf("invalid END_USER_MONTHLY_GRANT: %w", err)
 		}
-		if n < 0 {
-			return Config{}, fmt.Errorf("invalid END_USER_MONTHLY_GRANT: must be >= 0, got %v", n)
+		// NaN poisons every downstream comparison (NaN comparisons are all
+		// false → the credit gate and reserve check never trip → unlimited
+		// spend); infinity is the same defect spelled differently.
+		if math.IsNaN(n) || math.IsInf(n, 0) || n < 0 {
+			return Config{}, fmt.Errorf("invalid END_USER_MONTHLY_GRANT: must be a finite value >= 0, got %v", n)
 		}
 		endUserMonthlyGrant = n
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,12 @@ type Config struct {
 	// working; operators can lower it via ADMIN_SERVICE_CREDIT_GRANT.
 	AdminServiceCreditGrant float64
 
+	// EndUserMonthlyGrant (END_USER_MONTHLY_GRANT, default 5.0) is the
+	// monthly allowance for auto-provisioned end-user accounts, overridable
+	// per account via accounts.monthly_grant. See
+	// docs/design/end-user-accounts.md.
+	EndUserMonthlyGrant float64
+
 	// Public auth-surface rate limits (requests per minute) and the global
 	// bcrypt concurrency cap. See internal/authlimit.
 	AuthLoginPerMinIP     int
@@ -110,6 +116,21 @@ func Load() (Config, error) {
 		adminServiceCreditGrant = n
 	}
 
+	// Monthly allowance for auto-provisioned end-user accounts. Zero is a
+	// valid operator choice (new end users start blocked until an admin sets
+	// a per-account override); negative is a configuration error.
+	endUserMonthlyGrant := 5.0
+	if v := os.Getenv("END_USER_MONTHLY_GRANT"); v != "" {
+		n, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid END_USER_MONTHLY_GRANT: %w", err)
+		}
+		if n < 0 {
+			return Config{}, fmt.Errorf("invalid END_USER_MONTHLY_GRANT: must be >= 0, got %v", n)
+		}
+		endUserMonthlyGrant = n
+	}
+
 	authLoginIP, err := intEnvOrDefault("AUTH_RATELIMIT_LOGIN_PER_MIN", 5)
 	if err != nil {
 		return Config{}, err
@@ -168,6 +189,7 @@ func Load() (Config, error) {
 		LogLevel:            envOrDefault("LOG_LEVEL", "info"),
 
 		AdminServiceCreditGrant: adminServiceCreditGrant,
+		EndUserMonthlyGrant:     endUserMonthlyGrant,
 
 		AuthLoginPerMinIP:     authLoginIP,
 		AuthLoginPerMinEmail:  authLoginEmail,

--- a/internal/config/config_eua_test.go
+++ b/internal/config/config_eua_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+// Non-finite grants would poison every downstream balance comparison (NaN
+// comparisons are all false → unlimited spend), so Load must reject them.
+func TestLoad_EndUserMonthlyGrant_Validation(t *testing.T) {
+	t.Setenv("ADMIN_KEY", "test-admin")
+	t.Setenv("DATABASE_URL", "postgres://x/y")
+
+	for _, bad := range []string{"NaN", "+Inf", "-Inf", "Infinity", "-1"} {
+		t.Setenv("END_USER_MONTHLY_GRANT", bad)
+		if _, err := Load(); err == nil {
+			t.Errorf("END_USER_MONTHLY_GRANT=%q must be rejected", bad)
+		}
+	}
+
+	t.Setenv("END_USER_MONTHLY_GRANT", "7.5")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("valid grant rejected: %v", err)
+	}
+	if cfg.EndUserMonthlyGrant != 7.5 {
+		t.Errorf("expected 7.5, got %v", cfg.EndUserMonthlyGrant)
+	}
+
+	t.Setenv("END_USER_MONTHLY_GRANT", "")
+	cfg, err = Load()
+	if err != nil {
+		t.Fatalf("default case errored: %v", err)
+	}
+	if cfg.EndUserMonthlyGrant != 5.0 {
+		t.Errorf("expected default 5.0, got %v", cfg.EndUserMonthlyGrant)
+	}
+}

--- a/internal/credits/middleware.go
+++ b/internal/credits/middleware.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/krishna/local-ai-proxy/internal/apierror"
 	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/billing"
 	"github.com/krishna/local-ai-proxy/internal/metrics"
 	"github.com/krishna/local-ai-proxy/internal/store"
 )
@@ -15,6 +16,11 @@ import (
 // startup backfill (BackfillAdminKeyAccounts) attaches legacy NULL-account
 // keys to the admin service account, so a nil AccountID can only mean a
 // misprovisioned key; the gate fails closed on it.
+//
+// The gate checks the BILLING account: the billing.Resolution attached by
+// the billing middleware when present (end-user accounts on trusted keys),
+// else the key's own account. Allowance-managed accounts get the
+// monthly_limit_reached wording so chat users see an actionable error.
 func CreditGate(db *store.Store, m *metrics.Metrics) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -25,13 +31,21 @@ func CreditGate(db *store.Store, m *metrics.Metrics) func(http.Handler) http.Han
 				next.ServeHTTP(w, r)
 				return
 			}
-			if key.AccountID == nil {
+
+			var accountID int64
+			var allowanceManaged bool
+			if res, ok := billing.FromContext(r.Context()); ok {
+				accountID = res.AccountID
+				allowanceManaged = res.AllowanceManaged
+			} else if key.AccountID != nil {
+				accountID = *key.AccountID
+			} else {
 				m.RecordCreditGateReject()
 				apierror.WriteError(w, r, http.StatusForbidden, "account_required", "invalid_request_error", "API key is not attached to an account")
 				return
 			}
 
-			isActive, balance, reserved, err := db.GetAccountCreditStatus(*key.AccountID)
+			isActive, balance, reserved, err := db.GetAccountCreditStatus(accountID)
 			if err != nil {
 				apierror.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to check credit status")
 				return
@@ -45,6 +59,10 @@ func CreditGate(db *store.Store, m *metrics.Metrics) func(http.Handler) http.Han
 
 			if balance-reserved <= 0 {
 				m.RecordCreditGateReject()
+				if allowanceManaged {
+					apierror.WriteError(w, r, http.StatusPaymentRequired, "monthly_limit_reached", "invalid_request_error", "Monthly usage limit reached — resets next month")
+					return
+				}
 				apierror.WriteError(w, r, http.StatusPaymentRequired, "insufficient_credits", "invalid_request_error", "Insufficient credits")
 				return
 			}

--- a/internal/credits/middleware_billing_test.go
+++ b/internal/credits/middleware_billing_test.go
@@ -1,0 +1,89 @@
+package credits
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// The gate must check the RESOLVED billing account, not the key's own account:
+// an end user with a funded allowance passes even when the shared key account
+// is empty (the Codex P1 regression from the design review).
+func TestCreditGate_ResolvedBillingAccount_OverridesKeyAccount(t *testing.T) {
+	db := setupTestStore(t)
+	sharedAcc, _, _ := db.RegisterUser("gate-shared@example.com", "hash", "Shared")
+	// Shared account left at 0 balance.
+
+	endUser, err := db.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "gate-user-1", Email: "eu@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+
+	gate := CreditGate(db, nil)
+	called := false
+	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	key := &store.APIKey{ID: 1, AccountID: &sharedAcc, TrustUserHeaders: true}
+	req := httptest.NewRequest("POST", "/test", nil)
+	ctx := auth.WithKey(req.Context(), key)
+	ctx = billing.WithResolution(ctx, billing.Resolution{AccountID: endUser.AccountID, AllowanceManaged: true})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+	if !called {
+		t.Errorf("funded end user must pass the gate even with an empty key account (got %d: %s)",
+			rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreditGate_AllowanceExhausted_MonthlyLimitWording(t *testing.T) {
+	db := setupTestStore(t)
+	sharedAcc, _, _ := db.RegisterUser("gate-shared2@example.com", "hash", "Shared2")
+	_ = db.AddCredits(sharedAcc, 100, "grant")
+
+	// End user provisioned with a zero grant → blocked from the start.
+	endUser, err := db.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "gate-user-2", Email: "blocked@example.com",
+	}, 0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+
+	gate := CreditGate(db, nil)
+	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler must not be called for an exhausted allowance")
+	}))
+
+	key := &store.APIKey{ID: 1, AccountID: &sharedAcc, TrustUserHeaders: true}
+	req := httptest.NewRequest("POST", "/test", nil)
+	ctx := auth.WithKey(req.Context(), key)
+	ctx = billing.WithResolution(ctx, billing.Resolution{AccountID: endUser.AccountID, AllowanceManaged: true})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+	if rec.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", rec.Code)
+	}
+	var resp struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal error body: %v", err)
+	}
+	if resp.Error.Code != "monthly_limit_reached" {
+		t.Errorf("expected code monthly_limit_reached, got %q", resp.Error.Code)
+	}
+}

--- a/internal/credits/middleware_test.go
+++ b/internal/credits/middleware_test.go
@@ -38,6 +38,7 @@ func setupTestStore(t *testing.T) *store.Store {
 		_, _ = pool.Exec(c, "DELETE FROM user_sessions")
 		_, _ = pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = pool.Exec(c, "DELETE FROM users")
+		_, _ = pool.Exec(c, "DELETE FROM federated_identities")
 		_, _ = pool.Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/krishna/local-ai-proxy/internal/apierror"
 	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/billing"
 	"github.com/krishna/local-ai-proxy/internal/credits"
 	"github.com/krishna/local-ai-proxy/internal/metrics"
 	"github.com/krishna/local-ai-proxy/internal/registry"
@@ -198,6 +199,18 @@ func (h *handler) handleChatCompletions(w http.ResponseWriter, r *http.Request) 
 	start := time.Now()
 	key := auth.KeyFromContext(r.Context())
 
+	// Billing account: the resolution attached by the billing middleware
+	// (end-user account on trusted keys) when present, else the key's own
+	// account. Reserve, settle, usage stats, and the usage row all follow it.
+	var bill billingInfo
+	if key != nil {
+		bill.AccountID = key.AccountID
+	}
+	if res, ok := billing.FromContext(r.Context()); ok {
+		id := res.AccountID
+		bill = billingInfo{AccountID: &id, AllowanceManaged: res.AllowanceManaged}
+	}
+
 	// Read and peek at request body
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxBody)
 	body, err := io.ReadAll(r.Body)
@@ -222,9 +235,9 @@ func (h *handler) handleChatCompletions(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// --- Credit enforcement (only for keys with AccountID) ---
+	// --- Credit enforcement (only for keys with a billing account) ---
 	var pricing *store.CreditPricing
-	creditEnabled := key != nil && key.AccountID != nil && h.db != nil
+	creditEnabled := key != nil && bill.AccountID != nil && h.db != nil
 
 	if creditEnabled {
 		// (2) Model allowlist: reject unpriced models
@@ -247,9 +260,9 @@ func (h *handler) handleChatCompletions(w http.ResponseWriter, r *http.Request) 
 				maxTokens = meta.MaxCompletionTokens
 			}
 			estimatedPrompt := credits.EstimatePromptTokens(len(body))
-			stats, statsErr := h.db.GetAccountUsageStats(*key.AccountID, meta.Model)
+			stats, statsErr := h.db.GetAccountUsageStats(*bill.AccountID, meta.Model)
 			if statsErr != nil {
-				slog.WarnContext(r.Context(), "session usage stats lookup error", "error", statsErr, "account_id", *key.AccountID, "model", meta.Model)
+				slog.WarnContext(r.Context(), "session usage stats lookup error", "error", statsErr, "account_id", *bill.AccountID, "model", meta.Model)
 			}
 			estimatedCompletion := credits.EstimateCompletionTokens(maxTokens, stats, pricing)
 			estimatedTotal := estimatedPrompt + estimatedCompletion
@@ -296,15 +309,20 @@ func (h *handler) handleChatCompletions(w http.ResponseWriter, r *http.Request) 
 			maxTok = meta.MaxCompletionTokens
 		}
 		promptEst := credits.EstimatePromptTokens(len(body))
-		stats, statsErr := h.db.GetAccountUsageStats(*key.AccountID, meta.Model)
+		stats, statsErr := h.db.GetAccountUsageStats(*bill.AccountID, meta.Model)
 		if statsErr != nil {
-			slog.WarnContext(r.Context(), "usage stats lookup error", "error", statsErr, "account_id", *key.AccountID, "model", meta.Model)
+			slog.WarnContext(r.Context(), "usage stats lookup error", "error", statsErr, "account_id", *bill.AccountID, "model", meta.Model)
 		}
 		completionEst := credits.EstimateCompletionTokens(maxTok, stats, pricing)
 		reserveAmount := credits.EstimateCost(pricing, promptEst, completionEst)
 
-		holdID, err = h.db.ReserveCredits(*key.AccountID, reserveAmount)
+		holdID, err = h.db.ReserveCredits(*bill.AccountID, reserveAmount)
 		if err != nil {
+			if bill.AllowanceManaged {
+				writeError(w, r, http.StatusPaymentRequired, "monthly_limit_reached", "invalid_request_error",
+					"Monthly usage limit reached — resets next month")
+				return
+			}
 			writeError(w, r, http.StatusPaymentRequired, "insufficient_credits", "invalid_request_error",
 				"Insufficient credits for this request")
 			return
@@ -314,10 +332,18 @@ func (h *handler) handleChatCompletions(w http.ResponseWriter, r *http.Request) 
 	// (5) Forward
 	isStream := meta.Stream != nil && *meta.Stream
 	if isStream {
-		h.handleStreaming(w, r, body, meta.Model, node, key, start, holdID, creditEnabled, pricing)
+		h.handleStreaming(w, r, body, meta.Model, node, key, bill, start, holdID, creditEnabled, pricing)
 	} else {
-		h.handleNonStreaming(w, r, body, meta.Model, node, key, start, holdID, creditEnabled, pricing)
+		h.handleNonStreaming(w, r, body, meta.Model, node, key, bill, start, holdID, creditEnabled, pricing)
 	}
+}
+
+// billingInfo carries the resolved billing account through the request flow.
+// AccountID nil = credit-disabled path (no db or misprovisioned key —
+// creditEnabled is false and no holds are taken).
+type billingInfo struct {
+	AccountID        *int64
+	AllowanceManaged bool
 }
 
 // newUpstreamRequest builds the forwarded request for a node: the chat path
@@ -358,7 +384,7 @@ func copyResponseHeaders(dst, src http.Header) {
 }
 
 func (h *handler) handleNonStreaming(w http.ResponseWriter, r *http.Request, body []byte,
-	model string, node registry.Node, key *store.APIKey, start time.Time,
+	model string, node registry.Node, key *store.APIKey, bill billingInfo, start time.Time,
 	holdID int64, creditEnabled bool, pricing *store.CreditPricing) {
 
 	nodeID := node.ID
@@ -382,13 +408,13 @@ func (h *handler) handleNonStreaming(w http.ResponseWriter, r *http.Request, bod
 		// timeout — which still owes the client a 502.
 		if r.Context().Err() != nil {
 			if key != nil {
-				h.logUsage(key, usageData{Model: model}, time.Since(start), "partial", 0, &nodeID)
+				h.logUsage(key, bill, usageData{Model: model}, time.Since(start), "partial", 0, &nodeID)
 			}
 			return
 		}
 		slog.ErrorContext(r.Context(), "upstream error", "error", err, "model", model, "node", node.Name)
 		if key != nil {
-			h.logUsage(key, usageData{Model: model}, time.Since(start), "error", 0, &nodeID)
+			h.logUsage(key, bill, usageData{Model: model}, time.Since(start), "error", 0, &nodeID)
 		}
 		writeError(w, r, http.StatusBadGateway, "upstream_error", "server_error", "Failed to connect to upstream model server")
 		return
@@ -404,7 +430,7 @@ func (h *handler) handleNonStreaming(w http.ResponseWriter, r *http.Request, bod
 		}
 		slog.ErrorContext(r.Context(), "read response error", "error", err, "model", model, "node", node.Name)
 		if key != nil {
-			h.logUsage(key, usageData{Model: model}, time.Since(start), "error", 0, &nodeID)
+			h.logUsage(key, bill, usageData{Model: model}, time.Since(start), "error", 0, &nodeID)
 		}
 		writeError(w, r, http.StatusBadGateway, "upstream_error", "server_error", "Failed to read upstream response")
 		return
@@ -427,13 +453,13 @@ func (h *handler) handleNonStreaming(w http.ResponseWriter, r *http.Request, bod
 			// Upstream error — release hold, no charge
 			h.db.ReleaseHold(holdID)
 		} else {
-			actualCost = h.settleCredits(holdID, key, &ud, len(respBody), pricing)
+			actualCost = h.settleCredits(holdID, bill, &ud, len(respBody), pricing)
 		}
 	}
 
 	// Log usage and record metrics
 	if key != nil {
-		h.logUsage(key, ud, time.Since(start), status, actualCost, &nodeID)
+		h.logUsage(key, bill, ud, time.Since(start), status, actualCost, &nodeID)
 	}
 	h.metrics.RecordTokens(model, node.Name, ud.Usage.PromptTokens, ud.Usage.CompletionTokens)
 
@@ -445,7 +471,7 @@ func (h *handler) handleNonStreaming(w http.ResponseWriter, r *http.Request, bod
 }
 
 func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body []byte,
-	model string, node registry.Node, key *store.APIKey, start time.Time,
+	model string, node registry.Node, key *store.APIKey, bill billingInfo, start time.Time,
 	holdID int64, creditEnabled bool, pricing *store.CreditPricing) {
 
 	nodeID := node.ID
@@ -475,13 +501,13 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 		}
 		if r.Context().Err() != nil {
 			if key != nil {
-				h.logUsage(key, usageData{Model: model}, time.Since(start), "partial", 0, &nodeID)
+				h.logUsage(key, bill, usageData{Model: model}, time.Since(start), "partial", 0, &nodeID)
 			}
 			return
 		}
 		slog.ErrorContext(r.Context(), "upstream error", "error", err, "model", model, "node", node.Name, "stream", true)
 		if key != nil {
-			h.logUsage(key, usageData{Model: model}, time.Since(start), "error", 0, &nodeID)
+			h.logUsage(key, bill, usageData{Model: model}, time.Since(start), "error", 0, &nodeID)
 		}
 		writeError(w, r, http.StatusBadGateway, "upstream_error", "server_error", "Failed to connect to upstream model server")
 		return
@@ -500,7 +526,7 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 			h.db.ReleaseHold(holdID)
 		}
 		if key != nil {
-			h.logUsage(key, usageData{Model: model}, time.Since(start), "error", 0, &nodeID)
+			h.logUsage(key, bill, usageData{Model: model}, time.Since(start), "error", 0, &nodeID)
 		}
 		return
 	}
@@ -558,11 +584,11 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 	// Credit settlement
 	var actualCost float64
 	if creditEnabled {
-		actualCost = h.settleStreamCredits(holdID, key, &ud, bytesWritten, status, pricing)
+		actualCost = h.settleStreamCredits(holdID, bill, &ud, bytesWritten, status, pricing)
 	}
 
 	if key != nil {
-		h.logUsage(key, ud, time.Since(start), status, actualCost, &nodeID)
+		h.logUsage(key, bill, ud, time.Since(start), status, actualCost, &nodeID)
 	}
 	h.metrics.RecordTokens(model, node.Name, ud.Usage.PromptTokens, ud.Usage.CompletionTokens)
 }
@@ -571,7 +597,7 @@ func (h *handler) handleStreaming(w http.ResponseWriter, r *http.Request, body [
 // returns the amount actually charged (0 when the hold had already been
 // released by the sweeper). Called only for successful (200) upstream
 // responses.
-func (h *handler) settleCredits(holdID int64, key *store.APIKey, ud *usageData, respBodyLen int, pricing *store.CreditPricing) float64 {
+func (h *handler) settleCredits(holdID int64, bill billingInfo, ud *usageData, respBodyLen int, pricing *store.CreditPricing) float64 {
 	promptTokens := ud.Usage.PromptTokens
 	completionTokens := ud.Usage.CompletionTokens
 
@@ -588,9 +614,9 @@ func (h *handler) settleCredits(holdID int64, key *store.APIKey, ud *usageData, 
 	}
 
 	// Update usage stats for future estimates
-	if key != nil && key.AccountID != nil && completionTokens > 0 {
-		if err := h.db.UpdateAccountUsageStats(*key.AccountID, ud.Model, completionTokens); err != nil {
-			slog.Warn("update usage stats error", "error", err, "account_id", *key.AccountID, "model", ud.Model)
+	if bill.AccountID != nil && completionTokens > 0 {
+		if err := h.db.UpdateAccountUsageStats(*bill.AccountID, ud.Model, completionTokens); err != nil {
+			slog.Warn("update usage stats error", "error", err, "account_id", *bill.AccountID, "model", ud.Model)
 		}
 	}
 	return charged
@@ -598,7 +624,7 @@ func (h *handler) settleCredits(holdID int64, key *store.APIKey, ud *usageData, 
 
 // settleStreamCredits handles credit settlement for streaming responses and
 // returns the amount actually charged.
-func (h *handler) settleStreamCredits(holdID int64, key *store.APIKey, ud *usageData, bytesWritten int, status string, pricing *store.CreditPricing) float64 {
+func (h *handler) settleStreamCredits(holdID int64, bill billingInfo, ud *usageData, bytesWritten int, status string, pricing *store.CreditPricing) float64 {
 	if status == "error" && bytesWritten == 0 {
 		h.db.ReleaseHold(holdID)
 		return 0
@@ -619,9 +645,9 @@ func (h *handler) settleStreamCredits(holdID int64, key *store.APIKey, ud *usage
 		slog.Error("settle hold error", "error", err, "hold_id", holdID, "stream", true)
 	}
 
-	if key != nil && key.AccountID != nil && completionTokens > 0 {
-		if err := h.db.UpdateAccountUsageStats(*key.AccountID, ud.Model, completionTokens); err != nil {
-			slog.Warn("update usage stats error", "error", err, "account_id", *key.AccountID, "model", ud.Model)
+	if bill.AccountID != nil && completionTokens > 0 {
+		if err := h.db.UpdateAccountUsageStats(*bill.AccountID, ud.Model, completionTokens); err != nil {
+			slog.Warn("update usage stats error", "error", err, "account_id", *bill.AccountID, "model", ud.Model)
 		}
 	}
 	return charged
@@ -629,7 +655,7 @@ func (h *handler) settleStreamCredits(holdID int64, key *store.APIKey, ud *usage
 
 // logUsage queues one usage entry. nodeID attributes the entry to the node
 // that served the request; requests that never resolved a node pass nil.
-func (h *handler) logUsage(key *store.APIKey, ud usageData, duration time.Duration, status string, creditsCharged float64, nodeID *int64) {
+func (h *handler) logUsage(key *store.APIKey, bill billingInfo, ud usageData, duration time.Duration, status string, creditsCharged float64, nodeID *int64) {
 	if key == nil {
 		return
 	}
@@ -643,6 +669,7 @@ func (h *handler) logUsage(key *store.APIKey, ud usageData, duration time.Durati
 		Status:           status,
 		CreditsCharged:   creditsCharged,
 		NodeID:           nodeID,
+		AccountID:        bill.AccountID,
 	}
 	select {
 	case h.usageCh <- entry:

--- a/internal/proxy/proxy_billing_test.go
+++ b/internal/proxy/proxy_billing_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// End-to-end through the billing middleware + handler: a trusted key
+// forwarding an OpenWebUI identity settles against the auto-provisioned
+// end-user account; the shared key account is untouched; the usage entry is
+// attributed to the end-user account.
+func TestBillingIntegration_TrustedHeaders_BillEndUserAccount(t *testing.T) {
+	db := setupTestDB(t)
+	sharedAcc, _, _ := db.RegisterUser("owui-shared@example.com", "hash", "OWUIShared")
+	_ = db.AddCredits(sharedAcc, 1000, "grant")
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
+
+	ollamaResp := map[string]any{
+		"id": "chatcmpl-1", "object": "chat.completion", "model": "llama3.1:8b",
+		"choices": []map[string]any{{"message": map[string]any{"role": "assistant", "content": "Hi!"}}},
+		"usage":   map[string]any{"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+	}
+	upstream := mockOllamaChatNonStreaming(http.StatusOK, ollamaResp)
+	defer upstream.Close()
+
+	usageCh := make(chan store.UsageEntry, 10)
+	h := NewHandler(singleNodeRegistry(t, upstream.URL, "llama3.1:8b"), usageCh, 52428800, db, nil, Options{})
+	chain := billing.Middleware(db, 5.0)(h)
+
+	reqBody := `{"model":"llama3.1:8b","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(billing.HeaderUserID, "owui-e2e-1")
+	req.Header.Set(billing.HeaderUserEmail, "enduser@example.com")
+	key := &store.APIKey{ID: 1, Name: "openwebui", AccountID: &sharedAcc, TrustUserHeaders: true}
+	req = addKeyToRequest(req, key)
+
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// End-user account exists, funded by the allowance, and paid for the request.
+	var endUserAcc int64
+	if err := db.Pool().QueryRow(t.Context(),
+		`SELECT account_id FROM federated_identities WHERE source='openwebui' AND external_id='owui-e2e-1'`).Scan(&endUserAcc); err != nil {
+		t.Fatalf("end-user account not provisioned: %v", err)
+	}
+	endBal, _ := db.GetCreditBalance(endUserAcc)
+	if endBal.Balance >= 5.0 {
+		t.Errorf("expected end-user balance < 5.0 after settlement, got %v", endBal.Balance)
+	}
+	if endBal.Reserved != 0 {
+		t.Errorf("expected end-user reserved 0 after settlement, got %v", endBal.Reserved)
+	}
+
+	// Shared account: completely untouched.
+	sharedBal, _ := db.GetCreditBalance(sharedAcc)
+	if sharedBal.Balance != 1000 || sharedBal.Reserved != 0 {
+		t.Errorf("shared account must be untouched, got balance %v reserved %v",
+			sharedBal.Balance, sharedBal.Reserved)
+	}
+
+	// Usage entry attributed to the end-user account.
+	select {
+	case entry := <-usageCh:
+		if entry.AccountID == nil || *entry.AccountID != endUserAcc {
+			t.Errorf("expected usage attribution to end-user account %d, got %v", endUserAcc, entry.AccountID)
+		}
+		if entry.CreditsCharged <= 0 {
+			t.Errorf("expected CreditsCharged > 0, got %v", entry.CreditsCharged)
+		}
+	default:
+		t.Error("expected a usage entry")
+	}
+}
+
+// Reserve failure on an allowance-managed account uses the monthly-limit wording.
+func TestBillingIntegration_AllowanceTooLow_MonthlyLimitReached(t *testing.T) {
+	db := setupTestDB(t)
+	sharedAcc, _, _ := db.RegisterUser("owui-shared2@example.com", "hash", "OWUIShared2")
+	_ = db.AddCredits(sharedAcc, 1000, "grant")
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
+
+	upstream := mockOllamaChatNonStreaming(http.StatusOK, map[string]any{})
+	defer upstream.Close()
+
+	usageCh := make(chan store.UsageEntry, 10)
+	h := NewHandler(singleNodeRegistry(t, upstream.URL, "llama3.1:8b"), usageCh, 52428800, db, nil, Options{})
+	chain := billing.Middleware(db, 0.000001)(h) // grant too small for any request
+
+	reqBody := `{"model":"llama3.1:8b","messages":[{"role":"user","content":"Hi"}],"max_tokens":500}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(billing.HeaderUserID, "owui-e2e-2")
+	key := &store.APIKey{ID: 1, Name: "openwebui", AccountID: &sharedAcc, TrustUserHeaders: true}
+	req = addKeyToRequest(req, key)
+
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+	if rec.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "monthly_limit_reached") {
+		t.Errorf("expected monthly_limit_reached error code, got: %s", rec.Body.String())
+	}
+}

--- a/internal/proxy/proxy_metrics_test.go
+++ b/internal/proxy/proxy_metrics_test.go
@@ -22,7 +22,7 @@ func TestLogUsage_ChannelFull_IncrementsUsageDrops(t *testing.T) {
 	h := &handler{usageCh: usageCh, metrics: m}
 
 	key := &store.APIKey{ID: 1}
-	h.logUsage(key, usageData{Model: "llama3.1:8b"}, 0, "ok", 0, nil)
+	h.logUsage(key, billingInfo{}, usageData{Model: "llama3.1:8b"}, 0, "ok", 0, nil)
 
 	if got := testutil.ToFloat64(m.UsageDrops); got != 1 {
 		t.Errorf("UsageDrops = %v, want 1 after drop", got)
@@ -37,7 +37,7 @@ func TestLogUsage_ChannelHasRoom_DoesNotIncrement(t *testing.T) {
 	h := &handler{usageCh: usageCh, metrics: m}
 
 	key := &store.APIKey{ID: 1}
-	h.logUsage(key, usageData{Model: "llama3.1:8b"}, 0, "ok", 0, nil)
+	h.logUsage(key, billingInfo{}, usageData{Model: "llama3.1:8b"}, 0, "ok", 0, nil)
 
 	if got := testutil.ToFloat64(m.UsageDrops); got != 0 {
 		t.Errorf("UsageDrops = %v, want 0 when channel has room", got)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -102,6 +102,7 @@ func setupTestDB(t *testing.T) *store.Store {
 		_, _ = pool.Exec(c, "DELETE FROM user_sessions")
 		_, _ = pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = pool.Exec(c, "DELETE FROM users")
+		_, _ = pool.Exec(c, "DELETE FROM federated_identities")
 		_, _ = pool.Exec(c, "DELETE FROM accounts")
 	}
 	wipe()
@@ -1228,7 +1229,7 @@ func TestLogUsage_NilKey(t *testing.T) {
 	h := &handler{usageCh: usageCh}
 
 	// Should not panic and should not send to channel
-	h.logUsage(nil, usageData{Model: "test"}, time.Second, "completed", 0, nil)
+	h.logUsage(nil, billingInfo{}, usageData{Model: "test"}, time.Second, "completed", 0, nil)
 
 	select {
 	case entry := <-usageCh:
@@ -1247,7 +1248,7 @@ func TestLogUsage_ChannelFull(t *testing.T) {
 	key := testAPIKey()
 
 	// Should not block — entry is dropped silently
-	h.logUsage(key, usageData{Model: "test"}, time.Second, "completed", 0, nil)
+	h.logUsage(key, billingInfo{}, usageData{Model: "test"}, time.Second, "completed", 0, nil)
 
 	// Drain the original entry
 	<-usageCh
@@ -1272,7 +1273,7 @@ func TestLogUsage_Success(t *testing.T) {
 	ud.Usage.TotalTokens = 15
 
 	nodeID := int64(7)
-	h.logUsage(key, ud, 500*time.Millisecond, "completed", 0.12, &nodeID)
+	h.logUsage(key, billingInfo{}, ud, 500*time.Millisecond, "completed", 0.12, &nodeID)
 
 	select {
 	case entry := <-usageCh:

--- a/internal/store/credits.go
+++ b/internal/store/credits.go
@@ -581,17 +581,31 @@ func (s *Store) SetSessionTokenLimit(keyID int64, limit *int) error {
 }
 
 // ListAccountsWithBalances returns all accounts with their credit balances.
-func (s *Store) ListAccountsWithBalances() ([]struct {
+// AccountWithBalance is one row of the admin accounts listing: the account,
+// its balance state, and — for allowance-managed end-user accounts — the
+// allowance override and the federated identity's email (oldest identity
+// wins on the rare account with several).
+type AccountWithBalance struct {
 	Account
-	Balance  float64
-	Reserved float64
-}, error) {
+	Balance          float64
+	Reserved         float64
+	AllowanceManaged bool
+	MonthlyGrant     *float64 // nil = env default applies
+	FederatedEmail   *string  // nil = no federated identity
+}
+
+func (s *Store) ListAccountsWithBalances() ([]AccountWithBalance, error) {
 	rows, err := s.pool.Query(
 		context.Background(),
 		`SELECT a.id, a.name, a.type, a.is_active, a.created_at,
-		        COALESCE(cb.balance, 0), COALESCE(cb.reserved, 0)
+		        COALESCE(cb.balance, 0), COALESCE(cb.reserved, 0),
+		        a.allowance_managed, a.monthly_grant, fi.email
 		 FROM accounts a
 		 LEFT JOIN credit_balances cb ON cb.account_id = a.id
+		 LEFT JOIN LATERAL (
+		     SELECT email FROM federated_identities
+		     WHERE account_id = a.id ORDER BY id LIMIT 1
+		 ) fi ON TRUE
 		 ORDER BY a.id`,
 	)
 	if err != nil {
@@ -599,24 +613,11 @@ func (s *Store) ListAccountsWithBalances() ([]struct {
 	}
 	defer rows.Close()
 
-	type AccountWithBalance struct {
-		Account
-		Balance  float64
-		Reserved float64
-	}
-	var results []struct {
-		Account
-		Balance  float64
-		Reserved float64
-	}
+	var results []AccountWithBalance
 	for rows.Next() {
-		var r struct {
-			Account
-			Balance  float64
-			Reserved float64
-		}
+		var r AccountWithBalance
 		if err := rows.Scan(&r.ID, &r.Name, &r.Type, &r.IsActive, &r.CreatedAt,
-			&r.Balance, &r.Reserved); err != nil {
+			&r.Balance, &r.Reserved, &r.AllowanceManaged, &r.MonthlyGrant, &r.FederatedEmail); err != nil {
 			return nil, err
 		}
 		results = append(results, r)

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -315,3 +315,8 @@ END $$;
 
 CREATE INDEX IF NOT EXISTS idx_usage_logs_account_created
     ON usage_logs(account_id, created_at);
+
+-- The admin accounts listing resolves each account's display email via a
+-- correlated per-account lookup; this index keeps that O(log n) per row.
+CREATE INDEX IF NOT EXISTS idx_federated_identities_account
+    ON federated_identities(account_id, id);

--- a/internal/user/authlimit_integration_test.go
+++ b/internal/user/authlimit_integration_test.go
@@ -42,6 +42,7 @@ func setupGuardedUserTest(t *testing.T, cfg authlimit.Config) (http.Handler, *au
 		_, _ = s.Pool().Exec(c, "DELETE FROM user_sessions")
 		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
 		_, _ = s.Pool().Exec(c, "DELETE FROM users")
+		_, _ = s.Pool().Exec(c, "DELETE FROM federated_identities")
 		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/user/handler_metrics_test.go
+++ b/internal/user/handler_metrics_test.go
@@ -41,6 +41,7 @@ func setupUserMetricsTest(t *testing.T) (http.Handler, *store.Store, *metrics.Me
 		_, _ = s.Pool().Exec(c, "DELETE FROM user_sessions")
 		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
 		_, _ = s.Pool().Exec(c, "DELETE FROM users")
+		_, _ = s.Pool().Exec(c, "DELETE FROM federated_identities")
 		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/user/handler_test.go
+++ b/internal/user/handler_test.go
@@ -40,6 +40,7 @@ func setupUserTest(t *testing.T) (http.Handler, *store.Store) {
 		_, _ = s.Pool().Exec(c, "DELETE FROM user_sessions")
 		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
 		_, _ = s.Pool().Exec(c, "DELETE FROM users")
+		_, _ = s.Pool().Exec(c, "DELETE FROM federated_identities")
 		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
 	}
 


### PR DESCRIPTION
Completes the backend for end-user accounts (design #56, store #57).

**EUA-3 — proxy billing resolution**
- New `billing.Middleware` between auth and CreditGate: trusted keys with `X-OpenWebUI-User-Id` bill the auto-provisioned end-user account; spoofed headers on untrusted keys are inert; resolution failure fails closed
- CreditGate + chat handler consume the resolved account (fixes the Codex P1 gate-ordering finding from the design review) — pre-check, reserve, settle, usage stats, usage row all follow it
- 402 `monthly_limit_reached` for allowance-managed accounts at both gate and reserve
- `END_USER_MONTHLY_GRANT` env (default 5.0)

**EUA-4 — admin API**
- `PUT /api/admin/keys/{id}/trust-user-headers`
- `PUT /api/admin/accounts/{id}/allowance` (value = override, null = env default)
- `GET /api/admin/accounts`: `allowance_managed`, `monthly_grant`, federated `email`, `?type=end_user`
- README: endpoints + env var

Full suite green locally with CI flags (`-race -p 1`, 905 tests incl. new middleware/gate/E2E-integration coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe