### PR TITLE
feat(usage): per-model performance metrics (speed, p50/p95, errors)

### DIFF
--- a/internal/admin/usage_analytics.go
+++ b/internal/admin/usage_analytics.go
@@ -26,11 +26,18 @@ type usageSummaryDTO struct {
 }
 
 type modelUsageDTO struct {
-	Model         string  `json:"model"`
-	Requests      int     `json:"requests"`
-	TotalTokens   int     `json:"total_tokens"`
-	Credits       float64 `json:"credits"`
-	AvgDurationMs float64 `json:"avg_duration_ms"`
+	Model            string   `json:"model"`
+	Requests         int      `json:"requests"`
+	TotalTokens      int      `json:"total_tokens"`
+	Credits          float64  `json:"credits"`
+	AvgDurationMs    float64  `json:"avg_duration_ms"`
+	PromptTokens     int      `json:"prompt_tokens"`
+	CompletionTokens int      `json:"completion_tokens"`
+	TokPerSec        *float64 `json:"tok_per_sec"`
+	P50DurationMs    *float64 `json:"p50_duration_ms"`
+	P95DurationMs    *float64 `json:"p95_duration_ms"`
+	ErrorCount       int      `json:"error_count"`
+	PartialCount     int      `json:"partial_count"`
 }
 
 type ownerUsageDTO struct {
@@ -296,11 +303,18 @@ func (h *handler) getUsageByModel(w http.ResponseWriter, r *http.Request) {
 	dtos := make([]modelUsageDTO, len(rows))
 	for i, r := range rows {
 		dtos[i] = modelUsageDTO{
-			Model:         r.Model,
-			Requests:      r.Requests,
-			TotalTokens:   r.TotalTokens,
-			Credits:       r.Credits,
-			AvgDurationMs: r.AvgDurationMs,
+			Model:            r.Model,
+			Requests:         r.Requests,
+			TotalTokens:      r.TotalTokens,
+			Credits:          r.Credits,
+			AvgDurationMs:    r.AvgDurationMs,
+			PromptTokens:     r.PromptTokens,
+			CompletionTokens: r.CompletionTokens,
+			TokPerSec:        r.TokPerSec,
+			P50DurationMs:    r.P50DurationMs,
+			P95DurationMs:    r.P95DurationMs,
+			ErrorCount:       r.ErrorCount,
+			PartialCount:     r.PartialCount,
 		}
 	}
 	page, pag := sliceWindow(dtos, limit, offset)

--- a/internal/admin/usage_analytics_http_test.go
+++ b/internal/admin/usage_analytics_http_test.go
@@ -328,6 +328,115 @@ func TestUsageByModel_NodeFilter(t *testing.T) {
 	}
 }
 
+// seedPerfMetricsUsage adds rows for two extra models on top of the base
+// fixture, with hand-computable performance metrics:
+//
+//	bench:7b (5 rows):
+//	  completed  p=100 c=200 dur=1000
+//	  completed  p=100 c=400 dur=2000
+//	  completed  p=0   c=0   dur=3000  (usage extraction failed — no tokens)
+//	  error      p=50  c=0   dur=100
+//	  partial    p=80  c=40  dur=500
+//	allfail:1b (1 row):
+//	  error      p=10  c=0   dur=50
+func seedPerfMetricsUsage(t *testing.T, s *store.Store, fx usageFixture) {
+	t.Helper()
+	ctx := context.Background()
+	type row struct {
+		model        string
+		prompt, comp int
+		dur          int64
+		status       string
+	}
+	rows := []row{
+		{"bench:7b", 100, 200, 1000, "completed"},
+		{"bench:7b", 100, 400, 2000, "completed"},
+		{"bench:7b", 0, 0, 3000, "completed"},
+		{"bench:7b", 50, 0, 100, "error"},
+		{"bench:7b", 80, 40, 500, "partial"},
+		{"allfail:1b", 10, 0, 50, "error"},
+	}
+	for i, r := range rows {
+		if _, err := s.Pool().Exec(ctx,
+			`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged, created_at, node_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+			fx.keyUser, r.model, r.prompt, r.comp, r.prompt+r.comp, r.dur, r.status, 0.1, fx.t0.Add(time.Duration(i)*time.Minute), &fx.nodeA,
+		); err != nil {
+			t.Fatalf("insert perf usage: %v", err)
+		}
+	}
+}
+
+func TestUsageByModel_PerformanceMetrics(t *testing.T) {
+	h, s := setupAdminTest(t)
+	fx := seedUsageFixtureHTTP(t, s)
+	seedPerfMetricsUsage(t, s, fx)
+
+	rec := doAdmin(t, h, "/api/admin/usage/by-model?since="+fx.t0.Format(time.RFC3339))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Data []modelUsageDTO `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	byModel := make(map[string]modelUsageDTO, len(body.Data))
+	for _, d := range body.Data {
+		byModel[d.Model] = d
+	}
+
+	bench, ok := byModel["bench:7b"]
+	if !ok {
+		t.Fatalf("bench:7b missing, body=%s", rec.Body.String())
+	}
+	if bench.Requests != 5 || bench.TotalTokens != 970 {
+		t.Errorf("bench requests/total = %d/%d, want 5/970", bench.Requests, bench.TotalTokens)
+	}
+	if bench.PromptTokens != 330 || bench.CompletionTokens != 640 {
+		t.Errorf("bench prompt/completion = %d/%d, want 330/640", bench.PromptTokens, bench.CompletionTokens)
+	}
+	// Speed uses only completed rows that actually recorded completion
+	// tokens: (200+400) tokens / (1000+2000)ms = 200 tok/s. The zero-token
+	// completed row and the error/partial rows must not dilute it.
+	if bench.TokPerSec == nil || *bench.TokPerSec < 199.99 || *bench.TokPerSec > 200.01 {
+		t.Errorf("bench tok_per_sec = %v, want 200", bench.TokPerSec)
+	}
+	// Percentiles cover all completed rows (latency is real even when token
+	// extraction failed): durations {1000, 2000, 3000}.
+	if bench.P50DurationMs == nil || *bench.P50DurationMs != 2000 {
+		t.Errorf("bench p50 = %v, want 2000", bench.P50DurationMs)
+	}
+	if bench.P95DurationMs == nil || *bench.P95DurationMs < 2899.99 || *bench.P95DurationMs > 2900.01 {
+		t.Errorf("bench p95 = %v, want 2900", bench.P95DurationMs)
+	}
+	if bench.ErrorCount != 1 || bench.PartialCount != 1 {
+		t.Errorf("bench errors/partials = %d/%d, want 1/1", bench.ErrorCount, bench.PartialCount)
+	}
+
+	// A model with no completed rows has no speed or latency percentiles —
+	// null, not zero (zero would read as "instant").
+	allfail, ok := byModel["allfail:1b"]
+	if !ok {
+		t.Fatalf("allfail:1b missing, body=%s", rec.Body.String())
+	}
+	if allfail.TokPerSec != nil || allfail.P50DurationMs != nil || allfail.P95DurationMs != nil {
+		t.Errorf("allfail speed/percentiles = %v/%v/%v, want all null",
+			allfail.TokPerSec, allfail.P50DurationMs, allfail.P95DurationMs)
+	}
+	if allfail.ErrorCount != 1 || allfail.Requests != 1 {
+		t.Errorf("allfail errors/requests = %d/%d, want 1/1", allfail.ErrorCount, allfail.Requests)
+	}
+
+	// Pre-existing fixture model keeps its established aggregates (guard
+	// against the new aggregates changing grouping or filtering).
+	llama := byModel["llama3.1:8b"]
+	if llama.Requests != 3 || llama.TotalTokens != 1200 {
+		t.Errorf("llama requests/total = %d/%d, want 3/1200", llama.Requests, llama.TotalTokens)
+	}
+}
+
 // --- by-user --------------------------------------------------------------
 
 func TestUsageByUser_OwnerTypeDerivation(t *testing.T) {

--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -38,11 +38,23 @@ type UsageSummary struct {
 
 // ModelUsageRow is one row of GetUsageByModel.
 type ModelUsageRow struct {
-	Model         string
-	Requests      int
-	TotalTokens   int
-	Credits       float64
-	AvgDurationMs float64
+	Model            string
+	Requests         int
+	TotalTokens      int
+	Credits          float64
+	AvgDurationMs    float64
+	PromptTokens     int
+	CompletionTokens int
+	// TokPerSec is completion tokens per second over completed requests that
+	// recorded completion tokens; nil when the group has none. P50/P95 cover
+	// all completed requests; nil when the group has none. ErrorCount and
+	// PartialCount surface non-completed statuses (upstream failures and
+	// client disconnects respectively).
+	TokPerSec     *float64
+	P50DurationMs *float64
+	P95DurationMs *float64
+	ErrorCount    int
+	PartialCount  int
 }
 
 // OwnerUsageRow is one row of GetUsageByUser. Either the user fields or the
@@ -173,13 +185,27 @@ func (s *Store) GetUsageSummary(f UsageFilter) (UsageSummary, error) {
 // GetUsageByModel returns per-model aggregates, ordered by total_tokens desc.
 func (s *Store) GetUsageByModel(f UsageFilter) ([]ModelUsageRow, error) {
 	var sb strings.Builder
+	// Speed only counts completed requests that recorded completion tokens
+	// (streaming rows where usage extraction failed log zero tokens but real
+	// duration — including them would drag the rate toward zero). Latency
+	// percentiles cover all completed requests: a zero-token completion still
+	// took real wall time. Error rows are excluded from both — they return
+	// fast and would flatter every latency number.
 	sb.WriteString(
 		`SELECT
 		   ul.model,
 		   COUNT(*),
 		   COALESCE(SUM(ul.total_tokens), 0),
 		   COALESCE(SUM(ul.credits_charged), 0),
-		   COALESCE(AVG(ul.duration_ms), 0)
+		   COALESCE(AVG(ul.duration_ms), 0),
+		   COALESCE(SUM(ul.prompt_tokens), 0),
+		   COALESCE(SUM(ul.completion_tokens), 0),
+		   SUM(ul.completion_tokens) FILTER (WHERE ul.status = 'completed' AND ul.completion_tokens > 0 AND ul.duration_ms > 0)::float8
+		     / NULLIF(SUM(ul.duration_ms) FILTER (WHERE ul.status = 'completed' AND ul.completion_tokens > 0 AND ul.duration_ms > 0) / 1000.0, 0),
+		   percentile_cont(0.5) WITHIN GROUP (ORDER BY ul.duration_ms) FILTER (WHERE ul.status = 'completed'),
+		   percentile_cont(0.95) WITHIN GROUP (ORDER BY ul.duration_ms) FILTER (WHERE ul.status = 'completed'),
+		   COUNT(*) FILTER (WHERE ul.status = 'error'),
+		   COUNT(*) FILTER (WHERE ul.status = 'partial')
 		 FROM usage_logs ul
 		 JOIN api_keys k ON ul.api_key_id = k.id
 		 WHERE 1=1`)
@@ -195,7 +221,9 @@ func (s *Store) GetUsageByModel(f UsageFilter) ([]ModelUsageRow, error) {
 	out := make([]ModelUsageRow, 0)
 	for rows.Next() {
 		var r ModelUsageRow
-		if err := rows.Scan(&r.Model, &r.Requests, &r.TotalTokens, &r.Credits, &r.AvgDurationMs); err != nil {
+		if err := rows.Scan(&r.Model, &r.Requests, &r.TotalTokens, &r.Credits, &r.AvgDurationMs,
+			&r.PromptTokens, &r.CompletionTokens, &r.TokPerSec, &r.P50DurationMs, &r.P95DurationMs,
+			&r.ErrorCount, &r.PartialCount); err != nil {
 			return nil, fmt.Errorf("scan model row: %w", err)
 		}
 		out = append(out, r)


### PR DESCRIPTION
## Summary
- Extends `GET /api/admin/usage/by-model` with performance metrics computed entirely from existing `usage_logs` columns (no schema change, no new capture):
  - `tok_per_sec` — completion tokens per second, over completed requests that recorded completion tokens
  - `p50_duration_ms` / `p95_duration_ms` — latency percentiles over completed requests
  - `prompt_tokens` / `completion_tokens` — in/out token split
  - `error_count` / `partial_count` — upstream failures vs client disconnects
- Null (not zero) speed/percentiles for models with no completed rows.
- Additive DTO fields; existing consumers unaffected. Frontend PR follows.

## Semantics
- Speed excludes zero-token completed rows (streaming usage-extraction failures log real duration but no tokens — including them would understate every model).
- Percentiles include zero-token completed rows (latency is real regardless) and exclude error/partial rows (fast failures flatter latency).

## Test plan
- New `TestUsageByModel_PerformanceMetrics`: hand-computed fixture (200 tok/s, p50=2000, p95=2900, error/partial counts), null semantics for a model with no completed rows, and a guard that pre-existing fixture aggregates are unchanged.
- Full suite: 914 passed with CI flags (`-race -count=1 -p 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe