### PR TITLE
feat(usage): per-model timeseries endpoint (charts backend)

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -167,6 +167,7 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 	mux.HandleFunc("GET /api/admin/usage/by-user", handler.getUsageByUser)
 	mux.HandleFunc("GET /api/admin/usage/by-account", handler.getUsageByAccount)
 	mux.HandleFunc("GET /api/admin/usage/timeseries", handler.getUsageTimeseries)
+	mux.HandleFunc("GET /api/admin/usage/timeseries-by-model", handler.getUsageTimeseriesByModel)
 	mux.HandleFunc("GET /api/admin/users", handler.listUsers)
 	mux.HandleFunc("GET /api/admin/users/{id}", handler.getUser)
 	mux.HandleFunc("PUT /api/admin/users/{id}/activate", handler.activateUser)

--- a/internal/admin/usage_analytics.go
+++ b/internal/admin/usage_analytics.go
@@ -478,14 +478,16 @@ func (h *handler) getUsageTimeseriesByModel(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	rows, err := h.store.GetUsageTimeseriesByModel(f, interval)
+	// The store enforces the maxTimeseriesModels cut in SQL (cheap ranking
+	// bounds the expensive percentile work); here we only group and order
+	// the surviving rows for presentation.
+	rows, err := h.store.GetUsageTimeseriesByModel(f, interval, maxTimeseriesModels)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "usage timeseries by model error", "error", err)
 		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to get usage timeseries by model")
 		return
 	}
 
-	// Rank models by window token total, keep the top maxTimeseriesModels.
 	byModel := make(map[string][]store.ModelTimeseriesRow)
 	totals := make(map[string]int)
 	order := make([]string, 0)
@@ -497,9 +499,6 @@ func (h *handler) getUsageTimeseriesByModel(w http.ResponseWriter, r *http.Reque
 		totals[row.Model] += row.TotalTokens
 	}
 	sort.SliceStable(order, func(i, j int) bool { return totals[order[i]] > totals[order[j]] })
-	if len(order) > maxTimeseriesModels {
-		order = order[:maxTimeseriesModels]
-	}
 
 	// Dense, aligned series: one bucket per interval step in [since, until)
 	// for every model, zero-filled with null speed/p95 where no rows exist.

--- a/internal/admin/usage_analytics.go
+++ b/internal/admin/usage_analytics.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"sort"
@@ -132,7 +133,30 @@ const (
 	// so cardinality is client-controlled. 12 matches the FE chart palette;
 	// the cut keeps the highest window token totals.
 	maxTimeseriesModels = 12
+	// maxTimeseriesBuckets bounds gap-fill allocation on both timeseries
+	// endpoints: since/until are client-controlled, and an oversized window
+	// with interval=hour would otherwise allocate one bucket per hour per
+	// series before encoding (e.g. since=1970&until=9999 ≈ 70M buckets).
+	// 2000 covers ~83 days hourly or ~5.5 years daily — beyond either,
+	// callers must coarsen the interval or shrink the range.
+	maxTimeseriesBuckets = 2000
 )
+
+// checkBucketCount rejects [since, until) windows that would gap-fill more
+// than maxTimeseriesBuckets steps at the given interval. Returns a 400-ready
+// code/message pair when the window is too large.
+func checkBucketCount(since, until time.Time, interval string) (code, msg string, err error) {
+	step := time.Hour
+	if interval == "day" {
+		step = 24 * time.Hour
+	}
+	if until.Sub(since) > time.Duration(maxTimeseriesBuckets)*step {
+		return "invalid_range",
+			"Time window too large for interval: reduce the range or use a coarser interval",
+			fmt.Errorf("window %s exceeds %d %s buckets", until.Sub(since), maxTimeseriesBuckets, interval)
+	}
+	return "", "", nil
+}
 
 // parseTimeParam accepts RFC3339 or YYYY-MM-DD. Returns a descriptive error
 // with a short code suitable for proxy.WriteError.
@@ -443,6 +467,11 @@ func (h *handler) getUsageTimeseries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if bcode, bmsg, berr := checkBucketCount(*f.Since, *f.Until, interval); berr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, bcode, "invalid_request_error", bmsg)
+		return
+	}
+
 	rows, err := h.store.GetUsageTimeseries(f, interval)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "usage timeseries error", "error", err)
@@ -475,6 +504,11 @@ func (h *handler) getUsageTimeseriesByModel(w http.ResponseWriter, r *http.Reque
 	interval, icode, imsg, ierr := parseInterval(r, *f.Since, *f.Until)
 	if ierr != nil {
 		proxy.WriteError(w, r, http.StatusBadRequest, icode, "invalid_request_error", imsg)
+		return
+	}
+
+	if bcode, bmsg, berr := checkBucketCount(*f.Since, *f.Until, interval); berr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, bcode, "invalid_request_error", bmsg)
 		return
 	}
 

--- a/internal/admin/usage_analytics.go
+++ b/internal/admin/usage_analytics.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -87,6 +88,35 @@ type timeseriesResponseDTO struct {
 	Buckets  []timeseriesBucketDTO `json:"buckets"`
 }
 
+type modelSeriesBucketDTO struct {
+	Bucket           time.Time `json:"bucket"`
+	Requests         int       `json:"requests"`
+	Errors           int       `json:"errors"`
+	PromptTokens     int       `json:"prompt_tokens"`
+	CompletionTokens int       `json:"completion_tokens"`
+	TotalTokens      int       `json:"total_tokens"`
+	Credits          float64   `json:"credits"`
+	TokPerSec        *float64  `json:"tok_per_sec"`
+	AvgDurationMs    float64   `json:"avg_duration_ms"`
+	P95DurationMs    *float64  `json:"p95_duration_ms"`
+}
+
+type modelSeriesDTO struct {
+	Model   string                 `json:"model"`
+	Buckets []modelSeriesBucketDTO `json:"buckets"`
+}
+
+// timeseriesByModelResponseDTO is the payload for
+// GET /api/admin/usage/timeseries-by-model — a detail envelope like
+// /usage/timeseries (Locked Decision #20). Every series is gap-filled over
+// the same [since, until) window so chart x-axes align without client-side
+// bucket reconciliation. Series are ordered by window total_tokens desc and
+// capped at maxTimeseriesModels.
+type timeseriesByModelResponseDTO struct {
+	Interval string           `json:"interval"`
+	Series   []modelSeriesDTO `json:"series"`
+}
+
 // --- Query parsing ---------------------------------------------------------
 
 const (
@@ -97,6 +127,11 @@ const (
 	// for the timeseries endpoint flips from "hour" to "day". Callers can
 	// always override via ?interval=.
 	intervalHourCutoff = 48 * time.Hour
+	// maxTimeseriesModels bounds the per-model timeseries response: request
+	// bodies can carry arbitrary model names (error rows log them verbatim),
+	// so cardinality is client-controlled. 12 matches the FE chart palette;
+	// the cut keeps the highest window token totals.
+	maxTimeseriesModels = 12
 )
 
 // parseTimeParam accepts RFC3339 or YYYY-MM-DD. Returns a descriptive error
@@ -429,6 +464,71 @@ func (h *handler) getUsageTimeseries(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeEnvelope(w, timeseriesResponseDTO{Interval: interval, Buckets: dtos}, nil)
+}
+
+func (h *handler) getUsageTimeseriesByModel(w http.ResponseWriter, r *http.Request) {
+	f, code, msg, err := parseUsageFilter(r, time.Now())
+	if err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, code, "invalid_request_error", msg)
+		return
+	}
+	interval, icode, imsg, ierr := parseInterval(r, *f.Since, *f.Until)
+	if ierr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, icode, "invalid_request_error", imsg)
+		return
+	}
+
+	rows, err := h.store.GetUsageTimeseriesByModel(f, interval)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "usage timeseries by model error", "error", err)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to get usage timeseries by model")
+		return
+	}
+
+	// Rank models by window token total, keep the top maxTimeseriesModels.
+	byModel := make(map[string][]store.ModelTimeseriesRow)
+	totals := make(map[string]int)
+	order := make([]string, 0)
+	for _, row := range rows {
+		if _, seen := byModel[row.Model]; !seen {
+			order = append(order, row.Model)
+		}
+		byModel[row.Model] = append(byModel[row.Model], row)
+		totals[row.Model] += row.TotalTokens
+	}
+	sort.SliceStable(order, func(i, j int) bool { return totals[order[i]] > totals[order[j]] })
+	if len(order) > maxTimeseriesModels {
+		order = order[:maxTimeseriesModels]
+	}
+
+	// Dense, aligned series: one bucket per interval step in [since, until)
+	// for every model, zero-filled with null speed/p95 where no rows exist.
+	series := make([]modelSeriesDTO, 0, len(order))
+	for _, model := range order {
+		next := make(map[time.Time]store.ModelTimeseriesRow, len(byModel[model]))
+		for _, row := range byModel[model] {
+			next[row.Bucket] = row
+		}
+		buckets := make([]modelSeriesBucketDTO, 0)
+		for cur := truncateToInterval(*f.Since, interval); cur.Before(*f.Until); cur = advanceBucket(cur, interval) {
+			dto := modelSeriesBucketDTO{Bucket: cur}
+			if row, ok := next[cur]; ok {
+				dto.Requests = row.Requests
+				dto.Errors = row.Errors
+				dto.PromptTokens = row.PromptTokens
+				dto.CompletionTokens = row.CompletionTokens
+				dto.TotalTokens = row.TotalTokens
+				dto.Credits = row.Credits
+				dto.TokPerSec = row.TokPerSec
+				dto.AvgDurationMs = row.AvgDurationMs
+				dto.P95DurationMs = row.P95DurationMs
+			}
+			buckets = append(buckets, dto)
+		}
+		series = append(series, modelSeriesDTO{Model: model, Buckets: buckets})
+	}
+
+	writeEnvelope(w, timeseriesByModelResponseDTO{Interval: interval, Series: series}, nil)
 }
 
 // deriveOwnerType maps the three populations documented in PLAN.md §By-User.

--- a/internal/admin/usage_analytics_http_test.go
+++ b/internal/admin/usage_analytics_http_test.go
@@ -1011,11 +1011,21 @@ func TestUsageTimeseriesByModel_Validation(t *testing.T) {
 	for _, path := range []string{
 		"/api/admin/usage/timeseries-by-model?interval=fortnight",
 		"/api/admin/usage/timeseries-by-model?since=2026-04-10&until=2026-04-10",
+		// Oversized gap-fill windows are rejected on BOTH timeseries
+		// endpoints, not silently allocated (1970→9999 hourly ≈ 70M buckets).
+		"/api/admin/usage/timeseries-by-model?interval=hour&since=1970-01-01&until=9999-01-01",
+		"/api/admin/usage/timeseries?interval=hour&since=1970-01-01&until=9999-01-01",
+		"/api/admin/usage/timeseries?interval=day&since=1970-01-01&until=9999-01-01",
 	} {
 		rec := doAdmin(t, h, path)
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("%s: status = %d, want 400 (body=%s)", path, rec.Code, rec.Body.String())
 		}
+	}
+	// A window right at the cap still works: 83 days hourly = 1992 buckets.
+	rec := doAdmin(t, h, "/api/admin/usage/timeseries?interval=hour&since=2026-01-01&until=2026-03-25")
+	if rec.Code != http.StatusOK {
+		t.Errorf("at-cap window: status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/admin/usage_analytics_http_test.go
+++ b/internal/admin/usage_analytics_http_test.go
@@ -859,6 +859,166 @@ func TestUsageTimeseries_InvalidInterval(t *testing.T) {
 	}
 }
 
+// --- timeseries-by-model ---------------------------------------------------
+
+func TestUsageTimeseriesByModel_SeriesMetricsAndGapFill(t *testing.T) {
+	h, s := setupAdminTest(t)
+	fx := seedUsageFixtureHTTP(t, s)
+	seedPerfMetricsUsage(t, s, fx)
+
+	path := fmt.Sprintf("/api/admin/usage/timeseries-by-model?interval=hour&since=%s&until=%s",
+		fx.t0.Format(time.RFC3339), fx.t0.Add(3*time.Hour).Format(time.RFC3339))
+	rec := doAdmin(t, h, path)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Data       timeseriesByModelResponseDTO `json:"data"`
+		Pagination *Pagination                  `json:"pagination"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Pagination != nil {
+		t.Error("timeseries-by-model is a detail envelope; pagination must be absent")
+	}
+	if body.Data.Interval != "hour" {
+		t.Errorf("interval = %q, want hour", body.Data.Interval)
+	}
+
+	// Series ordered by window total_tokens desc:
+	// bench 970 > llama 450 (rows at t0, t0+1h) > gpt 75 > allfail 10.
+	models := make([]string, len(body.Data.Series))
+	for i, s := range body.Data.Series {
+		models[i] = s.Model
+	}
+	want := []string{"bench:7b", "llama3.1:8b", "gpt-4o-mini", "allfail:1b"}
+	if len(models) != len(want) {
+		t.Fatalf("series models = %v, want %v", models, want)
+	}
+	for i := range want {
+		if models[i] != want[i] {
+			t.Fatalf("series models = %v, want %v", models, want)
+		}
+	}
+
+	// Every series is dense over [since, until): exactly 3 aligned hour buckets.
+	for _, series := range body.Data.Series {
+		if len(series.Buckets) != 3 {
+			t.Fatalf("%s: len(buckets) = %d, want 3", series.Model, len(series.Buckets))
+		}
+		for i, b := range series.Buckets {
+			wantBucket := fx.t0.Add(time.Duration(i) * time.Hour)
+			if !b.Bucket.Equal(wantBucket) {
+				t.Errorf("%s bucket[%d] = %v, want %v", series.Model, i, b.Bucket, wantBucket)
+			}
+		}
+	}
+
+	bench := body.Data.Series[0]
+	b0 := bench.Buckets[0]
+	if b0.Requests != 5 || b0.Errors != 1 {
+		t.Errorf("bench[0] requests/errors = %d/%d, want 5/1", b0.Requests, b0.Errors)
+	}
+	if b0.PromptTokens != 330 || b0.CompletionTokens != 640 || b0.TotalTokens != 970 {
+		t.Errorf("bench[0] tokens = %d/%d/%d, want 330/640/970",
+			b0.PromptTokens, b0.CompletionTokens, b0.TotalTokens)
+	}
+	if b0.TokPerSec == nil || *b0.TokPerSec < 199.99 || *b0.TokPerSec > 200.01 {
+		t.Errorf("bench[0] tok_per_sec = %v, want 200", b0.TokPerSec)
+	}
+	if b0.P95DurationMs == nil || *b0.P95DurationMs < 2899.99 || *b0.P95DurationMs > 2900.01 {
+		t.Errorf("bench[0] p95 = %v, want 2900", b0.P95DurationMs)
+	}
+	// avg covers all 5 rows: (1000+2000+3000+100+500)/5 = 1320.
+	if b0.AvgDurationMs < 1319.99 || b0.AvgDurationMs > 1320.01 {
+		t.Errorf("bench[0] avg = %v, want 1320", b0.AvgDurationMs)
+	}
+	// Gap-filled buckets: zero counts, null speed/percentiles.
+	for i := 1; i <= 2; i++ {
+		gb := bench.Buckets[i]
+		if gb.Requests != 0 || gb.TotalTokens != 0 {
+			t.Errorf("bench[%d] not zero-filled: %+v", i, gb)
+		}
+		if gb.TokPerSec != nil || gb.P95DurationMs != nil {
+			t.Errorf("bench[%d] speed/p95 = %v/%v, want null", i, gb.TokPerSec, gb.P95DurationMs)
+		}
+	}
+
+	// llama has one real row in bucket 0 (150 tok) and one in bucket 1 (300).
+	llama := body.Data.Series[1]
+	if llama.Buckets[0].TotalTokens != 150 || llama.Buckets[1].TotalTokens != 300 || llama.Buckets[2].TotalTokens != 0 {
+		t.Errorf("llama totals = %d/%d/%d, want 150/300/0",
+			llama.Buckets[0].TotalTokens, llama.Buckets[1].TotalTokens, llama.Buckets[2].TotalTokens)
+	}
+
+	// allfail has no completed rows anywhere: null speed/p95 even in its real bucket.
+	allfail := body.Data.Series[3]
+	if allfail.Buckets[0].Errors != 1 || allfail.Buckets[0].TokPerSec != nil || allfail.Buckets[0].P95DurationMs != nil {
+		t.Errorf("allfail[0] = %+v, want errors=1 and null speed/p95", allfail.Buckets[0])
+	}
+}
+
+func TestUsageTimeseriesByModel_CapsSeriesAtTopModels(t *testing.T) {
+	h, s := setupAdminTest(t)
+	fx := seedUsageFixtureHTTP(t, s)
+	ctx := context.Background()
+
+	// 14 extra models, one completed row each, descending token weight so the
+	// expected cut is deterministic (weight 14000 down to 1000).
+	for i := 1; i <= 14; i++ {
+		if _, err := s.Pool().Exec(ctx,
+			`INSERT INTO usage_logs (api_key_id, model, prompt_tokens, completion_tokens, total_tokens, duration_ms, status, credits_charged, created_at)
+			 VALUES ($1, $2, $3, 0, $3, 100, 'completed', 0, $4)`,
+			fx.keyUser, fmt.Sprintf("capmodel-%02d", i), i*1000, fx.t0,
+		); err != nil {
+			t.Fatalf("insert cap row: %v", err)
+		}
+	}
+
+	path := fmt.Sprintf("/api/admin/usage/timeseries-by-model?interval=hour&since=%s&until=%s",
+		fx.t0.Format(time.RFC3339), fx.t0.Add(time.Hour).Format(time.RFC3339))
+	rec := doAdmin(t, h, path)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Data timeseriesByModelResponseDTO `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(body.Data.Series) != maxTimeseriesModels {
+		t.Fatalf("len(series) = %d, want cap %d", len(body.Data.Series), maxTimeseriesModels)
+	}
+	// Top of the cut must be the heaviest extra model; fixture models with
+	// less window traffic than the cut line must be gone.
+	if body.Data.Series[0].Model != "capmodel-14" {
+		t.Errorf("series[0] = %q, want capmodel-14", body.Data.Series[0].Model)
+	}
+	for _, sr := range body.Data.Series {
+		if sr.Model == "capmodel-01" {
+			t.Error("capmodel-01 (lightest) should have been cut by the cap")
+		}
+	}
+}
+
+func TestUsageTimeseriesByModel_Validation(t *testing.T) {
+	// Own handler: keeps the shared validation table under the 10 req/min
+	// admin bucket.
+	h, _ := setupAdminTest(t)
+	for _, path := range []string{
+		"/api/admin/usage/timeseries-by-model?interval=fortnight",
+		"/api/admin/usage/timeseries-by-model?since=2026-04-10&until=2026-04-10",
+	} {
+		rec := doAdmin(t, h, path)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400 (body=%s)", path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
 // --- validation -----------------------------------------------------------
 
 func TestUsageEndpoints_ValidationErrors(t *testing.T) {
@@ -899,6 +1059,7 @@ func TestUsageEndpoints_InvalidNodeID(t *testing.T) {
 		"/api/admin/usage/by-user?node_id=abc",
 		"/api/admin/usage/by-account?node_id=abc",
 		"/api/admin/usage/timeseries?node_id=abc",
+		"/api/admin/usage/timeseries-by-model?node_id=abc",
 	} {
 		t.Run(path, func(t *testing.T) {
 			rec := doAdmin(t, h, path)
@@ -951,6 +1112,7 @@ func TestUsageEndpoints_RequireAuth(t *testing.T) {
 		"/api/admin/usage/by-user",
 		"/api/admin/usage/by-account",
 		"/api/admin/usage/timeseries",
+		"/api/admin/usage/timeseries-by-model",
 	} {
 		t.Run(path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, path, nil)

--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -101,6 +101,23 @@ type TimeseriesBucket struct {
 	Errors           int
 }
 
+// ModelTimeseriesRow is one (bucket, model) cell of GetUsageTimeseriesByModel.
+// TokPerSec and P95DurationMs follow the ModelUsageRow semantics: computed
+// over completed rows only, nil when the cell has none.
+type ModelTimeseriesRow struct {
+	Bucket           time.Time
+	Model            string
+	Requests         int
+	Errors           int
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+	Credits          float64
+	TokPerSec        *float64
+	AvgDurationMs    float64
+	P95DurationMs    *float64
+}
+
 // buildUsageFilterClause appends WHERE conditions derived from f to the given
 // string builder, starting at argIdx. It returns the updated args slice and
 // the next argument index.
@@ -384,6 +401,63 @@ func (s *Store) GetUsageTimeseries(f UsageFilter, interval string) ([]Timeseries
 			return nil, fmt.Errorf("scan bucket: %w", err)
 		}
 		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// GetUsageTimeseriesByModel returns per-(bucket, model) aggregates, ordered
+// by model then bucket ascending. interval must be "hour" or "day".
+// Gap-filling and top-N model selection are the caller's responsibility.
+// Metric semantics match GetUsageByModel: speed uses completed rows that
+// recorded completion tokens, p95 covers all completed rows, avg covers
+// every row.
+func (s *Store) GetUsageTimeseriesByModel(f UsageFilter, interval string) ([]ModelTimeseriesRow, error) {
+	switch interval {
+	case "hour", "day":
+	default:
+		return nil, fmt.Errorf("invalid interval %q: must be 'hour' or 'day'", interval)
+	}
+
+	var sb strings.Builder
+	// date_trunc stays explicitly UTC for the same reason as GetUsageTimeseries:
+	// handler gap-fill keys on UTC bucket boundaries.
+	sb.WriteString(
+		`SELECT
+		   date_trunc($1, ul.created_at AT TIME ZONE 'UTC'),
+		   ul.model,
+		   COUNT(*),
+		   COUNT(*) FILTER (WHERE ul.status = 'error'),
+		   COALESCE(SUM(ul.prompt_tokens), 0),
+		   COALESCE(SUM(ul.completion_tokens), 0),
+		   COALESCE(SUM(ul.total_tokens), 0),
+		   COALESCE(SUM(ul.credits_charged), 0),
+		   SUM(ul.completion_tokens) FILTER (WHERE ul.status = 'completed' AND ul.completion_tokens > 0 AND ul.duration_ms > 0)::float8
+		     / NULLIF(SUM(ul.duration_ms) FILTER (WHERE ul.status = 'completed' AND ul.completion_tokens > 0 AND ul.duration_ms > 0) / 1000.0, 0),
+		   COALESCE(AVG(ul.duration_ms), 0),
+		   percentile_cont(0.95) WITHIN GROUP (ORDER BY ul.duration_ms) FILTER (WHERE ul.status = 'completed')
+		 FROM usage_logs ul
+		 JOIN api_keys k ON ul.api_key_id = k.id
+		 WHERE 1=1`)
+
+	args := []any{interval}
+	args, _ = buildUsageFilterClause(&sb, args, f, 2)
+	sb.WriteString(` GROUP BY 1, 2 ORDER BY 2, 1`)
+
+	rows, err := s.pool.Query(context.Background(), sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage timeseries by model: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]ModelTimeseriesRow, 0)
+	for rows.Next() {
+		var r ModelTimeseriesRow
+		if err := rows.Scan(&r.Bucket, &r.Model, &r.Requests, &r.Errors, &r.PromptTokens,
+			&r.CompletionTokens, &r.TotalTokens, &r.Credits, &r.TokPerSec,
+			&r.AvgDurationMs, &r.P95DurationMs); err != nil {
+			return nil, fmt.Errorf("scan model timeseries row: %w", err)
+		}
+		out = append(out, r)
 	}
 	return out, rows.Err()
 }

--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -405,24 +405,42 @@ func (s *Store) GetUsageTimeseries(f UsageFilter, interval string) ([]Timeseries
 	return out, rows.Err()
 }
 
-// GetUsageTimeseriesByModel returns per-(bucket, model) aggregates, ordered
-// by model then bucket ascending. interval must be "hour" or "day".
-// Gap-filling and top-N model selection are the caller's responsibility.
+// GetUsageTimeseriesByModel returns per-(bucket, model) aggregates for the
+// topModels models with the highest window token totals, ordered by model
+// then bucket ascending. interval must be "hour" or "day". Gap-filling is
+// the caller's responsibility. The top-N cut happens in SQL so cheap COUNT/
+// SUM ranking bounds the expensive percentile aggregation — model-name
+// cardinality is client-controlled (error rows log requested names verbatim).
 // Metric semantics match GetUsageByModel: speed uses completed rows that
 // recorded completion tokens, p95 covers all completed rows, avg covers
 // every row.
-func (s *Store) GetUsageTimeseriesByModel(f UsageFilter, interval string) ([]ModelTimeseriesRow, error) {
+func (s *Store) GetUsageTimeseriesByModel(f UsageFilter, interval string, topModels int) ([]ModelTimeseriesRow, error) {
 	switch interval {
 	case "hour", "day":
 	default:
 		return nil, fmt.Errorf("invalid interval %q: must be 'hour' or 'day'", interval)
+	}
+	if topModels <= 0 {
+		return nil, fmt.Errorf("invalid topModels %d: must be positive", topModels)
 	}
 
 	var sb strings.Builder
 	// date_trunc stays explicitly UTC for the same reason as GetUsageTimeseries:
 	// handler gap-fill keys on UTC bucket boundaries.
 	sb.WriteString(
-		`SELECT
+		`WITH top_models AS (
+		   SELECT ul.model
+		   FROM usage_logs ul
+		   JOIN api_keys k ON ul.api_key_id = k.id
+		   WHERE 1=1`)
+	args := []any{interval, topModels}
+	args, next := buildUsageFilterClause(&sb, args, f, 3)
+	sb.WriteString(
+		`  GROUP BY ul.model
+		   ORDER BY COALESCE(SUM(ul.total_tokens), 0) DESC, ul.model
+		   LIMIT $2
+		 )
+		 SELECT
 		   date_trunc($1, ul.created_at AT TIME ZONE 'UTC'),
 		   ul.model,
 		   COUNT(*),
@@ -437,10 +455,8 @@ func (s *Store) GetUsageTimeseriesByModel(f UsageFilter, interval string) ([]Mod
 		   percentile_cont(0.95) WITHIN GROUP (ORDER BY ul.duration_ms) FILTER (WHERE ul.status = 'completed')
 		 FROM usage_logs ul
 		 JOIN api_keys k ON ul.api_key_id = k.id
-		 WHERE 1=1`)
-
-	args := []any{interval}
-	args, _ = buildUsageFilterClause(&sb, args, f, 2)
+		 WHERE ul.model IN (SELECT model FROM top_models)`)
+	args, _ = buildUsageFilterClause(&sb, args, f, next)
 	sb.WriteString(` GROUP BY 1, 2 ORDER BY 2, 1`)
 
 	rows, err := s.pool.Query(context.Background(), sb.String(), args...)


### PR DESCRIPTION
## Summary
Backend for the By-model page rework (charts for every metric): new `GET /api/admin/usage/timeseries-by-model`.

- (bucket × model) rows: requests, errors, prompt/completion/total tokens, credits, `tok_per_sec`, `avg_duration_ms`, `p95_duration_ms`
- Detail envelope `{data: {interval, series: [{model, buckets}]}}` — same Locked-Decision-#20 flavor as `/usage/timeseries`
- Every series gap-filled over the same `[since, until)` window (zero counts, **null** speed/p95) so chart x-axes align with no client-side reconciliation
- Series ordered by window token total, capped at **12** (FE palette size; model-name cardinality is client-controlled since error rows log requested names verbatim)
- Same interval defaulting (`hour` ≤48h window, else `day`) and filter surface as the existing timeseries endpoint

## Test plan
- `TestUsageTimeseriesByModel_SeriesMetricsAndGapFill` — hand-computed fixture: series order, dense aligned buckets, per-bucket speed 200 tok/s / p95 2900 / avg 1320, zero-filled gaps with null metrics, all-error model has null speed/p95 in its real bucket
- `TestUsageTimeseriesByModel_CapsSeriesAtTopModels` — 14 seeded models → 12 series, heaviest kept, lightest cut
- Validation (own handler for the admin rate-limit bucket) + added to shared auth and node-id tables
- Full suite: 919 passed with CI flags (`-race -count=1 -p 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe