### PR TITLE
fix(cd): never let :latest be the desired image — kills the phantom pricing seeder

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,11 +93,18 @@ jobs:
           # exist and prefix each with a `---` document separator so the stream
           # is valid multi-document YAML. A plain `cat` of the files concatenates
           # them into a single document (duplicate top-level keys, last wins) so
-          # kubectl applies only the final manifest. Then pin the freshly pushed
-          # image and wait for the rollout.
+          # kubectl applies only the final manifest.
+          #
+          # CRITICAL: the built image is substituted into the manifest BEFORE
+          # apply. The previous apply-then-set-image sequence briefly made the
+          # manifest's ":latest" the desired state; with IfNotPresent the node
+          # booted its STALE cached :latest (a pre-OSS build whose startup
+          # seeded the pricing catalog) for a few seconds on EVERY deploy —
+          # the "phantom pricing seeder" (2026-07 forensics). The desired
+          # image must never be a mutable tag at any point in the rollout.
           for f in deploy/k8s/*.yaml; do printf '%s\n' '---'; cat "$f"; done \
+            | sed "s|image: ghcr.io/skrx7392/local-ai-proxy:latest|image: ${IMAGE}|" \
             | $SSH "export KUBECONFIG=/home/sk/.kube/config && sudo kubectl apply -f -"
 
           $SSH "export KUBECONFIG=/home/sk/.kube/config && \
-            sudo kubectl -n local-ai set image deployment/ai-proxy ai-proxy='${IMAGE}' && \
             sudo kubectl -n local-ai rollout status deployment/ai-proxy --timeout=120s"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -19,6 +19,11 @@ spec:
     spec:
       containers:
         - name: ai-proxy
+          # Placeholder ONLY — cd.yml substitutes the freshly built commit-SHA
+          # image before apply. A mutable :latest desired state + IfNotPresent
+          # boots whatever stale image the node has cached (this was the
+          # 2026-07 "phantom pricing seeder": every deploy briefly ran a
+          # pre-OSS cached build whose startup re-seeded the catalog).
           image: ghcr.io/skrx7392/local-ai-proxy:latest
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
**The 2026-07 phantom pricing seeder is solved.** It was never an external client.

**Mechanism**: cd.yml applied `deploy/k8s/deployment.yaml` (image `:latest`, `IfNotPresent`) *before* `set image <sha>`. The node's cached `:latest` dates from commit `1985a06` (pre-OSS-1, seed.go intact — verified via crictl image IDs). So every deploy booted that relic for a few seconds; its startup seed re-inserted the 7-model catalog (postgres statement logs: INSERTs on the same connection/PID as its schema migration, 5ms apart, from the pod IP, using the pre-redenomination column list). Then set-image replaced it with the real build — gone before anyone could look. Explains the 8/8 deploy correlation, the 'fired before the new pod was listening' observation, and today's zero admin POSTs in the freshly enabled traefik access log.

**Fix**: sed the commit-SHA image into the manifest before apply; drop the set-image step. A mutable tag is never the desired state at any point.

**Validation**: after merge, this PR's own deploy must leave the catalog untouched (single active gemma4:e4b row) — will verify.

Follow-up done on the node: stale `:latest` tag removed from containerd cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe