### PR TITLE
feat(analytics): usage-by-account endpoint for EUA billing attribution

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -165,6 +165,7 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 	mux.HandleFunc("GET /api/admin/usage/summary", handler.getUsageSummary)
 	mux.HandleFunc("GET /api/admin/usage/by-model", handler.getUsageByModel)
 	mux.HandleFunc("GET /api/admin/usage/by-user", handler.getUsageByUser)
+	mux.HandleFunc("GET /api/admin/usage/by-account", handler.getUsageByAccount)
 	mux.HandleFunc("GET /api/admin/usage/timeseries", handler.getUsageTimeseries)
 	mux.HandleFunc("GET /api/admin/users", handler.listUsers)
 	mux.HandleFunc("GET /api/admin/users/{id}", handler.getUser)

--- a/internal/admin/usage_analytics.go
+++ b/internal/admin/usage_analytics.go
@@ -47,6 +47,17 @@ type ownerUsageDTO struct {
 	KeyCount    int     `json:"key_count"`
 }
 
+type accountUsageDTO struct {
+	AccountID   *int64  `json:"account_id"`
+	AccountName *string `json:"account_name"`
+	AccountType *string `json:"account_type"`
+	Email       *string `json:"email"`
+	Requests    int     `json:"requests"`
+	TotalTokens int     `json:"total_tokens"`
+	Credits     float64 `json:"credits"`
+	KeyCount    int     `json:"key_count"`
+}
+
 type timeseriesBucketDTO struct {
 	Bucket           time.Time `json:"bucket"`
 	Requests         int       `json:"requests"`
@@ -325,6 +336,42 @@ func (h *handler) getUsageByUser(w http.ResponseWriter, r *http.Request) {
 			AccountID:   row.AccountID,
 			AccountName: row.AccountName,
 			AccountType: row.AccountType,
+			Requests:    row.Requests,
+			TotalTokens: row.TotalTokens,
+			Credits:     row.Credits,
+			KeyCount:    row.KeyCount,
+		}
+	}
+	page, pag := sliceWindow(dtos, limit, offset)
+	writeEnvelope(w, page, pag)
+}
+
+func (h *handler) getUsageByAccount(w http.ResponseWriter, r *http.Request) {
+	f, code, msg, err := parseUsageFilter(r, time.Now())
+	if err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, code, "invalid_request_error", msg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
+	rows, err := h.store.GetUsageByAccount(f)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "usage by account error", "error", err)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to get usage by account")
+		return
+	}
+
+	dtos := make([]accountUsageDTO, len(rows))
+	for i, row := range rows {
+		dtos[i] = accountUsageDTO{
+			AccountID:   row.AccountID,
+			AccountName: row.AccountName,
+			AccountType: row.AccountType,
+			Email:       row.Email,
 			Requests:    row.Requests,
 			TotalTokens: row.TotalTokens,
 			Credits:     row.Credits,

--- a/internal/admin/usage_analytics_http_test.go
+++ b/internal/admin/usage_analytics_http_test.go
@@ -45,6 +45,11 @@ func seedUsageFixtureHTTP(t *testing.T, s *store.Store) usageFixture {
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
+	// Registration links user → personal account; CreateUser alone doesn't.
+	// Mirror that here so account→user lookups behave like production.
+	if _, err := s.Pool().Exec(ctx, `UPDATE users SET account_id = $1 WHERE id = $2`, personal, uid); err != nil {
+		t.Fatalf("link user to personal account: %v", err)
+	}
 	keyUser, err := s.CreateKeyForAccount(uid, personal, "alice-key", "hashU", "sk-u", 60)
 	if err != nil {
 		t.Fatalf("CreateKeyForAccount user: %v", err)
@@ -408,6 +413,159 @@ func TestUsageByUser_NodeFilter(t *testing.T) {
 	}
 }
 
+// --- by-account -----------------------------------------------------------
+
+// seedEndUserUsage extends the base fixture with the EUA population the
+// by-user grouping can't represent cleanly:
+//   - an end_user account with a federated identity, whose usage rides the
+//     SERVICE key (trusted-header attribution: usage_logs.account_id is the
+//     billing account, not the key's own account)
+//   - a key with no account at all (legacy admin key) → unattributed row.
+//
+// Returns (endUserAcct, orphanKey).
+func seedEndUserUsage(t *testing.T, s *store.Store, fx usageFixture) (int64, int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	eu, err := s.CreateAccount("openwebui:u-777", "end_user")
+	if err != nil {
+		t.Fatalf("CreateAccount end_user: %v", err)
+	}
+	if _, err := s.Pool().Exec(ctx,
+		`INSERT INTO federated_identities (source, external_id, account_id, email, display_name)
+		 VALUES ('openwebui', 'u-777', $1, 'chat-user@example.com', 'Chat User')`, eu); err != nil {
+		t.Fatalf("insert federated identity: %v", err)
+	}
+
+	orphanKey, err := s.CreateKey("legacy-admin-key", "hashL", "sk-l", 60)
+	if err != nil {
+		t.Fatalf("CreateKey orphan: %v", err)
+	}
+
+	type row struct {
+		keyID  int64
+		acct   *int64
+		tokens int
+		credit float64
+		offset time.Duration
+	}
+	rows := []row{
+		{fx.keyService, &eu, 2000, 0.80, 3 * time.Hour},
+		{fx.keyService, &eu, 1000, 0.40, 4 * time.Hour},
+		{orphanKey, nil, 10, 0.01, 7 * time.Hour},
+	}
+	for _, r := range rows {
+		if _, err := s.Pool().Exec(ctx,
+			`INSERT INTO usage_logs (api_key_id, account_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged, created_at)
+			 VALUES ($1, $2, 'gemma4:e4b', $3, 0, $3, 100, 'completed', $4, $5)`,
+			r.keyID, r.acct, r.tokens, r.credit, fx.t0.Add(r.offset),
+		); err != nil {
+			t.Fatalf("insert eua usage: %v", err)
+		}
+	}
+	return eu, orphanKey
+}
+
+func TestUsageByAccount_GroupsByBillingAccount(t *testing.T) {
+	h, s := setupAdminTest(t)
+	fx := seedUsageFixtureHTTP(t, s)
+	eu, _ := seedEndUserUsage(t, s, fx)
+
+	rec := doAdmin(t, h, "/api/admin/usage/by-account?since="+fx.t0.Format(time.RFC3339))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Data       []accountUsageDTO `json:"data"`
+		Pagination *Pagination       `json:"pagination"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Pagination == nil {
+		t.Fatalf("by-account must use the list envelope, body=%s", rec.Body.String())
+	}
+	// end_user (3000 tokens) > service (780) > personal (525) > unattributed (10)
+	if len(body.Data) != 4 {
+		t.Fatalf("len(data) = %d, want 4 accounts, body=%s", len(body.Data), rec.Body.String())
+	}
+
+	euRow := body.Data[0]
+	if euRow.AccountID == nil || *euRow.AccountID != eu {
+		t.Fatalf("first row account_id = %v, want end_user acct %d (ordered by tokens desc)", euRow.AccountID, eu)
+	}
+	if euRow.AccountType == nil || *euRow.AccountType != "end_user" {
+		t.Errorf("end_user row account_type = %v, want end_user", euRow.AccountType)
+	}
+	if euRow.Email == nil || *euRow.Email != "chat-user@example.com" {
+		t.Errorf("end_user row email = %v, want federated identity email", euRow.Email)
+	}
+	if euRow.Requests != 2 || euRow.TotalTokens != 3000 || euRow.KeyCount != 1 {
+		t.Errorf("end_user row = %+v, want 2 requests / 3000 tokens / 1 key", euRow)
+	}
+
+	svcRow := body.Data[1]
+	if svcRow.AccountID == nil || *svcRow.AccountID != fx.serviceAcct {
+		t.Errorf("second row account_id = %v, want service acct %d", svcRow.AccountID, fx.serviceAcct)
+	}
+	// The service key carried end-user traffic too, but those rows bill the
+	// end_user account: the service row must count ONLY unattributed key rows.
+	if svcRow.Requests != 2 || svcRow.TotalTokens != 780 {
+		t.Errorf("service row = %+v, want 2 requests / 780 tokens", svcRow)
+	}
+	if svcRow.Email != nil {
+		t.Errorf("service row email = %v, want nil", svcRow.Email)
+	}
+
+	personalRow := body.Data[2]
+	if personalRow.AccountID == nil || *personalRow.AccountID != fx.personalAcct {
+		t.Errorf("third row account_id = %v, want personal acct %d", personalRow.AccountID, fx.personalAcct)
+	}
+	if personalRow.AccountType == nil || *personalRow.AccountType != "personal" {
+		t.Errorf("personal row account_type = %v, want personal", personalRow.AccountType)
+	}
+	// Personal accounts fall back to the owning user's email for display.
+	if personalRow.Email == nil || *personalRow.Email != "alice@example.com" {
+		t.Errorf("personal row email = %v, want alice@example.com", personalRow.Email)
+	}
+
+	orphanRow := body.Data[3]
+	if orphanRow.AccountID != nil || orphanRow.AccountName != nil || orphanRow.AccountType != nil || orphanRow.Email != nil {
+		t.Errorf("unattributed row should be all-NULL identity, got %+v", orphanRow)
+	}
+	if orphanRow.Requests != 1 || orphanRow.TotalTokens != 10 {
+		t.Errorf("unattributed row = %+v, want 1 request / 10 tokens", orphanRow)
+	}
+}
+
+func TestUsageByAccount_AccountFilter(t *testing.T) {
+	h, s := setupAdminTest(t)
+	fx := seedUsageFixtureHTTP(t, s)
+	eu, _ := seedEndUserUsage(t, s, fx)
+
+	path := fmt.Sprintf("/api/admin/usage/by-account?account_id=%d&since=%s", eu, fx.t0.Format(time.RFC3339))
+	rec := doAdmin(t, h, path)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Data []accountUsageDTO `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(body.Data) != 1 {
+		t.Fatalf("len(data) = %d, want just the filtered end_user account, body=%s", len(body.Data), rec.Body.String())
+	}
+	if body.Data[0].AccountID == nil || *body.Data[0].AccountID != eu {
+		t.Errorf("row account_id = %v, want %d", body.Data[0].AccountID, eu)
+	}
+	if body.Data[0].TotalTokens != 3000 {
+		t.Errorf("row tokens = %d, want 3000", body.Data[0].TotalTokens)
+	}
+}
+
 // --- timeseries -----------------------------------------------------------
 //
 // Timeseries is locked to the **detail envelope** shape per PLAN.md §Locked
@@ -607,6 +765,7 @@ func TestUsageEndpoints_ValidationErrors(t *testing.T) {
 		{"zero api_key_id", "/api/admin/usage/by-model?api_key_id=0"},
 		{"limit over cap", "/api/admin/usage/by-user?limit=501"},
 		{"negative offset", "/api/admin/usage/by-user?offset=-1"},
+		{"by-account limit over cap", "/api/admin/usage/by-account?limit=501"},
 		{"bad interval", "/api/admin/usage/timeseries?interval=fortnight"},
 	}
 	for _, c := range cases {
@@ -629,6 +788,7 @@ func TestUsageEndpoints_InvalidNodeID(t *testing.T) {
 		"/api/admin/usage/summary?node_id=abc",
 		"/api/admin/usage/by-model?node_id=abc",
 		"/api/admin/usage/by-user?node_id=abc",
+		"/api/admin/usage/by-account?node_id=abc",
 		"/api/admin/usage/timeseries?node_id=abc",
 	} {
 		t.Run(path, func(t *testing.T) {
@@ -680,6 +840,7 @@ func TestUsageEndpoints_RequireAuth(t *testing.T) {
 		"/api/admin/usage/summary",
 		"/api/admin/usage/by-model",
 		"/api/admin/usage/by-user",
+		"/api/admin/usage/by-account",
 		"/api/admin/usage/timeseries",
 	} {
 		t.Run(path, func(t *testing.T) {

--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -61,6 +61,23 @@ type OwnerUsageRow struct {
 	KeyCount    int
 }
 
+// AccountUsageRow is one row of GetUsageByAccount: aggregates grouped by the
+// billing account — usage_logs.account_id when the row was attributed (end-user
+// traffic on trusted keys), else the key's own account. A NULL AccountID row
+// collects usage from keys that have no account (legacy admin-created keys).
+// Email is display metadata: the account's federated-identity email (end_user
+// accounts) or the owning user's email (personal accounts), else NULL.
+type AccountUsageRow struct {
+	AccountID   *int64
+	AccountName *string
+	AccountType *string
+	Email       *string
+	Requests    int
+	TotalTokens int
+	Credits     float64
+	KeyCount    int
+}
+
 // TimeseriesBucket is one bucket of GetUsageTimeseries.
 type TimeseriesBucket struct {
 	Bucket           time.Time
@@ -226,6 +243,64 @@ func (s *Store) GetUsageByUser(f UsageFilter) ([]OwnerUsageRow, error) {
 		if err := rows.Scan(&r.UserID, &r.Email, &r.Name, &r.AccountID, &r.AccountName, &r.AccountType,
 			&r.Requests, &r.TotalTokens, &r.Credits, &r.KeyCount); err != nil {
 			return nil, fmt.Errorf("scan owner row: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GetUsageByAccount returns per-billing-account aggregates, ordered by
+// total_tokens desc. Aggregation happens in a subquery so the account/email
+// joins run once per account, not once per usage row.
+func (s *Store) GetUsageByAccount(f UsageFilter) ([]AccountUsageRow, error) {
+	var sb strings.Builder
+	sb.WriteString(
+		`SELECT
+		   g.account_id,
+		   a.name,
+		   a.type,
+		   COALESCE(fi.email, usr.email),
+		   g.requests,
+		   g.total_tokens,
+		   g.credits,
+		   g.key_count
+		 FROM (
+		   SELECT
+		     COALESCE(ul.account_id, k.account_id) AS account_id,
+		     COUNT(*) AS requests,
+		     COALESCE(SUM(ul.total_tokens), 0) AS total_tokens,
+		     COALESCE(SUM(ul.credits_charged), 0) AS credits,
+		     COUNT(DISTINCT ul.api_key_id) AS key_count
+		   FROM usage_logs ul
+		   JOIN api_keys k ON ul.api_key_id = k.id
+		   WHERE 1=1`)
+	args, _ := buildUsageFilterClause(&sb, nil, f, 1)
+	sb.WriteString(
+		`   GROUP BY COALESCE(ul.account_id, k.account_id)
+		 ) g
+		 LEFT JOIN accounts a ON a.id = g.account_id
+		 LEFT JOIN LATERAL (
+		     SELECT email FROM federated_identities
+		     WHERE account_id = a.id ORDER BY id LIMIT 1
+		 ) fi ON TRUE
+		 LEFT JOIN LATERAL (
+		     SELECT email FROM users
+		     WHERE account_id = a.id ORDER BY id LIMIT 1
+		 ) usr ON TRUE
+		 ORDER BY g.total_tokens DESC`)
+
+	rows, err := s.pool.Query(context.Background(), sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage by account: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]AccountUsageRow, 0)
+	for rows.Next() {
+		var r AccountUsageRow
+		if err := rows.Scan(&r.AccountID, &r.AccountName, &r.AccountType, &r.Email,
+			&r.Requests, &r.TotalTokens, &r.Credits, &r.KeyCount); err != nil {
+			return nil, fmt.Errorf("scan account row: %w", err)
 		}
 		out = append(out, r)
 	}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -320,3 +320,8 @@ CREATE INDEX IF NOT EXISTS idx_usage_logs_account_created
 -- correlated per-account lookup; this index keeps that O(log n) per row.
 CREATE INDEX IF NOT EXISTS idx_federated_identities_account
     ON federated_identities(account_id, id);
+
+-- Same shape for the personal-account fallback in usage-by-account: the
+-- per-account owning-user email lookup filters users on account_id.
+CREATE INDEX IF NOT EXISTS idx_users_account
+    ON users(account_id, id);


### PR DESCRIPTION
## Why

End-user accounts (EUA, #56–#58) broke the admin console's by-user usage grouping in two ways:

1. **End-user traffic is invisible as its own line.** All chat traffic rides the shared OpenWebUI key, so `/usage/by-user` groups it under that key's owner and only splits on the billing account internally.
2. **It violates the FE wire contract.** The by-user rows now emit `account_type=end_user`, which the admin frontend's Zod schema (`personal|service` only) rejects — the By-user tab hard-fails once end-user usage is in range.

Per Krishna's direction, the Usage tab moves to **account**-based grouping — the billing account is the one entity that covers proxy users (personal), machine keys (service), and chat users (end_user).

## What

- `GET /api/admin/usage/by-account` — list envelope, same filters/pagination as the other analytics endpoints. Groups by `COALESCE(usage_logs.account_id, api_keys.account_id)`; NULL-account keys collapse into one unattributed row.
- Display email per account: federated-identity email (end_user) → owning user's email (personal) → NULL (service).
- Aggregation runs in a subquery so the account/email joins execute once per account, not per usage row.
- New `idx_users_account (account_id, id)` supporting the owning-user lookup (Codex review finding; mirrors `idx_federated_identities_account`).
- `/usage/by-user` is unchanged for API compatibility; the FE stops using it (companion frontend PR).

## Tests

- `TestUsageByAccount_GroupsByBillingAccount` — end_user/service/personal/unattributed split, email resolution per type, key counts, token-desc ordering; asserts the service account is NOT charged for end-user traffic carried on its key.
- `TestUsageByAccount_AccountFilter` — `?account_id=` composes with the grouping.
- by-account added to the shared validation/auth/node-id test tables.
- Fixture now links `users.account_id` like production registration does (it previously left it NULL, which masked the personal-email path).

Full suite: 913 green with CI flags (`-race -p 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe