### PR TITLE
Credit requests: cap-hit detection, webhook notification, admin API (BE-1)

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/krishna/local-ai-proxy/internal/billing"
 	"github.com/krishna/local-ai-proxy/internal/bootstrap"
 	"github.com/krishna/local-ai-proxy/internal/config"
+	"github.com/krishna/local-ai-proxy/internal/creditrequest"
 	"github.com/krishna/local-ai-proxy/internal/credits"
 	"github.com/krishna/local-ai-proxy/internal/health"
 	"github.com/krishna/local-ai-proxy/internal/logging"
@@ -207,11 +208,12 @@ func main() {
 	}
 
 	limiter := ratelimit.New()
+	capHits := creditrequest.New(db, cfg.CreditAlertWebhookURL, cfg.EndUserMonthlyGrant)
 	proxyHandler := proxy.NewHandler(reg, usageCh, cfg.MaxRequestBody, db, m,
-		proxy.Options{ModelsListAll: cfg.ModelsListAll})
+		proxy.Options{ModelsListAll: cfg.ModelsListAll, CapHits: capHits})
 	authMiddleware := auth.Middleware(db)
 	billingResolver := billing.Middleware(db, cfg.EndUserMonthlyGrant)
-	creditGate := credits.CreditGate(db, m)
+	creditGate := credits.CreditGate(db, m, capHits)
 	rateLimitMiddleware := ratelimit.Middleware(limiter, m)
 	cors := middleware.CORS(cfg.CORSOrigins)
 
@@ -268,6 +270,7 @@ func main() {
 		Refresher: nodePoller,
 
 		AdminServiceCreditGrant: cfg.AdminServiceCreditGrant,
+		EndUserMonthlyGrant:     cfg.EndUserMonthlyGrant,
 	})
 	bootstrapHandler := bootstrap.New(db, cfg.AdminBootstrapToken, m)
 	userHandler := user.NewHandler(db, cfg.DefaultCreditGrant, m, authGuard)

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -348,5 +348,9 @@ func main() {
 	close(usageCh)
 	<-writerDone
 
+	// Drain in-flight cap-hit recordings (filed rows + webhook deliveries)
+	// before the deferred db.Close tears the pool down under them.
+	capHits.Wait()
+
 	slog.Info("shutdown complete")
 }

--- a/docs/design/credit-requests.md
+++ b/docs/design/credit-requests.md
@@ -1,0 +1,168 @@
+# Credit Requests: cap-hit detection + one-click top-ups
+
+Status: accepted (Krishna 2026-07-21: auto-trigger on cap-hit; Discord card offers
+top-ups only; v1 includes the admin UI phase)
+Author: Claude, reviewed by Krishna
+
+## Problem
+
+When an end-user account exhausts its monthly allowance, every request 402s with
+`monthly_limit_reached` and the message "Monthly usage limit reached — resets next
+month". That error text rendered in OpenWebUI chat is the user's entire experience,
+and it is a dead end: there is no way to ask for more credits, and nothing records
+or notifies on cap-hits — the admin never learns someone is blocked unless they
+complain out-of-band.
+
+Both remediation levers already exist as admin endpoints, so approval needs no new
+billing machinery:
+
+- `POST /api/admin/accounts/{id}/credits` — one-time grant. Allowance accounts are
+  reset-to-grant, so a mid-month grant naturally expires at the next monthly reset:
+  "extra credits this month only" semantics for free.
+- `PUT /api/admin/accounts/{id}/allowance` — permanent monthly grant change
+  (deliberately NOT exposed on the Discord card; it stays an admin-console action).
+
+## Decision summary
+
+The **first 402 of a cap-hit episode automatically files a `credit_requests` row**
+and fires a webhook to the existing Discord bot, which posts a card with one-click
+top-up buttons. The 402 message tells the user the admin has been notified. The
+admin console lists requests and gains the (previously missing) allowance editor.
+
+No user action is required or possible: once capped, every API call is rejected, and
+there is no portal — so the "request" is filed by the proxy on the user's behalf.
+An explicit user-clickable signed link in the 402 message is deferred to v2.
+
+## 1. credit_requests table
+
+```sql
+CREATE TABLE IF NOT EXISTS credit_requests (
+    id            BIGSERIAL PRIMARY KEY,
+    account_id    BIGINT NOT NULL REFERENCES accounts(id),
+    period        DATE NOT NULL,        -- first day of the UTC month (allowance_period convention)
+    status        TEXT NOT NULL DEFAULT 'pending',   -- pending | granted | dismissed
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at   TIMESTAMPTZ,
+    resolved_note TEXT                  -- e.g. '+$5 via discord by myrwin7'
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credit_requests_pending
+    ON credit_requests(account_id, period) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_credit_requests_status ON credit_requests(status, created_at);
+```
+
+**Filing policy** (per account, per UTC month):
+
+- No row, or only `granted` rows → cap-hit files a new request. A user who burned
+  through a top-up may legitimately need to ask again; each episode gets one card.
+- A `pending` row exists → no-op (the partial unique index makes concurrent 402s
+  race-safe: one winner inserts, losers hit the index and do nothing).
+- A `dismissed` row exists → no-op for the rest of the month. Dismiss means "leave
+  me alone about this account this month". Insert uses
+  `WHERE NOT EXISTS (... status IN ('pending','dismissed') ...)`; the partial index
+  backstops the pending race, and a dismissed row is only ever written by resolution
+  (never concurrently with itself), so the NOT EXISTS check suffices for it.
+
+Multiple `granted` rows per month are allowed and form the audit trail.
+
+## 2. Cap-hit detection
+
+Both `monthly_limit_reached` sites call a shared recorder when the billing account
+is allowance-managed:
+
+1. `CreditGate` pre-check (`internal/credits/middleware.go`).
+2. The reserve-failure path in `handleChatCompletions` (`internal/proxy/proxy.go`).
+
+The recorder runs **async** (goroutine, own context with timeout, errors logged) so
+the 402 path stays fast — a capped user retrying in chat produces one indexed
+NOT-EXISTS probe per attempt and zero writes after the first.
+
+On a successful insert (the winner), the recorder resolves display metadata
+(email/name via `federated_identities`, effective grant, spent ≈ grant − balance)
+and fires the notification.
+
+**402 message** for allowance-managed accounts becomes:
+"Monthly usage limit reached — your admin has been notified. Credits may be added
+shortly; otherwise your allowance resets next month."
+(Code stays `monthly_limit_reached`; only the human text changes. The text is
+static — it does not re-check request state per 402.)
+
+## 3. Notification webhook
+
+- Config: `CREDIT_ALERT_WEBHOOK_URL` (empty = disabled; requests are still recorded
+  and visible in the admin console — Discord is a consumer, not the source of truth).
+- Fire-and-forget POST with a short timeout, one retry, then give up and log. A lost
+  notification self-heals: the bot reconciles pending requests on startup, and the
+  admin console always shows them.
+- Payload: `{request_id, account_id, email, display_name, monthly_grant, spent, period}`.
+- Prod value: `http://openwebui-discord-bot.openwebui.svc.cluster.local:8080/credit-request`.
+
+## 4. Admin API
+
+- `GET /api/admin/credit-requests?status=pending|granted|dismissed&limit&offset` —
+  list envelope; rows join account name, federated email, effective monthly grant,
+  current balance. Default filter: `pending`.
+- `PUT /api/admin/credit-requests/{id}` body `{"status": "granted"|"dismissed", "note"?: string}` —
+  valid only from `pending` (409 `already_resolved` otherwise). Resolution does NOT
+  move money itself; the caller grants credits first (existing endpoint), then marks
+  the request. Keeping the two steps separate reuses the audited grant path and
+  keeps this endpoint trivial.
+- `GET /api/admin/accounts` rows gain `effective_monthly_grant` (the env default
+  resolved server-side) so the UI never hardcodes the default.
+
+All responses keep the `{data: ...}` envelope convention.
+
+## 5. Discord bot (BOT-2)
+
+Extends `local-ai-chat/discord-approval-bot/` (same deployment):
+
+- New explicit route `POST /credit-request` (registered before the catch-all
+  signup-webhook route) → card in the existing channel:
+  title "💳 Credit request", fields Name / Email / Grant / Spent this month,
+  footer marker `credit-req:<request_id>` (restart-dedupe via channel history scan,
+  same pattern as signups).
+- Buttons: **+$1 this month**, **+$5 this month**, **Dismiss**. Allow-list enforced
+  exactly like signup buttons. No permanent-raise button (decision above).
+- Action flow: top-up → `POST /api/admin/accounts/{account_id}/credits`
+  `{amount, description: "credit-request top-up via discord"}` →
+  `PUT /api/admin/credit-requests/{id}` `{status:"granted", note:"+$N via discord by <user>"}` →
+  edit card to "✅ +$N by <name>". Dismiss → PUT dismissed → "⛔ Dismissed by <name>".
+  If the request was already resolved elsewhere (admin console), the PUT 409s and
+  the card is edited to reflect that instead of erroring.
+- Startup reconcile: `GET /api/admin/credit-requests?status=pending` → announce any
+  request whose marker is absent from recent channel history.
+- New env/secrets: `PROXY_ADMIN_URL` (`http://ai-proxy.local-ai.svc.cluster.local`),
+  `PROXY_ADMIN_KEY` (a dedicated admin key minted for the bot, stored in a k8s
+  secret + the repo-external secrets dir, per convention). Admin rate limit
+  (10 req/min) is far above bot traffic.
+
+## 6. Admin console (FE-3, folds in the FE-4 allowance-editor remainder)
+
+Accounts page:
+
+- Allowance-managed rows show monthly grant (marking the env default, via
+  `effective_monthly_grant`) and current balance.
+- Inline allowance editor dialog → `PUT /api/admin/accounts/{id}/allowance`
+  (endpoint has had no UI since EUA shipped).
+- Pending credit requests surface as a highlighted strip above the table when any
+  exist: email, spent/grant, per-row **Top up** (opens the existing
+  GrantCreditsDialog, then marks the request granted) and **Dismiss**.
+
+## 7. Rollout (order matters)
+
+1. Merge + deploy backend (schema idempotent-on-boot). `CREDIT_ALERT_WEBHOOK_URL`
+   unset → detection + admin API live, no Discord traffic.
+2. Mint the bot's admin key; add secret; deploy the extended bot.
+3. Set `CREDIT_ALERT_WEBHOOK_URL` on the proxy deployment and roll it.
+4. Verify end-to-end with a low-grant test account: chat past the cap → card
+   appears → +$1 → chat works again → request marked granted.
+5. Deploy admin-frontend (FE-3) independently.
+
+Rollback: unset the webhook URL (detection keeps recording silently); the table and
+endpoints are inert without traffic.
+
+## Non-goals / v2
+
+- Explicit user-clickable request link (signed token in the 402 message).
+- Auto-approval policy (e.g., first +$1/month granted automatically).
+- Email notifications; user-visible balance (needs the portal).
+- Changing allowance semantics — reset-to-grant stands.

--- a/docs/design/credit-requests.md
+++ b/docs/design/credit-requests.md
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS credit_requests (
     id            BIGSERIAL PRIMARY KEY,
     account_id    BIGINT NOT NULL REFERENCES accounts(id),
     period        DATE NOT NULL,        -- first day of the UTC month (allowance_period convention)
-    status        TEXT NOT NULL DEFAULT 'pending',   -- pending | granted | dismissed
+    status        TEXT NOT NULL DEFAULT 'pending',   -- pending | granted | dismissed | expired
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     resolved_at   TIMESTAMPTZ,
     resolved_note TEXT                  -- e.g. '+$5 via discord by myrwin7'
@@ -64,6 +64,13 @@ CREATE INDEX IF NOT EXISTS idx_credit_requests_status ON credit_requests(status,
 
 Multiple `granted` rows per month are allowed and form the audit trail.
 
+**Month rollover**: a pending request whose period has passed stops being
+actionable — the allowance has reset, so granting against it would double up.
+Stale pending rows are **lazily expired** (status `expired`, same no-cron
+pattern as the allowance top-up): the pending listing expires them before
+returning, and a resolve attempt on a stale row is refused with
+`request_expired` and expires it.
+
 ## 2. Cap-hit detection
 
 Both `monthly_limit_reached` sites call a shared recorder when the billing account
@@ -72,9 +79,13 @@ is allowance-managed:
 1. `CreditGate` pre-check (`internal/credits/middleware.go`).
 2. The reserve-failure path in `handleChatCompletions` (`internal/proxy/proxy.go`).
 
-The recorder runs **async** (goroutine, own context with timeout, errors logged) so
-the 402 path stays fast — a capped user retrying in chat produces one indexed
-NOT-EXISTS probe per attempt and zero writes after the first.
+The recorder runs **async** (goroutine, errors logged) so the 402 path stays
+fast — a capped user retrying in chat produces one indexed NOT-EXISTS probe
+per attempt and zero writes after the first. The filing itself is never
+throttled or skipped (it is one fast insert, the same load profile as the
+402 handling); only webhook delivery is concurrency-capped, and only filing
+winners — at most one per account per month — ever reach delivery. Graceful
+shutdown drains in-flight recordings before closing the pool.
 
 On a successful insert (the winner), the recorder resolves display metadata
 (email/name via `federated_identities`, effective grant, spent ≈ grant − balance)
@@ -98,14 +109,17 @@ static — it does not re-check request state per 402.)
 
 ## 4. Admin API
 
-- `GET /api/admin/credit-requests?status=pending|granted|dismissed&limit&offset` —
+- `GET /api/admin/credit-requests?status=pending|granted|dismissed|expired&limit&offset` —
   list envelope; rows join account name, federated email, effective monthly grant,
-  current balance. Default filter: `pending`.
+  current balance. Default filter: `pending` (stale rows are expired before the
+  listing returns, so pending is always actionable).
 - `PUT /api/admin/credit-requests/{id}` body `{"status": "granted"|"dismissed", "note"?: string}` —
-  valid only from `pending` (409 `already_resolved` otherwise). Resolution does NOT
-  move money itself; the caller grants credits first (existing endpoint), then marks
-  the request. Keeping the two steps separate reuses the audited grant path and
-  keeps this endpoint trivial.
+  valid only from `pending` in the **current month** (409 `already_resolved` /
+  `request_expired` otherwise); response is a `{data: {id, status}}` envelope.
+  Resolution does NOT move money itself. Callers **mark first, then grant**: the
+  pending row is the idempotency lock, so a raced or stale actor can never grant
+  twice; a grant failure after marking is surfaced for manual follow-up (the safe
+  failure direction — no double money).
 - `GET /api/admin/accounts` rows gain `effective_monthly_grant` (the env default
   resolved server-side) so the UI never hardcodes the default.
 
@@ -122,12 +136,12 @@ Extends `local-ai-chat/discord-approval-bot/` (same deployment):
   same pattern as signups).
 - Buttons: **+$1 this month**, **+$5 this month**, **Dismiss**. Allow-list enforced
   exactly like signup buttons. No permanent-raise button (decision above).
-- Action flow: top-up → `POST /api/admin/accounts/{account_id}/credits`
-  `{amount, description: "credit-request top-up via discord"}` →
-  `PUT /api/admin/credit-requests/{id}` `{status:"granted", note:"+$N via discord by <user>"}` →
-  edit card to "✅ +$N by <name>". Dismiss → PUT dismissed → "⛔ Dismissed by <name>".
-  If the request was already resolved elsewhere (admin console), the PUT 409s and
-  the card is edited to reflect that instead of erroring.
+- Action flow (mark-first, see §4): top-up → `PUT /api/admin/credit-requests/{id}`
+  `{status:"granted", note:"+$N via discord by <user>"}`; on 409/404 the card
+  becomes "no longer actionable" and **no money moves**; on success →
+  `POST /api/admin/accounts/{account_id}/credits` → card "✅ +$N by <name>"
+  (a grant failure after marking edits the card to a manual-follow-up warning).
+  Dismiss → PUT dismissed → "⛔ Dismissed by <name>".
 - Startup reconcile: `GET /api/admin/credit-requests?status=pending` → announce any
   request whose marker is absent from recent channel history.
 - New env/secrets: `PROXY_ADMIN_URL` (`http://ai-proxy.local-ai.svc.cluster.local`),

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -63,6 +63,10 @@ type handler struct {
 	// this a no-op lookup). Zero in tests is fine — grants can be added via
 	// POST /api/admin/accounts/{id}/credits.
 	adminServiceCreditGrant float64
+
+	// Env-default monthly allowance, used to resolve each account's
+	// effective grant server-side (accounts + credit-requests listings).
+	endUserMonthlyGrant float64
 }
 
 // NodeSnapshotter exposes the node registry's current routing state.
@@ -95,6 +99,10 @@ type Options struct {
 	// OSS-2: initial grant for the admin service account when created on
 	// demand (see handler.adminServiceCreditGrant).
 	AdminServiceCreditGrant float64
+
+	// Env-default monthly allowance (cfg.EndUserMonthlyGrant); see
+	// handler.endUserMonthlyGrant.
+	EndUserMonthlyGrant float64
 }
 
 type adminSessionCtxKey struct{}
@@ -155,6 +163,7 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 		nodeRefresher:     opts.Refresher,
 
 		adminServiceCreditGrant: opts.AdminServiceCreditGrant,
+		endUserMonthlyGrant:     opts.EndUserMonthlyGrant,
 	}
 
 	mux := http.NewServeMux()
@@ -186,6 +195,10 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 	mux.HandleFunc("POST /api/admin/accounts/{id}/credits", handler.grantCredits)
 	mux.HandleFunc("POST /api/admin/accounts/{id}/keys", handler.createAccountKey)
 	mux.HandleFunc("PUT /api/admin/accounts/{id}/allowance", handler.setAccountAllowance)
+
+	// Credit requests (docs/design/credit-requests.md).
+	mux.HandleFunc("GET /api/admin/credit-requests", handler.listCreditRequests)
+	mux.HandleFunc("PUT /api/admin/credit-requests/{id}", handler.resolveCreditRequest)
 
 	// Registration tokens
 	mux.HandleFunc("POST /api/admin/registration-tokens", handler.createRegistrationToken)
@@ -688,7 +701,10 @@ func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 		CreatedAt        string   `json:"created_at"`
 		AllowanceManaged bool     `json:"allowance_managed"`
 		MonthlyGrant     *float64 `json:"monthly_grant"`
-		Email            *string  `json:"email"`
+		// EffectiveMonthlyGrant resolves the override against the env
+		// default server-side; null for non-allowance-managed accounts.
+		EffectiveMonthlyGrant *float64 `json:"effective_monthly_grant"`
+		Email                 *string  `json:"email"`
 	}
 
 	resp := make([]accountResponse, 0, len(accounts))
@@ -699,18 +715,27 @@ func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 		if isActive != nil && a.IsActive != *isActive {
 			continue
 		}
+		var effectiveGrant *float64
+		if a.AllowanceManaged {
+			g := h.endUserMonthlyGrant
+			if a.MonthlyGrant != nil {
+				g = *a.MonthlyGrant
+			}
+			effectiveGrant = &g
+		}
 		resp = append(resp, accountResponse{
-			ID:               a.ID,
-			Name:             a.Name,
-			Type:             a.Type,
-			IsActive:         a.IsActive,
-			Balance:          a.Balance,
-			Reserved:         a.Reserved,
-			Available:        a.Balance - a.Reserved,
-			CreatedAt:        a.CreatedAt.Format(time.RFC3339),
-			AllowanceManaged: a.AllowanceManaged,
-			MonthlyGrant:     a.MonthlyGrant,
-			Email:            a.FederatedEmail,
+			ID:                    a.ID,
+			Name:                  a.Name,
+			Type:                  a.Type,
+			IsActive:              a.IsActive,
+			Balance:               a.Balance,
+			Reserved:              a.Reserved,
+			Available:             a.Balance - a.Reserved,
+			CreatedAt:             a.CreatedAt.Format(time.RFC3339),
+			AllowanceManaged:      a.AllowanceManaged,
+			MonthlyGrant:          a.MonthlyGrant,
+			EffectiveMonthlyGrant: effectiveGrant,
+			Email:                 a.FederatedEmail,
 		})
 	}
 

--- a/internal/admin/admin_metrics_test.go
+++ b/internal/admin/admin_metrics_test.go
@@ -45,6 +45,7 @@ func setupAdminMetricsTest(t *testing.T) (http.Handler, *store.Store, *metrics.M
 		_, _ = p.Exec(c, "DELETE FROM api_keys")
 		_, _ = p.Exec(c, "DELETE FROM users")
 		_, _ = p.Exec(c, "DELETE FROM federated_identities")
+		_, _ = p.Exec(c, "DELETE FROM credit_requests")
 		_, _ = p.Exec(c, "DELETE FROM accounts")
 	}
 

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -45,6 +45,7 @@ func setupAdminTest(t *testing.T) (http.Handler, *store.Store) {
 		_, _ = p.Exec(c, "DELETE FROM api_keys")
 		_, _ = p.Exec(c, "DELETE FROM users")
 		_, _ = p.Exec(c, "DELETE FROM federated_identities")
+		_, _ = p.Exec(c, "DELETE FROM credit_requests")
 		_, _ = p.Exec(c, "DELETE FROM accounts")
 	}
 

--- a/internal/admin/config_health_test.go
+++ b/internal/admin/config_health_test.go
@@ -51,6 +51,7 @@ func setupAdminWithObservability(
 		_, _ = p.Exec(c, "DELETE FROM api_keys")
 		_, _ = p.Exec(c, "DELETE FROM users")
 		_, _ = p.Exec(c, "DELETE FROM federated_identities")
+		_, _ = p.Exec(c, "DELETE FROM credit_requests")
 		_, _ = p.Exec(c, "DELETE FROM accounts")
 	}
 	wipe(s.Pool())

--- a/internal/admin/credit_requests.go
+++ b/internal/admin/credit_requests.go
@@ -18,17 +18,17 @@ import (
 // caller (admin console, Discord bot) grants credits through
 // POST /api/admin/accounts/{id}/credits first, then marks the request.
 
-// parseCreditRequestStatus parses `?status=pending|granted|dismissed`.
+// parseCreditRequestStatus parses `?status=pending|granted|dismissed|expired`.
 // Empty defaults to pending — the actionable view.
 func parseCreditRequestStatus(r *http.Request) (string, string, string, error) {
 	raw := r.URL.Query().Get("status")
 	switch raw {
 	case "":
 		return "pending", "", "", nil
-	case "pending", "granted", "dismissed":
+	case "pending", "granted", "dismissed", "expired":
 		return raw, "", "", nil
 	default:
-		return "", "invalid_status", "status must be 'pending', 'granted' or 'dismissed'", strconv.ErrSyntax
+		return "", "invalid_status", "status must be 'pending', 'granted', 'dismissed' or 'expired'", strconv.ErrSyntax
 	}
 }
 
@@ -65,7 +65,7 @@ func (h *handler) listCreditRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := h.store.ListCreditRequests(status)
+	rows, err := h.store.ListCreditRequests(status, time.Now())
 	if err != nil {
 		slog.ErrorContext(r.Context(), "list credit requests error", "error", err)
 		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to list credit requests")
@@ -126,12 +126,14 @@ func (h *handler) resolveCreditRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.store.ResolveCreditRequest(id, req.Status, req.Note); err != nil {
+	if err := h.store.ResolveCreditRequest(id, req.Status, req.Note, time.Now()); err != nil {
 		switch {
 		case errors.Is(err, store.ErrCreditRequestNotFound):
 			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Credit request not found")
 		case errors.Is(err, store.ErrCreditRequestResolved):
 			proxy.WriteError(w, r, http.StatusConflict, "already_resolved", "invalid_request_error", "Credit request was already resolved")
+		case errors.Is(err, store.ErrCreditRequestExpired):
+			proxy.WriteError(w, r, http.StatusConflict, "request_expired", "invalid_request_error", "Credit request expired at month rollover — the allowance has already reset")
 		default:
 			slog.ErrorContext(r.Context(), "resolve credit request error", "error", err, "credit_request_id", id)
 			proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to resolve credit request")
@@ -139,6 +141,5 @@ func (h *handler) resolveCreditRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"id": id, "status": req.Status})
+	writeEnvelope(w, map[string]any{"id": id, "status": req.Status}, nil)
 }

--- a/internal/admin/credit_requests.go
+++ b/internal/admin/credit_requests.go
@@ -1,0 +1,144 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/apierror"
+	"github.com/krishna/local-ai-proxy/internal/proxy"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// Credit-request admin surface (docs/design/credit-requests.md): list
+// cap-hit requests and resolve them. Resolution never moves money — the
+// caller (admin console, Discord bot) grants credits through
+// POST /api/admin/accounts/{id}/credits first, then marks the request.
+
+// parseCreditRequestStatus parses `?status=pending|granted|dismissed`.
+// Empty defaults to pending — the actionable view.
+func parseCreditRequestStatus(r *http.Request) (string, string, string, error) {
+	raw := r.URL.Query().Get("status")
+	switch raw {
+	case "":
+		return "pending", "", "", nil
+	case "pending", "granted", "dismissed":
+		return raw, "", "", nil
+	default:
+		return "", "invalid_status", "status must be 'pending', 'granted' or 'dismissed'", strconv.ErrSyntax
+	}
+}
+
+type creditRequestResponse struct {
+	ID           int64   `json:"id"`
+	AccountID    int64   `json:"account_id"`
+	AccountName  string  `json:"account_name"`
+	Email        *string `json:"email"`
+	Period       string  `json:"period"` // YYYY-MM-DD, first day of the month
+	Status       string  `json:"status"`
+	CreatedAt    string  `json:"created_at"`
+	ResolvedAt   *string `json:"resolved_at"`
+	ResolvedNote *string `json:"resolved_note"`
+	// EffectiveMonthlyGrant resolves the per-account override against the
+	// env default server-side so clients never hardcode the default.
+	EffectiveMonthlyGrant float64 `json:"effective_monthly_grant"`
+	Balance               float64 `json:"balance"`
+}
+
+func (h *handler) listCreditRequests(w http.ResponseWriter, r *http.Request) {
+	envelope, ecode, emsg, eerr := wantEnvelope(r)
+	if eerr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, ecode, "invalid_request_error", emsg)
+		return
+	}
+	status, scode, smsg, serr := parseCreditRequestStatus(r)
+	if serr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, scode, "invalid_request_error", smsg)
+		return
+	}
+	limit, offset, pcode, pmsg, perr := parsePagination(r)
+	if perr != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, pcode, "invalid_request_error", pmsg)
+		return
+	}
+
+	rows, err := h.store.ListCreditRequests(status)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "list credit requests error", "error", err)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to list credit requests")
+		return
+	}
+
+	resp := make([]creditRequestResponse, 0, len(rows))
+	for _, row := range rows {
+		grant := h.endUserMonthlyGrant
+		if row.MonthlyGrant != nil {
+			grant = *row.MonthlyGrant
+		}
+		var resolvedAt *string
+		if row.ResolvedAt != nil {
+			v := row.ResolvedAt.Format(time.RFC3339)
+			resolvedAt = &v
+		}
+		resp = append(resp, creditRequestResponse{
+			ID:                    row.ID,
+			AccountID:             row.AccountID,
+			AccountName:           row.AccountName,
+			Email:                 row.Email,
+			Period:                row.Period.Format("2006-01-02"),
+			Status:                row.Status,
+			CreatedAt:             row.CreatedAt.Format(time.RFC3339),
+			ResolvedAt:            resolvedAt,
+			ResolvedNote:          row.ResolvedNote,
+			EffectiveMonthlyGrant: grant,
+			Balance:               row.Balance,
+		})
+	}
+
+	if envelope {
+		page, pag := sliceWindow(resp, limit, offset)
+		writeEnvelope(w, page, pag)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (h *handler) resolveCreditRequest(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid credit request ID")
+		return
+	}
+
+	var req struct {
+		Status string `json:"status"`
+		Note   string `json:"note"`
+	}
+	if !apierror.DecodeJSON(w, r, &req) {
+		return
+	}
+	if req.Status != "granted" && req.Status != "dismissed" {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_status", "invalid_request_error", "status must be 'granted' or 'dismissed'")
+		return
+	}
+
+	if err := h.store.ResolveCreditRequest(id, req.Status, req.Note); err != nil {
+		switch {
+		case errors.Is(err, store.ErrCreditRequestNotFound):
+			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Credit request not found")
+		case errors.Is(err, store.ErrCreditRequestResolved):
+			proxy.WriteError(w, r, http.StatusConflict, "already_resolved", "invalid_request_error", "Credit request was already resolved")
+		default:
+			slog.ErrorContext(r.Context(), "resolve credit request error", "error", err, "credit_request_id", id)
+			proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to resolve credit request")
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"id": id, "status": req.Status})
+}

--- a/internal/admin/credit_requests_test.go
+++ b/internal/admin/credit_requests_test.go
@@ -1,0 +1,264 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// newCreditRequestHandler builds a handler with the env-default grant wired,
+// mirroring main.go. A fresh handler per test keeps each test inside the
+// 10 req/min X-Admin-Key budget.
+func newCreditRequestHandler(s *store.Store) http.Handler {
+	usageCh := make(chan store.UsageEntry, 10)
+	return NewHandler(s, testAdminKey, usageCh, Options{EndUserMonthlyGrant: 5.0})
+}
+
+func provisionEndUserAccount(t *testing.T, s *store.Store, extID, email string) int64 {
+	t.Helper()
+	res, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: extID, Email: email, DisplayName: "EU " + extID,
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	return res.AccountID
+}
+
+func adminGet(t *testing.T, h http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("X-Admin-Key", testAdminKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+type creditRequestDTO struct {
+	ID                    int64    `json:"id"`
+	AccountID             int64    `json:"account_id"`
+	AccountName           string   `json:"account_name"`
+	Email                 *string  `json:"email"`
+	Period                string   `json:"period"`
+	Status                string   `json:"status"`
+	CreatedAt             string   `json:"created_at"`
+	ResolvedAt            *string  `json:"resolved_at"`
+	ResolvedNote          *string  `json:"resolved_note"`
+	EffectiveMonthlyGrant float64  `json:"effective_monthly_grant"`
+	Balance               float64  `json:"balance"`
+}
+
+func decodeCreditRequestList(t *testing.T, rec *httptest.ResponseRecorder) ([]creditRequestDTO, *Pagination) {
+	t.Helper()
+	var env struct {
+		Data       []creditRequestDTO `json:"data"`
+		Pagination *Pagination        `json:"pagination"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v (%s)", err, rec.Body.String())
+	}
+	return env.Data, env.Pagination
+}
+
+func TestCreditRequests_ListPendingDefault(t *testing.T) {
+	_, s := setupAdminTest(t)
+	h := newCreditRequestHandler(s)
+
+	accA := provisionEndUserAccount(t, s, "adm-1a", "list-a@example.com")
+	accB := provisionEndUserAccount(t, s, "adm-1b", "list-b@example.com")
+	override := 12.5
+	if err := s.SetMonthlyGrant(accB, &override); err != nil {
+		t.Fatalf("SetMonthlyGrant: %v", err)
+	}
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	if _, _, err := s.FileCreditRequest(accA, now); err != nil {
+		t.Fatalf("file A: %v", err)
+	}
+	if _, _, err := s.FileCreditRequest(accB, now.Add(time.Minute)); err != nil {
+		t.Fatalf("file B: %v", err)
+	}
+
+	rec := adminGet(t, h, "/api/admin/credit-requests")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	rows, pag := decodeCreditRequestList(t, rec)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if pag == nil || pag.Total != 2 {
+		t.Errorf("expected pagination total 2, got %+v", pag)
+	}
+	// Newest first: B (with its override), then A (env default).
+	if rows[0].AccountID != accB || rows[1].AccountID != accA {
+		t.Errorf("expected [B, A], got [%d, %d]", rows[0].AccountID, rows[1].AccountID)
+	}
+	if rows[0].EffectiveMonthlyGrant != 12.5 {
+		t.Errorf("expected effective grant 12.5 for override, got %v", rows[0].EffectiveMonthlyGrant)
+	}
+	if rows[1].EffectiveMonthlyGrant != 5.0 {
+		t.Errorf("expected effective grant 5.0 (env default), got %v", rows[1].EffectiveMonthlyGrant)
+	}
+	if rows[0].Email == nil || *rows[0].Email != "list-b@example.com" {
+		t.Errorf("expected email join, got %v", rows[0].Email)
+	}
+	if rows[0].Period != "2026-07-01" {
+		t.Errorf("expected period 2026-07-01, got %q", rows[0].Period)
+	}
+	if rows[0].Status != "pending" {
+		t.Errorf("expected pending, got %q", rows[0].Status)
+	}
+}
+
+func TestCreditRequests_StatusFilterAndValidation(t *testing.T) {
+	_, s := setupAdminTest(t)
+	h := newCreditRequestHandler(s)
+
+	acc := provisionEndUserAccount(t, s, "adm-2", "filter@example.com")
+	id, _, err := s.FileCreditRequest(acc, time.Now())
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	if err := s.ResolveCreditRequest(id, "granted", "+$5 test"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	rec := adminGet(t, h, "/api/admin/credit-requests")
+	rows, _ := decodeCreditRequestList(t, rec)
+	if len(rows) != 0 {
+		t.Errorf("default pending view: expected 0 rows, got %d", len(rows))
+	}
+
+	rec = adminGet(t, h, "/api/admin/credit-requests?status=granted")
+	rows, _ = decodeCreditRequestList(t, rec)
+	if len(rows) != 1 || rows[0].ID != id {
+		t.Fatalf("expected the granted row, got %+v", rows)
+	}
+	if rows[0].ResolvedNote == nil || *rows[0].ResolvedNote != "+$5 test" {
+		t.Errorf("expected resolved note, got %v", rows[0].ResolvedNote)
+	}
+	if rows[0].ResolvedAt == nil {
+		t.Error("expected resolved_at")
+	}
+
+	rec = adminGet(t, h, "/api/admin/credit-requests?status=bogus")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for bogus status, got %d", rec.Code)
+	}
+}
+
+func TestCreditRequests_Resolve(t *testing.T) {
+	_, s := setupAdminTest(t)
+	h := newCreditRequestHandler(s)
+
+	acc := provisionEndUserAccount(t, s, "adm-3", "resolve@example.com")
+	id, _, err := s.FileCreditRequest(acc, time.Now())
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+
+	rec := adminPut(t, h, "/api/admin/credit-requests/"+itoa(id),
+		`{"status":"granted","note":"+$5 via discord by tester"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rows, err := s.ListCreditRequests("granted")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("expected 1 granted row, got %v err=%v", rows, err)
+	}
+	if rows[0].ResolvedNote == nil || *rows[0].ResolvedNote != "+$5 via discord by tester" {
+		t.Errorf("note not persisted: %v", rows[0].ResolvedNote)
+	}
+
+	// Already resolved → 409 with a distinct code.
+	rec = adminPut(t, h, "/api/admin/credit-requests/"+itoa(id), `{"status":"dismissed"}`)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rec = adminPut(t, h, "/api/admin/credit-requests/999999", `{"status":"granted"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+
+	rec = adminPut(t, h, "/api/admin/credit-requests/"+itoa(id), `{"status":"pending"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid target status, got %d", rec.Code)
+	}
+
+	rec = adminPut(t, h, "/api/admin/credit-requests/not-a-number", `{"status":"granted"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for bad id, got %d", rec.Code)
+	}
+}
+
+func TestCreditRequests_RequireAuth(t *testing.T) {
+	h, _ := setupAdminTest(t)
+
+	for _, tc := range []struct {
+		method, path string
+	}{
+		{http.MethodGet, "/api/admin/credit-requests"},
+		{http.MethodPut, "/api/admin/credit-requests/1"},
+	} {
+		req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader([]byte(`{}`)))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: expected 401 without auth, got %d", tc.method, tc.path, rec.Code)
+		}
+	}
+}
+
+func TestListAccounts_EffectiveMonthlyGrant(t *testing.T) {
+	_, s := setupAdminTest(t)
+	h := newCreditRequestHandler(s)
+
+	defaultAcc := provisionEndUserAccount(t, s, "adm-4a", "grant-default@example.com")
+	overrideAcc := provisionEndUserAccount(t, s, "adm-4b", "grant-override@example.com")
+	override := 12.5
+	if err := s.SetMonthlyGrant(overrideAcc, &override); err != nil {
+		t.Fatalf("SetMonthlyGrant: %v", err)
+	}
+	personalAcc, _, _ := s.RegisterUser("personal@example.com", "hash", "Personal")
+
+	rec := adminGet(t, h, "/api/admin/accounts")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Data []struct {
+			ID                    int64    `json:"id"`
+			AllowanceManaged      bool     `json:"allowance_managed"`
+			EffectiveMonthlyGrant *float64 `json:"effective_monthly_grant"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	byID := map[int64]*float64{}
+	for _, a := range env.Data {
+		byID[a.ID] = a.EffectiveMonthlyGrant
+	}
+	if g := byID[defaultAcc]; g == nil || *g != 5.0 {
+		t.Errorf("default end-user account: expected effective 5.0, got %v", g)
+	}
+	if g := byID[overrideAcc]; g == nil || *g != 12.5 {
+		t.Errorf("override end-user account: expected effective 12.5, got %v", g)
+	}
+	if g := byID[personalAcc]; g != nil {
+		t.Errorf("personal account: expected null effective grant, got %v", *g)
+	}
+}
+
+func itoa(n int64) string {
+	return strconv.FormatInt(n, 10)
+}

--- a/internal/admin/credit_requests_test.go
+++ b/internal/admin/credit_requests_test.go
@@ -41,17 +41,17 @@ func adminGet(t *testing.T, h http.Handler, path string) *httptest.ResponseRecor
 }
 
 type creditRequestDTO struct {
-	ID                    int64    `json:"id"`
-	AccountID             int64    `json:"account_id"`
-	AccountName           string   `json:"account_name"`
-	Email                 *string  `json:"email"`
-	Period                string   `json:"period"`
-	Status                string   `json:"status"`
-	CreatedAt             string   `json:"created_at"`
-	ResolvedAt            *string  `json:"resolved_at"`
-	ResolvedNote          *string  `json:"resolved_note"`
-	EffectiveMonthlyGrant float64  `json:"effective_monthly_grant"`
-	Balance               float64  `json:"balance"`
+	ID                    int64   `json:"id"`
+	AccountID             int64   `json:"account_id"`
+	AccountName           string  `json:"account_name"`
+	Email                 *string `json:"email"`
+	Period                string  `json:"period"`
+	Status                string  `json:"status"`
+	CreatedAt             string  `json:"created_at"`
+	ResolvedAt            *string `json:"resolved_at"`
+	ResolvedNote          *string `json:"resolved_note"`
+	EffectiveMonthlyGrant float64 `json:"effective_monthly_grant"`
+	Balance               float64 `json:"balance"`
 }
 
 func decodeCreditRequestList(t *testing.T, rec *httptest.ResponseRecorder) ([]creditRequestDTO, *Pagination) {

--- a/internal/admin/credit_requests_test.go
+++ b/internal/admin/credit_requests_test.go
@@ -125,7 +125,7 @@ func TestCreditRequests_StatusFilterAndValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("file: %v", err)
 	}
-	if err := s.ResolveCreditRequest(id, "granted", "+$5 test"); err != nil {
+	if err := s.ResolveCreditRequest(id, "granted", "+$5 test", time.Now()); err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 
@@ -168,8 +168,20 @@ func TestCreditRequests_Resolve(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
+	var env struct {
+		Data struct {
+			ID     int64  `json:"id"`
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode resolve envelope: %v (%s)", err, rec.Body.String())
+	}
+	if env.Data.ID != id || env.Data.Status != "granted" {
+		t.Errorf("expected {data:{id:%d,status:granted}}, got %s", id, rec.Body.String())
+	}
 
-	rows, err := s.ListCreditRequests("granted")
+	rows, err := s.ListCreditRequests("granted", time.Now())
 	if err != nil || len(rows) != 1 {
 		t.Fatalf("expected 1 granted row, got %v err=%v", rows, err)
 	}
@@ -196,6 +208,41 @@ func TestCreditRequests_Resolve(t *testing.T) {
 	rec = adminPut(t, h, "/api/admin/credit-requests/not-a-number", `{"status":"granted"}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for bad id, got %d", rec.Code)
+	}
+}
+
+func TestCreditRequests_StalePendingExpiresViaHTTP(t *testing.T) {
+	_, s := setupAdminTest(t)
+	h := newCreditRequestHandler(s)
+
+	acc := provisionEndUserAccount(t, s, "adm-5", "stale-http@example.com")
+	// File for LAST month (last day of it, so the period is unambiguous).
+	now := time.Now().UTC()
+	lastMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -1)
+	id, filed, err := s.FileCreditRequest(acc, lastMonth)
+	if err != nil || !filed {
+		t.Fatalf("backdated file: filed=%v err=%v", filed, err)
+	}
+
+	// A stale Discord card's button lands directly on the resolve endpoint:
+	// refused with a distinct code, no state left actionable.
+	rec := adminPut(t, h, "/api/admin/credit-requests/"+itoa(id), `{"status":"granted"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for stale resolve, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !bytes.Contains([]byte(body), []byte("request_expired")) {
+		t.Errorf("expected request_expired code, got %s", body)
+	}
+
+	rec = adminGet(t, h, "/api/admin/credit-requests")
+	rows, _ := decodeCreditRequestList(t, rec)
+	if len(rows) != 0 {
+		t.Errorf("pending view must be empty after expiry, got %+v", rows)
+	}
+	rec = adminGet(t, h, "/api/admin/credit-requests?status=expired")
+	rows, _ = decodeCreditRequestList(t, rec)
+	if len(rows) != 1 || rows[0].ID != id {
+		t.Errorf("expected the request under status=expired, got %+v", rows)
 	}
 }
 

--- a/internal/admin/nodes_test.go
+++ b/internal/admin/nodes_test.go
@@ -44,6 +44,7 @@ func setupNodesTest(t *testing.T) (http.Handler, *store.Store, *registry.Registr
 		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
 		_, _ = s.Pool().Exec(c, "DELETE FROM users")
 		_, _ = s.Pool().Exec(c, "DELETE FROM federated_identities")
+		_, _ = s.Pool().Exec(c, "DELETE FROM credit_requests")
 		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/bootstrap/handler_metrics_test.go
+++ b/internal/bootstrap/handler_metrics_test.go
@@ -33,6 +33,7 @@ func TestBootstrap_Success_IncrementsRegistrationCounter(t *testing.T) {
 		_, _ = p.Exec(c, "DELETE FROM api_keys")
 		_, _ = p.Exec(c, "DELETE FROM users")
 		_, _ = p.Exec(c, "DELETE FROM federated_identities")
+		_, _ = p.Exec(c, "DELETE FROM credit_requests")
 		_, _ = p.Exec(c, "DELETE FROM accounts")
 	}
 	wipe(s.Pool())

--- a/internal/bootstrap/handler_test.go
+++ b/internal/bootstrap/handler_test.go
@@ -42,6 +42,7 @@ func setupBootstrapTest(t *testing.T, tokenOverride *string) (http.Handler, *sto
 		_, _ = pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = pool.Exec(c, "DELETE FROM users")
 		_, _ = pool.Exec(c, "DELETE FROM federated_identities")
+		_, _ = pool.Exec(c, "DELETE FROM credit_requests")
 		_, _ = pool.Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"strconv"
 )
@@ -49,6 +50,12 @@ type Config struct {
 	// per account via accounts.monthly_grant. See
 	// docs/design/end-user-accounts.md.
 	EndUserMonthlyGrant float64
+
+	// CreditAlertWebhookURL (CREDIT_ALERT_WEBHOOK_URL, optional) receives a
+	// POST when an end-user account hits its monthly allowance
+	// (docs/design/credit-requests.md). Empty = notifications disabled;
+	// cap-hits are still recorded in credit_requests.
+	CreditAlertWebhookURL string
 
 	// Public auth-surface rate limits (requests per minute) and the global
 	// bcrypt concurrency cap. See internal/authlimit.
@@ -177,6 +184,19 @@ func Load() (Config, error) {
 		modelsListAll = b
 	}
 
+	// A malformed webhook URL would fail silently on every cap-hit, so
+	// reject it at boot instead of at notification time.
+	creditAlertWebhookURL := os.Getenv("CREDIT_ALERT_WEBHOOK_URL")
+	if creditAlertWebhookURL != "" {
+		u, err := url.Parse(creditAlertWebhookURL)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid CREDIT_ALERT_WEBHOOK_URL: %w", err)
+		}
+		if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return Config{}, fmt.Errorf("invalid CREDIT_ALERT_WEBHOOK_URL: must be an absolute http(s) URL, got %q", creditAlertWebhookURL)
+		}
+	}
+
 	return Config{
 		OllamaURL:           ollamaURL,
 		OllamaURLSet:        ollamaExplicit,
@@ -194,6 +214,7 @@ func Load() (Config, error) {
 
 		AdminServiceCreditGrant: adminServiceCreditGrant,
 		EndUserMonthlyGrant:     endUserMonthlyGrant,
+		CreditAlertWebhookURL:   creditAlertWebhookURL,
 
 		AuthLoginPerMinIP:     authLoginIP,
 		AuthLoginPerMinEmail:  authLoginEmail,

--- a/internal/config/config_caphit_test.go
+++ b/internal/config/config_caphit_test.go
@@ -1,0 +1,36 @@
+package config
+
+import "testing"
+
+// A malformed webhook URL would make every cap-hit notification fail
+// silently at runtime, so Load must reject it at boot instead.
+func TestLoad_CreditAlertWebhookURL_Validation(t *testing.T) {
+	t.Setenv("ADMIN_KEY", "test-admin")
+	t.Setenv("DATABASE_URL", "postgres://x/y")
+
+	for _, bad := range []string{"://nope", "ftp://host/hook", "not a url", "/relative/only"} {
+		t.Setenv("CREDIT_ALERT_WEBHOOK_URL", bad)
+		if _, err := Load(); err == nil {
+			t.Errorf("CREDIT_ALERT_WEBHOOK_URL=%q must be rejected", bad)
+		}
+	}
+
+	t.Setenv("CREDIT_ALERT_WEBHOOK_URL", "http://openwebui-discord-bot.openwebui.svc.cluster.local:8080/credit-request")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("valid webhook URL rejected: %v", err)
+	}
+	if cfg.CreditAlertWebhookURL == "" {
+		t.Error("expected webhook URL to be carried through")
+	}
+
+	// Unset = disabled, never an error.
+	t.Setenv("CREDIT_ALERT_WEBHOOK_URL", "")
+	cfg, err = Load()
+	if err != nil {
+		t.Fatalf("unset case errored: %v", err)
+	}
+	if cfg.CreditAlertWebhookURL != "" {
+		t.Errorf("expected empty (disabled), got %q", cfg.CreditAlertWebhookURL)
+	}
+}

--- a/internal/creditrequest/recorder.go
+++ b/internal/creditrequest/recorder.go
@@ -46,7 +46,7 @@ type Recorder struct {
 	client       *http.Client
 
 	wg  sync.WaitGroup
-	sem chan struct{} // caps concurrent recordings under 402 storms
+	sem chan struct{} // caps concurrent webhook deliveries (never the filing)
 }
 
 // New builds a Recorder. webhookURL may be empty (requests are still
@@ -63,23 +63,18 @@ func New(db *store.Store, webhookURL string, defaultGrant float64) *Recorder {
 }
 
 // RecordCapHit files a credit request for the account (deduped per month)
-// and fires the webhook when this call was the one that filed it. Async and
-// non-blocking: under a saturated semaphore the event is skipped — the next
-// 402 from the still-capped account retries the filing.
+// and fires the webhook when this call was the one that filed it. Async so
+// the 402 response never waits. The filing itself always runs — one fast
+// indexed insert, the same load profile as the 402 handling that triggered
+// it — so slow webhook deliveries can never cause a cap-hit to go
+// unrecorded; only delivery is concurrency-capped.
 func (r *Recorder) RecordCapHit(accountID int64) {
 	if r == nil {
-		return
-	}
-	select {
-	case r.sem <- struct{}{}:
-	default:
-		slog.Debug("cap-hit recording skipped (saturated)", "account_id", accountID)
 		return
 	}
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
-		defer func() { <-r.sem }()
 		r.recordCapHit(accountID)
 	}()
 }
@@ -129,6 +124,10 @@ func (r *Recorder) recordCapHit(accountID int64) {
 	if info.DisplayName != nil {
 		n.DisplayName = *info.DisplayName
 	}
+	// Blocking acquire is safe here: only filing winners reach delivery, and
+	// there is at most one winner per account per month.
+	r.sem <- struct{}{}
+	defer func() { <-r.sem }()
 	if err := r.deliver(n); err != nil {
 		// The bot reconciles pending requests on startup and the admin
 		// console lists them, so a lost notification self-heals.

--- a/internal/creditrequest/recorder.go
+++ b/internal/creditrequest/recorder.go
@@ -1,0 +1,163 @@
+// Package creditrequest records "account hit its monthly allowance" events
+// and notifies the operator's webhook (docs/design/credit-requests.md).
+//
+// Both monthly_limit_reached 402 sites (the credit gate's pre-check and the
+// reserve failure in the chat handler) call RecordCapHit. The store dedupes
+// per account+month, so a capped user retrying in chat produces exactly one
+// filed request and one notification per episode.
+package creditrequest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// MonthlyLimitMessage is the user-facing 402 text for allowance-managed
+// accounts. It lives here so both 402 sites stay in sync — the wording
+// promises the admin was notified, which is exactly what RecordCapHit does.
+const MonthlyLimitMessage = "Monthly usage limit reached — your admin has been notified. " +
+	"Credits may be added shortly; otherwise your allowance resets next month."
+
+// Notification is the webhook payload for one filed credit request.
+type Notification struct {
+	RequestID    int64   `json:"request_id"`
+	AccountID    int64   `json:"account_id"`
+	Email        string  `json:"email"`
+	DisplayName  string  `json:"display_name"`
+	MonthlyGrant float64 `json:"monthly_grant"` // effective (override or env default)
+	Spent        float64 `json:"spent"`         // grant minus remaining balance
+	Period       string  `json:"period"`        // YYYY-MM-DD, first day of the month
+}
+
+// Recorder files credit requests and delivers webhook notifications
+// asynchronously so the 402 response path never waits on it. A nil *Recorder
+// is a no-op, letting call sites skip nil checks.
+type Recorder struct {
+	db           *store.Store
+	webhookURL   string // empty = record only, no notification
+	defaultGrant float64
+	client       *http.Client
+
+	wg  sync.WaitGroup
+	sem chan struct{} // caps concurrent recordings under 402 storms
+}
+
+// New builds a Recorder. webhookURL may be empty (requests are still
+// recorded and visible in the admin console — the webhook is a consumer,
+// not the source of truth).
+func New(db *store.Store, webhookURL string, defaultGrant float64) *Recorder {
+	return &Recorder{
+		db:           db,
+		webhookURL:   webhookURL,
+		defaultGrant: defaultGrant,
+		client:       &http.Client{Timeout: 5 * time.Second},
+		sem:          make(chan struct{}, 8),
+	}
+}
+
+// RecordCapHit files a credit request for the account (deduped per month)
+// and fires the webhook when this call was the one that filed it. Async and
+// non-blocking: under a saturated semaphore the event is skipped — the next
+// 402 from the still-capped account retries the filing.
+func (r *Recorder) RecordCapHit(accountID int64) {
+	if r == nil {
+		return
+	}
+	select {
+	case r.sem <- struct{}{}:
+	default:
+		slog.Debug("cap-hit recording skipped (saturated)", "account_id", accountID)
+		return
+	}
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		defer func() { <-r.sem }()
+		r.recordCapHit(accountID)
+	}()
+}
+
+// Wait blocks until all in-flight recordings finish. Used by tests and
+// shutdown; never called on the request path.
+func (r *Recorder) Wait() {
+	if r == nil {
+		return
+	}
+	r.wg.Wait()
+}
+
+func (r *Recorder) recordCapHit(accountID int64) {
+	id, filed, err := r.db.FileCreditRequest(accountID, time.Now())
+	if err != nil {
+		slog.Error("file credit request failed", "error", err, "account_id", accountID)
+		return
+	}
+	if !filed {
+		return
+	}
+	slog.Info("credit request filed", "request_id", id, "account_id", accountID)
+	if r.webhookURL == "" {
+		return
+	}
+
+	info, err := r.db.GetCreditRequestInfo(id)
+	if err != nil {
+		slog.Error("credit request info lookup failed", "error", err, "request_id", id)
+		return
+	}
+	grant := r.defaultGrant
+	if info.MonthlyGrant != nil {
+		grant = *info.MonthlyGrant
+	}
+	n := Notification{
+		RequestID:    id,
+		AccountID:    info.AccountID,
+		MonthlyGrant: grant,
+		Spent:        grant - info.Balance,
+		Period:       info.Period.Format("2006-01-02"),
+	}
+	if info.Email != nil {
+		n.Email = *info.Email
+	}
+	if info.DisplayName != nil {
+		n.DisplayName = *info.DisplayName
+	}
+	if err := r.deliver(n); err != nil {
+		// The bot reconciles pending requests on startup and the admin
+		// console lists them, so a lost notification self-heals.
+		slog.Error("credit request notification failed", "error", err, "request_id", id)
+	}
+}
+
+// deliver POSTs the notification, retrying once. Fire-and-forget beyond
+// that — durability lives in the credit_requests table, not the webhook.
+func (r *Recorder) deliver(n Notification) error {
+	body, err := json.Marshal(n)
+	if err != nil {
+		return err
+	}
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+		resp, err := r.client.Post(r.webhookURL, "application/json", bytes.NewReader(body))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		resp.Body.Close()
+		if resp.StatusCode < 300 {
+			return nil
+		}
+		lastErr = fmt.Errorf("webhook returned %d", resp.StatusCode)
+	}
+	return lastErr
+}

--- a/internal/creditrequest/recorder_test.go
+++ b/internal/creditrequest/recorder_test.go
@@ -1,0 +1,237 @@
+package creditrequest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+func setupRecorderTest(t *testing.T) *store.Store {
+	t.Helper()
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("DATABASE_URL not set, skipping recorder integration test")
+	}
+
+	s, err := store.New(context.Background(), dbURL)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+
+	wipe := func() {
+		c := context.Background()
+		p := s.Pool()
+		_, _ = p.Exec(c, "DELETE FROM registration_events")
+		_, _ = p.Exec(c, "DELETE FROM credit_holds")
+		_, _ = p.Exec(c, "DELETE FROM credit_transactions")
+		_, _ = p.Exec(c, "DELETE FROM account_usage_stats")
+		_, _ = p.Exec(c, "DELETE FROM credit_balances")
+		_, _ = p.Exec(c, "DELETE FROM credit_pricing")
+		_, _ = p.Exec(c, "DELETE FROM registration_tokens")
+		_, _ = p.Exec(c, "DELETE FROM usage_logs")
+		_, _ = p.Exec(c, "DELETE FROM nodes")
+		_, _ = p.Exec(c, "DELETE FROM user_sessions")
+		_, _ = p.Exec(c, "DELETE FROM api_keys")
+		_, _ = p.Exec(c, "DELETE FROM users")
+		_, _ = p.Exec(c, "DELETE FROM federated_identities")
+		_, _ = p.Exec(c, "DELETE FROM credit_requests")
+		_, _ = p.Exec(c, "DELETE FROM accounts")
+	}
+	wipe()
+	t.Cleanup(func() {
+		wipe()
+		s.Close()
+	})
+	return s
+}
+
+func provisionCappedEndUser(t *testing.T, s *store.Store, extID, email string) int64 {
+	t.Helper()
+	res, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: extID, Email: email, DisplayName: "Cap Hit",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	// Burn the whole allowance: the account is now in the capped state.
+	if err := s.AddCredits(res.AccountID, -5, "test burn"); err != nil {
+		t.Fatalf("burn allowance: %v", err)
+	}
+	return res.AccountID
+}
+
+func pendingRequests(t *testing.T, s *store.Store, accountID int64) int {
+	t.Helper()
+	rows, err := s.ListCreditRequests("pending")
+	if err != nil {
+		t.Fatalf("ListCreditRequests: %v", err)
+	}
+	n := 0
+	for _, r := range rows {
+		if r.AccountID == accountID {
+			n++
+		}
+	}
+	return n
+}
+
+// captureWebhook records every POST body it receives.
+type captureWebhook struct {
+	mu     sync.Mutex
+	bodies []Notification
+	status int
+}
+
+func (c *captureWebhook) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var n Notification
+		_ = json.NewDecoder(r.Body).Decode(&n)
+		c.mu.Lock()
+		c.bodies = append(c.bodies, n)
+		c.mu.Unlock()
+		status := c.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+	})
+}
+
+func (c *captureWebhook) received() []Notification {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Notification, len(c.bodies))
+	copy(out, c.bodies)
+	return out
+}
+
+func TestRecorder_CapHitFilesAndNotifies(t *testing.T) {
+	s := setupRecorderTest(t)
+	acc := provisionCappedEndUser(t, s, "rec-1", "dave@example.com")
+
+	hook := &captureWebhook{}
+	srv := httptest.NewServer(hook.handler())
+	defer srv.Close()
+
+	rec := New(s, srv.URL, 5.0)
+	rec.RecordCapHit(acc)
+	rec.Wait()
+
+	if n := pendingRequests(t, s, acc); n != 1 {
+		t.Fatalf("expected 1 pending request, got %d", n)
+	}
+	got := hook.received()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 webhook POST, got %d", len(got))
+	}
+	n := got[0]
+	if n.RequestID == 0 || n.AccountID != acc {
+		t.Errorf("ids: got request_id=%d account_id=%d", n.RequestID, n.AccountID)
+	}
+	if n.Email != "dave@example.com" || n.DisplayName != "Cap Hit" {
+		t.Errorf("identity: got email=%q name=%q", n.Email, n.DisplayName)
+	}
+	if n.MonthlyGrant != 5.0 {
+		t.Errorf("expected effective grant 5.0, got %v", n.MonthlyGrant)
+	}
+	if n.Spent != 5.0 {
+		t.Errorf("expected spent 5.0 (grant minus zero balance), got %v", n.Spent)
+	}
+	if n.Period == "" {
+		t.Error("expected a period")
+	}
+}
+
+func TestRecorder_UsesAccountGrantOverride(t *testing.T) {
+	s := setupRecorderTest(t)
+	acc := provisionCappedEndUser(t, s, "rec-2", "erin@example.com")
+	override := 12.5
+	if err := s.SetMonthlyGrant(acc, &override); err != nil {
+		t.Fatalf("SetMonthlyGrant: %v", err)
+	}
+
+	hook := &captureWebhook{}
+	srv := httptest.NewServer(hook.handler())
+	defer srv.Close()
+
+	rec := New(s, srv.URL, 5.0)
+	rec.RecordCapHit(acc)
+	rec.Wait()
+
+	got := hook.received()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 webhook POST, got %d", len(got))
+	}
+	if got[0].MonthlyGrant != 12.5 {
+		t.Errorf("expected override grant 12.5 in payload, got %v", got[0].MonthlyGrant)
+	}
+}
+
+func TestRecorder_SecondHitDoesNotRenotify(t *testing.T) {
+	s := setupRecorderTest(t)
+	acc := provisionCappedEndUser(t, s, "rec-3", "frank@example.com")
+
+	hook := &captureWebhook{}
+	srv := httptest.NewServer(hook.handler())
+	defer srv.Close()
+
+	rec := New(s, srv.URL, 5.0)
+	rec.RecordCapHit(acc)
+	rec.Wait()
+	rec.RecordCapHit(acc)
+	rec.Wait()
+
+	if n := pendingRequests(t, s, acc); n != 1 {
+		t.Errorf("expected 1 pending request, got %d", n)
+	}
+	if got := hook.received(); len(got) != 1 {
+		t.Errorf("expected 1 webhook POST, got %d", len(got))
+	}
+}
+
+func TestRecorder_NoWebhookStillRecords(t *testing.T) {
+	s := setupRecorderTest(t)
+	acc := provisionCappedEndUser(t, s, "rec-4", "grace@example.com")
+
+	rec := New(s, "", 5.0)
+	rec.RecordCapHit(acc)
+	rec.Wait()
+
+	if n := pendingRequests(t, s, acc); n != 1 {
+		t.Errorf("expected request recorded without webhook, got %d", n)
+	}
+}
+
+func TestRecorder_WebhookFailureStillRecords(t *testing.T) {
+	s := setupRecorderTest(t)
+	acc := provisionCappedEndUser(t, s, "rec-5", "heidi@example.com")
+
+	hook := &captureWebhook{status: http.StatusInternalServerError}
+	srv := httptest.NewServer(hook.handler())
+	defer srv.Close()
+
+	rec := New(s, srv.URL, 5.0)
+	rec.RecordCapHit(acc)
+	rec.Wait()
+
+	if n := pendingRequests(t, s, acc); n != 1 {
+		t.Errorf("expected request recorded despite webhook failure, got %d", n)
+	}
+	// Delivery is attempted, then retried once on failure.
+	if got := hook.received(); len(got) != 2 {
+		t.Errorf("expected 2 delivery attempts (1 retry), got %d", len(got))
+	}
+}
+
+func TestRecorder_NilSafe(t *testing.T) {
+	var rec *Recorder
+	rec.RecordCapHit(1) // must not panic
+	rec.Wait()
+}

--- a/internal/creditrequest/recorder_test.go
+++ b/internal/creditrequest/recorder_test.go
@@ -3,6 +3,7 @@ package creditrequest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -69,7 +70,7 @@ func provisionCappedEndUser(t *testing.T, s *store.Store, extID, email string) i
 
 func pendingRequests(t *testing.T, s *store.Store, accountID int64) int {
 	t.Helper()
-	rows, err := s.ListCreditRequests("pending")
+	rows, err := s.ListCreditRequests("pending", time.Now())
 	if err != nil {
 		t.Fatalf("ListCreditRequests: %v", err)
 	}
@@ -227,6 +228,35 @@ func TestRecorder_WebhookFailureStillRecords(t *testing.T) {
 	// Delivery is attempted, then retried once on failure.
 	if got := hook.received(); len(got) != 2 {
 		t.Errorf("expected 2 delivery attempts (1 retry), got %d", len(got))
+	}
+}
+
+// Slow/failing deliveries must never cause a cap-hit to go unrecorded: the
+// filing always runs; only webhook delivery queues behind the concurrency
+// cap. (With the old whole-recording semaphore, accounts beyond the cap were
+// silently dropped.)
+func TestRecorder_SlowWebhookNeverBlocksFiling(t *testing.T) {
+	s := setupRecorderTest(t)
+
+	hook := &captureWebhook{status: http.StatusInternalServerError}
+	srv := httptest.NewServer(hook.handler())
+	defer srv.Close()
+
+	rec := New(s, srv.URL, 5.0)
+	const accounts = 10 // more than the delivery semaphore's 8 slots
+	for i := 0; i < accounts; i++ {
+		acc := provisionCappedEndUser(t, s,
+			fmt.Sprintf("sat-%d", i), fmt.Sprintf("sat%d@example.com", i))
+		rec.RecordCapHit(acc)
+	}
+	rec.Wait()
+
+	rows, err := s.ListCreditRequests("pending", time.Now())
+	if err != nil {
+		t.Fatalf("ListCreditRequests: %v", err)
+	}
+	if len(rows) != accounts {
+		t.Errorf("expected all %d cap-hits filed despite failing webhook, got %d", accounts, len(rows))
 	}
 }
 

--- a/internal/credits/middleware.go
+++ b/internal/credits/middleware.go
@@ -6,6 +6,7 @@ import (
 	"github.com/krishna/local-ai-proxy/internal/apierror"
 	"github.com/krishna/local-ai-proxy/internal/auth"
 	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/creditrequest"
 	"github.com/krishna/local-ai-proxy/internal/metrics"
 	"github.com/krishna/local-ai-proxy/internal/store"
 )
@@ -20,8 +21,9 @@ import (
 // The gate checks the BILLING account: the billing.Resolution attached by
 // the billing middleware when present (end-user accounts on trusted keys),
 // else the key's own account. Allowance-managed accounts get the
-// monthly_limit_reached wording so chat users see an actionable error.
-func CreditGate(db *store.Store, m *metrics.Metrics) func(http.Handler) http.Handler {
+// monthly_limit_reached wording so chat users see an actionable error, and
+// the cap-hit is recorded (capHits may be nil — no-op).
+func CreditGate(db *store.Store, m *metrics.Metrics, capHits *creditrequest.Recorder) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			key := auth.KeyFromContext(r.Context())
@@ -60,7 +62,8 @@ func CreditGate(db *store.Store, m *metrics.Metrics) func(http.Handler) http.Han
 			if balance-reserved <= 0 {
 				m.RecordCreditGateReject()
 				if allowanceManaged {
-					apierror.WriteError(w, r, http.StatusPaymentRequired, "monthly_limit_reached", "invalid_request_error", "Monthly usage limit reached — resets next month")
+					capHits.RecordCapHit(accountID)
+					apierror.WriteError(w, r, http.StatusPaymentRequired, "monthly_limit_reached", "invalid_request_error", creditrequest.MonthlyLimitMessage)
 					return
 				}
 				apierror.WriteError(w, r, http.StatusPaymentRequired, "insufficient_credits", "invalid_request_error", "Insufficient credits")

--- a/internal/credits/middleware_billing_test.go
+++ b/internal/credits/middleware_billing_test.go
@@ -27,7 +27,7 @@ func TestCreditGate_ResolvedBillingAccount_OverridesKeyAccount(t *testing.T) {
 		t.Fatalf("ResolveEndUserAccount: %v", err)
 	}
 
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 	called := false
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -60,7 +60,7 @@ func TestCreditGate_AllowanceExhausted_MonthlyLimitWording(t *testing.T) {
 		t.Fatalf("ResolveEndUserAccount: %v", err)
 	}
 
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler must not be called for an exhausted allowance")
 	}))

--- a/internal/credits/middleware_caphit_test.go
+++ b/internal/credits/middleware_caphit_test.go
@@ -1,0 +1,100 @@
+package credits
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/creditrequest"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// Gate 402 on an allowance-managed account files a credit request (once) and
+// tells the user the admin has been notified.
+func TestCreditGate_AllowanceCapHit_FilesCreditRequest(t *testing.T) {
+	db := setupTestStore(t)
+	res, err := db.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "gate-cap-1", Email: "cap@example.com",
+	}, 0, time.Now()) // zero grant: capped from the first request
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	rec := creditrequest.New(db, "", 5.0)
+	gate := CreditGate(db, nil, rec)
+	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	}))
+
+	sharedAcc := int64(999)
+	key := &store.APIKey{ID: 1, AccountID: &sharedAcc, TrustUserHeaders: true}
+	do := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest("POST", "/api/v1/chat/completions", nil)
+		ctx := auth.WithKey(req.Context(), key)
+		ctx = billing.WithResolution(ctx, billing.Resolution{AccountID: res.AccountID, AllowanceManaged: true})
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req.WithContext(ctx))
+		return w
+	}
+
+	w := do()
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "monthly_limit_reached") {
+		t.Errorf("expected monthly_limit_reached, got: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "admin has been notified") {
+		t.Errorf("expected actionable message, got: %s", w.Body.String())
+	}
+
+	// Retrying while capped must not file another request.
+	_ = do()
+	rec.Wait()
+
+	rows, err := db.ListCreditRequests("pending")
+	if err != nil {
+		t.Fatalf("ListCreditRequests: %v", err)
+	}
+	if len(rows) != 1 || rows[0].AccountID != res.AccountID {
+		t.Errorf("expected 1 pending request for account %d, got %+v", res.AccountID, rows)
+	}
+}
+
+// A plain (non-allowance) account keeps insufficient_credits and never files.
+func TestCreditGate_NonAllowance402_DoesNotFile(t *testing.T) {
+	db := setupTestStore(t)
+	accID, _, _ := db.RegisterUser("gate-cap-2@example.com", "hash", "GateCap2")
+
+	rec := creditrequest.New(db, "", 5.0)
+	gate := CreditGate(db, nil, rec)
+	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	}))
+
+	key := &store.APIKey{ID: 1, AccountID: &accID}
+	req := httptest.NewRequest("POST", "/api/v1/chat/completions", nil)
+	req = req.WithContext(auth.WithKey(req.Context(), key))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "insufficient_credits") {
+		t.Errorf("expected insufficient_credits, got: %s", w.Body.String())
+	}
+	rec.Wait()
+
+	rows, err := db.ListCreditRequests("pending")
+	if err != nil {
+		t.Fatalf("ListCreditRequests: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected no credit requests, got %+v", rows)
+	}
+}

--- a/internal/credits/middleware_caphit_test.go
+++ b/internal/credits/middleware_caphit_test.go
@@ -56,7 +56,7 @@ func TestCreditGate_AllowanceCapHit_FilesCreditRequest(t *testing.T) {
 	_ = do()
 	rec.Wait()
 
-	rows, err := db.ListCreditRequests("pending")
+	rows, err := db.ListCreditRequests("pending", time.Now())
 	if err != nil {
 		t.Fatalf("ListCreditRequests: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestCreditGate_NonAllowance402_DoesNotFile(t *testing.T) {
 	}
 	rec.Wait()
 
-	rows, err := db.ListCreditRequests("pending")
+	rows, err := db.ListCreditRequests("pending", time.Now())
 	if err != nil {
 		t.Fatalf("ListCreditRequests: %v", err)
 	}

--- a/internal/credits/middleware_test.go
+++ b/internal/credits/middleware_test.go
@@ -39,6 +39,7 @@ func setupTestStore(t *testing.T) *store.Store {
 		_, _ = pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = pool.Exec(c, "DELETE FROM users")
 		_, _ = pool.Exec(c, "DELETE FROM federated_identities")
+		_, _ = pool.Exec(c, "DELETE FROM credit_requests")
 		_, _ = pool.Exec(c, "DELETE FROM accounts")
 	}
 	wipe()
@@ -55,7 +56,7 @@ func TestCreditGate_ErrorResponseFormat(t *testing.T) {
 	db := setupTestStore(t)
 	accID, _, _ := db.RegisterUser("gate-format@example.com", "hash", "GateFormat")
 	// No credits — will get 402
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called")
@@ -80,7 +81,7 @@ func TestCreditGate_NilAccountID_Returns403(t *testing.T) {
 	// rejected, never waved through. Startup backfill guarantees this state
 	// cannot occur in a healthy deployment, so rejecting is fail-closed.
 	db := setupTestStore(t)
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called for nil AccountID")
@@ -107,7 +108,7 @@ func TestCreditGate_LegacyAdminKey_UpgradePath(t *testing.T) {
 	// startup backfill it must chat again — attached to the admin service
 	// account, metered like every other key.
 	db := setupTestStore(t)
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 
 	rawHash := "legacy-hash-upgrade"
 	if _, err := db.CreateKey("legacy-admin", rawHash, "sk-legacy", 60); err != nil {
@@ -158,7 +159,7 @@ func TestCreditGate_SufficientBalance_PassesThrough(t *testing.T) {
 	db := setupTestStore(t)
 	accID, _, _ := db.RegisterUser("gate-pass@example.com", "hash", "GatePass")
 	_ = db.AddCredits(accID, 100, "grant")
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 
 	called := false
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -181,7 +182,7 @@ func TestCreditGate_ZeroBalance_Returns402(t *testing.T) {
 	db := setupTestStore(t)
 	accID, _, _ := db.RegisterUser("gate-zero@example.com", "hash", "GateZero")
 	// No credits added — balance is 0
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called")
@@ -200,7 +201,7 @@ func TestCreditGate_ZeroBalance_Returns402(t *testing.T) {
 
 func TestCreditGate_NoKey_PassesThrough(t *testing.T) {
 	db := setupTestStore(t)
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 
 	called := false
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -223,7 +224,7 @@ func TestCreditGate_InactiveAccount_Returns403(t *testing.T) {
 	accID, _, _ := db.RegisterUser("gate-inactive@example.com", "hash", "GateInactive")
 	_ = db.AddCredits(accID, 100, "grant")
 	_ = db.SetAccountActive(accID, false)
-	gate := CreditGate(db, nil)
+	gate := CreditGate(db, nil, nil)
 
 	handler := gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called")

--- a/internal/proxy/admin_key_upgrade_test.go
+++ b/internal/proxy/admin_key_upgrade_test.go
@@ -41,7 +41,7 @@ func TestLegacyAdminKey_ChatsAfterBackfill(t *testing.T) {
 
 	usageCh := make(chan store.UsageEntry, 10)
 	proxyHandler := NewHandler(singleNodeRegistry(t, upstream.URL, model), usageCh, 52428800, db, nil, Options{})
-	chain := credits.CreditGate(db, nil)(proxyHandler)
+	chain := credits.CreditGate(db, nil, nil)(proxyHandler)
 
 	chat := func(reqModel string) *httptest.ResponseRecorder {
 		key, err := db.GetKeyByHash(keyHash)
@@ -119,7 +119,7 @@ func TestCreditGateChain_NoBypassForNilAccount(t *testing.T) {
 
 	usageCh := make(chan store.UsageEntry, 10)
 	proxyHandler := NewHandler(singleNodeRegistry(t, upstream.URL, "m"), usageCh, 52428800, db, nil, Options{})
-	chain := credits.CreditGate(db, nil)(proxyHandler)
+	chain := credits.CreditGate(db, nil, nil)(proxyHandler)
 
 	key := &store.APIKey{ID: 42, Name: "detached"} // AccountID nil
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions",

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/krishna/local-ai-proxy/internal/apierror"
 	"github.com/krishna/local-ai-proxy/internal/auth"
 	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/creditrequest"
 	"github.com/krishna/local-ai-proxy/internal/credits"
 	"github.com/krishna/local-ai-proxy/internal/metrics"
 	"github.com/krishna/local-ai-proxy/internal/registry"
@@ -57,6 +58,10 @@ type Options struct {
 	// actively priced model regardless of node availability. Default false:
 	// only models served by at least one healthy node are listed.
 	ModelsListAll bool
+
+	// CapHits records allowance cap-hits on the reserve-failure 402 path
+	// (docs/design/credit-requests.md). Nil = recording disabled.
+	CapHits *creditrequest.Recorder
 }
 
 type handler struct {
@@ -67,6 +72,7 @@ type handler struct {
 	db            *store.Store     // nil = credits disabled
 	metrics       *metrics.Metrics // nil = metrics disabled
 	modelsListAll bool
+	capHits       *creditrequest.Recorder // nil-safe
 }
 
 // requestMeta holds fields peeked from the request body.
@@ -109,6 +115,7 @@ func NewHandler(reg Registry, usageCh chan<- store.UsageEntry, maxBody int64, db
 		db:            db,
 		metrics:       m,
 		modelsListAll: opts.ModelsListAll,
+		capHits:       opts.CapHits,
 	}
 }
 
@@ -319,8 +326,9 @@ func (h *handler) handleChatCompletions(w http.ResponseWriter, r *http.Request) 
 		holdID, err = h.db.ReserveCredits(*bill.AccountID, reserveAmount)
 		if err != nil {
 			if bill.AllowanceManaged {
+				h.capHits.RecordCapHit(*bill.AccountID)
 				writeError(w, r, http.StatusPaymentRequired, "monthly_limit_reached", "invalid_request_error",
-					"Monthly usage limit reached — resets next month")
+					creditrequest.MonthlyLimitMessage)
 				return
 			}
 			writeError(w, r, http.StatusPaymentRequired, "insufficient_credits", "invalid_request_error",

--- a/internal/proxy/proxy_caphit_test.go
+++ b/internal/proxy/proxy_caphit_test.go
@@ -1,0 +1,65 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/creditrequest"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// The reserve-failure 402 (gate passed on a positive sliver of balance, the
+// estimate didn't fit) is the second cap-hit site: it must file a credit
+// request just like the gate's pre-check does.
+func TestReserveFailure_AllowanceManaged_FilesCreditRequest(t *testing.T) {
+	db := setupTestDB(t)
+	sharedAcc, _, _ := db.RegisterUser("owui-caphit@example.com", "hash", "OWUICapHit")
+	_ = db.AddCredits(sharedAcc, 1000, "grant")
+	_ = db.UpsertPricing("llama3.1:8b", 2000, 2000, 500)
+
+	upstream := mockOllamaChatNonStreaming(http.StatusOK, map[string]any{})
+	defer upstream.Close()
+
+	rec := creditrequest.New(db, "", 0.000001)
+	usageCh := make(chan store.UsageEntry, 10)
+	h := NewHandler(singleNodeRegistry(t, upstream.URL, "llama3.1:8b"), usageCh, 52428800, db, nil,
+		Options{CapHits: rec})
+	// Grant far too small for any request: billing resolution succeeds, the
+	// gateless chain reaches reserve, and reserve fails.
+	chain := billing.Middleware(db, 0.000001)(h)
+
+	reqBody := `{"model":"llama3.1:8b","messages":[{"role":"user","content":"Hi"}],"max_tokens":500}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(billing.HeaderUserID, "owui-caphit-1")
+	req.Header.Set(billing.HeaderUserEmail, "caphit@example.com")
+	key := &store.APIKey{ID: 1, Name: "openwebui", AccountID: &sharedAcc, TrustUserHeaders: true}
+	req = addKeyToRequest(req, key)
+
+	w := httptest.NewRecorder()
+	chain.ServeHTTP(w, req)
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "monthly_limit_reached") {
+		t.Errorf("expected monthly_limit_reached, got: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "admin has been notified") {
+		t.Errorf("expected actionable message, got: %s", w.Body.String())
+	}
+	rec.Wait()
+
+	rows, err := db.ListCreditRequests("pending")
+	if err != nil {
+		t.Fatalf("ListCreditRequests: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 pending credit request, got %d", len(rows))
+	}
+	if rows[0].Email == nil || *rows[0].Email != "caphit@example.com" {
+		t.Errorf("expected end-user attribution, got %+v", rows[0])
+	}
+}

--- a/internal/proxy/proxy_caphit_test.go
+++ b/internal/proxy/proxy_caphit_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/krishna/local-ai-proxy/internal/billing"
 	"github.com/krishna/local-ai-proxy/internal/creditrequest"
@@ -52,7 +53,7 @@ func TestReserveFailure_AllowanceManaged_FilesCreditRequest(t *testing.T) {
 	}
 	rec.Wait()
 
-	rows, err := db.ListCreditRequests("pending")
+	rows, err := db.ListCreditRequests("pending", time.Now())
 	if err != nil {
 		t.Fatalf("ListCreditRequests: %v", err)
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -103,6 +103,7 @@ func setupTestDB(t *testing.T) *store.Store {
 		_, _ = pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = pool.Exec(c, "DELETE FROM users")
 		_, _ = pool.Exec(c, "DELETE FROM federated_identities")
+		_, _ = pool.Exec(c, "DELETE FROM credit_requests")
 		_, _ = pool.Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/store/credit_requests.go
+++ b/internal/store/credit_requests.go
@@ -1,0 +1,174 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Credit requests: auto-filed "account hit its monthly allowance" records
+// (docs/design/credit-requests.md). Filed by the cap-hit recorder on the 402
+// paths, listed/resolved by the admin API and the Discord bot.
+
+var (
+	// ErrCreditRequestNotFound: no credit request with that id.
+	ErrCreditRequestNotFound = errors.New("credit request not found")
+	// ErrCreditRequestResolved: the request was already granted or dismissed.
+	ErrCreditRequestResolved = errors.New("credit request already resolved")
+)
+
+// CreditRequest is one cap-hit record.
+type CreditRequest struct {
+	ID           int64
+	AccountID    int64
+	Period       time.Time // first day of the UTC month
+	Status       string    // pending | granted | dismissed
+	CreatedAt    time.Time
+	ResolvedAt   *time.Time
+	ResolvedNote *string
+}
+
+// CreditRequestRow adds the display fields the admin listing joins in.
+type CreditRequestRow struct {
+	CreditRequest
+	AccountName  string
+	Email        *string  // oldest federated identity, nil when none
+	MonthlyGrant *float64 // per-account override; nil = env default applies
+	Balance      float64
+}
+
+// CreditRequestInfo is the payload data for a cap-hit notification.
+type CreditRequestInfo struct {
+	AccountID    int64
+	Email        *string
+	DisplayName  *string
+	MonthlyGrant *float64 // override; nil = env default applies
+	Balance      float64
+	Period       time.Time
+}
+
+// FileCreditRequest files a cap-hit request for the account's current UTC
+// month unless one is pending (dedupe) or dismissed (silenced for the
+// month). Granted rows do not block: an account that burned through a top-up
+// may legitimately need to ask again. Returns (id, true) when this call
+// filed the request. Race-safe: the partial unique index on pending rows
+// elects a single winner among concurrent 402s.
+func (s *Store) FileCreditRequest(accountID int64, now time.Time) (int64, bool, error) {
+	month := time.Date(now.UTC().Year(), now.UTC().Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	var id int64
+	err := s.pool.QueryRow(context.Background(),
+		`INSERT INTO credit_requests (account_id, period)
+		 SELECT $1, $2
+		 WHERE NOT EXISTS (
+		     SELECT 1 FROM credit_requests
+		     WHERE account_id = $1 AND period = $2 AND status IN ('pending', 'dismissed')
+		 )
+		 ON CONFLICT DO NOTHING
+		 RETURNING id`,
+		accountID, month,
+	).Scan(&id)
+	if err == pgx.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("file credit request: %w", err)
+	}
+	return id, true, nil
+}
+
+// ListCreditRequests returns requests with the given status, newest first,
+// joined with account display data for the admin listing.
+func (s *Store) ListCreditRequests(status string) ([]CreditRequestRow, error) {
+	rows, err := s.pool.Query(context.Background(),
+		`SELECT cr.id, cr.account_id, cr.period, cr.status, cr.created_at,
+		        cr.resolved_at, cr.resolved_note,
+		        a.name, fi.email, a.monthly_grant, COALESCE(cb.balance, 0)
+		 FROM credit_requests cr
+		 JOIN accounts a ON a.id = cr.account_id
+		 LEFT JOIN credit_balances cb ON cb.account_id = cr.account_id
+		 LEFT JOIN LATERAL (
+		     SELECT email FROM federated_identities
+		     WHERE account_id = cr.account_id ORDER BY id LIMIT 1
+		 ) fi ON TRUE
+		 WHERE cr.status = $1
+		 ORDER BY cr.created_at DESC, cr.id DESC`,
+		status,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []CreditRequestRow
+	for rows.Next() {
+		var r CreditRequestRow
+		if err := rows.Scan(&r.ID, &r.AccountID, &r.Period, &r.Status, &r.CreatedAt,
+			&r.ResolvedAt, &r.ResolvedNote,
+			&r.AccountName, &r.Email, &r.MonthlyGrant, &r.Balance); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ResolveCreditRequest moves a pending request to granted or dismissed.
+// Resolution never moves money itself — callers grant credits through the
+// audited grant path first, then mark the request.
+func (s *Store) ResolveCreditRequest(id int64, status, note string) error {
+	ct, err := s.pool.Exec(context.Background(),
+		`UPDATE credit_requests
+		 SET status = $2, resolved_at = NOW(), resolved_note = NULLIF($3, '')
+		 WHERE id = $1 AND status = 'pending'`,
+		id, status, note,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() > 0 {
+		return nil
+	}
+
+	// Distinguish "no such request" from "already resolved".
+	var current string
+	err = s.pool.QueryRow(context.Background(),
+		`SELECT status FROM credit_requests WHERE id = $1`, id,
+	).Scan(&current)
+	if err == pgx.ErrNoRows {
+		return ErrCreditRequestNotFound
+	}
+	if err != nil {
+		return err
+	}
+	return ErrCreditRequestResolved
+}
+
+// GetCreditRequestInfo loads the notification payload data for a request.
+func (s *Store) GetCreditRequestInfo(id int64) (*CreditRequestInfo, error) {
+	var info CreditRequestInfo
+	err := s.pool.QueryRow(context.Background(),
+		`SELECT cr.account_id, fi.email, fi.display_name,
+		        a.monthly_grant, COALESCE(cb.balance, 0), cr.period
+		 FROM credit_requests cr
+		 JOIN accounts a ON a.id = cr.account_id
+		 LEFT JOIN credit_balances cb ON cb.account_id = cr.account_id
+		 LEFT JOIN LATERAL (
+		     SELECT email, display_name FROM federated_identities
+		     WHERE account_id = cr.account_id ORDER BY id LIMIT 1
+		 ) fi ON TRUE
+		 WHERE cr.id = $1`,
+		id,
+	).Scan(&info.AccountID, &info.Email, &info.DisplayName,
+		&info.MonthlyGrant, &info.Balance, &info.Period)
+	if err == pgx.ErrNoRows {
+		return nil, ErrCreditRequestNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/internal/store/credit_requests.go
+++ b/internal/store/credit_requests.go
@@ -18,6 +18,10 @@ var (
 	ErrCreditRequestNotFound = errors.New("credit request not found")
 	// ErrCreditRequestResolved: the request was already granted or dismissed.
 	ErrCreditRequestResolved = errors.New("credit request already resolved")
+	// ErrCreditRequestExpired: the request's allowance period is over — the
+	// balance has since reset, so acting on it would grant against the
+	// wrong month.
+	ErrCreditRequestExpired = errors.New("credit request expired")
 )
 
 // CreditRequest is one cap-hit record.
@@ -80,10 +84,31 @@ func (s *Store) FileCreditRequest(accountID int64, now time.Time) (int64, bool, 
 	return id, true, nil
 }
 
+// expireStaleCreditRequests lazily expires pending rows from past months:
+// once the allowance has reset, granting against the old request would be a
+// double grant, so it must stop being actionable. Same no-cron pattern as
+// the monthly allowance top-up.
+func (s *Store) expireStaleCreditRequests(ctx context.Context, now time.Time) error {
+	month := time.Date(now.UTC().Year(), now.UTC().Month(), 1, 0, 0, 0, 0, time.UTC)
+	_, err := s.pool.Exec(ctx,
+		`UPDATE credit_requests
+		 SET status = 'expired', resolved_at = NOW(), resolved_note = 'expired at month rollover'
+		 WHERE status = 'pending' AND period < $1`,
+		month,
+	)
+	return err
+}
+
 // ListCreditRequests returns requests with the given status, newest first,
-// joined with account display data for the admin listing.
-func (s *Store) ListCreditRequests(status string) ([]CreditRequestRow, error) {
-	rows, err := s.pool.Query(context.Background(),
+// joined with account display data for the admin listing. Pending rows from
+// past months are expired first, so the pending view only ever shows
+// actionable requests. now is injected for testability.
+func (s *Store) ListCreditRequests(status string, now time.Time) ([]CreditRequestRow, error) {
+	ctx := context.Background()
+	if err := s.expireStaleCreditRequests(ctx, now); err != nil {
+		return nil, fmt.Errorf("expire stale credit requests: %w", err)
+	}
+	rows, err := s.pool.Query(ctx,
 		`SELECT cr.id, cr.account_id, cr.period, cr.status, cr.created_at,
 		        cr.resolved_at, cr.resolved_note,
 		        a.name, fi.email, a.monthly_grant, COALESCE(cb.balance, 0)
@@ -116,15 +141,20 @@ func (s *Store) ListCreditRequests(status string) ([]CreditRequestRow, error) {
 	return out, rows.Err()
 }
 
-// ResolveCreditRequest moves a pending request to granted or dismissed.
-// Resolution never moves money itself — callers grant credits through the
-// audited grant path first, then mark the request.
-func (s *Store) ResolveCreditRequest(id int64, status, note string) error {
-	ct, err := s.pool.Exec(context.Background(),
+// ResolveCreditRequest moves a pending request of the CURRENT month to
+// granted or dismissed. Stale pending rows (period already rolled over) are
+// expired instead of resolved — the allowance has reset, so acting on them
+// would grant against the wrong month. Resolution never moves money itself;
+// callers mark the request first (this row is the idempotency lock) and then
+// grant through the audited grant path.
+func (s *Store) ResolveCreditRequest(id int64, status, note string, now time.Time) error {
+	ctx := context.Background()
+	month := time.Date(now.UTC().Year(), now.UTC().Month(), 1, 0, 0, 0, 0, time.UTC)
+	ct, err := s.pool.Exec(ctx,
 		`UPDATE credit_requests
 		 SET status = $2, resolved_at = NOW(), resolved_note = NULLIF($3, '')
-		 WHERE id = $1 AND status = 'pending'`,
-		id, status, note,
+		 WHERE id = $1 AND status = 'pending' AND period >= $4`,
+		id, status, note, month,
 	)
 	if err != nil {
 		return err
@@ -133,16 +163,23 @@ func (s *Store) ResolveCreditRequest(id int64, status, note string) error {
 		return nil
 	}
 
-	// Distinguish "no such request" from "already resolved".
+	// Distinguish "no such request" / "already resolved" / "stale period".
 	var current string
-	err = s.pool.QueryRow(context.Background(),
-		`SELECT status FROM credit_requests WHERE id = $1`, id,
-	).Scan(&current)
+	var period time.Time
+	err = s.pool.QueryRow(ctx,
+		`SELECT status, period FROM credit_requests WHERE id = $1`, id,
+	).Scan(&current, &period)
 	if err == pgx.ErrNoRows {
 		return ErrCreditRequestNotFound
 	}
 	if err != nil {
 		return err
+	}
+	if current == "pending" && period.Before(month) {
+		if err := s.expireStaleCreditRequests(ctx, now); err != nil {
+			return err
+		}
+		return ErrCreditRequestExpired
 	}
 	return ErrCreditRequestResolved
 }

--- a/internal/store/credit_requests_test.go
+++ b/internal/store/credit_requests_test.go
@@ -1,0 +1,275 @@
+package store
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// provisionEndUser creates an allowance-managed end-user account the way
+// production does: through federated identity resolution.
+func provisionEndUser(t *testing.T, s *Store, extID, email string, grant float64) int64 {
+	t.Helper()
+	res, err := s.ResolveEndUserAccount(FederatedIdentity{
+		Source: "openwebui", ExternalID: extID, Email: email, DisplayName: "Test User",
+	}, grant, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	return res.AccountID
+}
+
+func countCreditRequests(t *testing.T, s *Store, accountID int64) int {
+	t.Helper()
+	var n int
+	if err := s.pool.QueryRow(t.Context(),
+		`SELECT COUNT(*) FROM credit_requests WHERE account_id = $1`, accountID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count credit_requests: %v", err)
+	}
+	return n
+}
+
+func TestFileCreditRequest_FirstCapHitFiles(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-1", "cr1@example.com", 5)
+
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	id, filed, err := s.FileCreditRequest(acc, now)
+	if err != nil {
+		t.Fatalf("FileCreditRequest: %v", err)
+	}
+	if !filed || id == 0 {
+		t.Fatalf("expected a filed request with id, got filed=%v id=%d", filed, id)
+	}
+
+	var period time.Time
+	var status string
+	if err := s.pool.QueryRow(t.Context(),
+		`SELECT period, status FROM credit_requests WHERE id = $1`, id,
+	).Scan(&period, &status); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if status != "pending" {
+		t.Errorf("expected status pending, got %q", status)
+	}
+	if period.Format("2006-01-02") != "2026-07-01" {
+		t.Errorf("expected period 2026-07-01, got %s", period.Format("2006-01-02"))
+	}
+}
+
+func TestFileCreditRequest_PendingDedupes(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-2", "cr2@example.com", 5)
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	if _, filed, err := s.FileCreditRequest(acc, now); err != nil || !filed {
+		t.Fatalf("first file: filed=%v err=%v", filed, err)
+	}
+	if _, filed, err := s.FileCreditRequest(acc, now.Add(time.Hour)); err != nil || filed {
+		t.Fatalf("second file same month: expected no-op, got filed=%v err=%v", filed, err)
+	}
+	if n := countCreditRequests(t, s, acc); n != 1 {
+		t.Errorf("expected 1 request, got %d", n)
+	}
+}
+
+func TestFileCreditRequest_RefileAfterGrant(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-3", "cr3@example.com", 5)
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	id, _, err := s.FileCreditRequest(acc, now)
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	if err := s.ResolveCreditRequest(id, "granted", "+$5 via test"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// The user burned the top-up too: a new episode files a new request.
+	_, filed, err := s.FileCreditRequest(acc, now.Add(48*time.Hour))
+	if err != nil || !filed {
+		t.Fatalf("refile after grant: expected filed, got filed=%v err=%v", filed, err)
+	}
+	if n := countCreditRequests(t, s, acc); n != 2 {
+		t.Errorf("expected 2 requests, got %d", n)
+	}
+}
+
+func TestFileCreditRequest_DismissSilencesMonth(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-4", "cr4@example.com", 5)
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	id, _, err := s.FileCreditRequest(acc, now)
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	if err := s.ResolveCreditRequest(id, "dismissed", ""); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if _, filed, err := s.FileCreditRequest(acc, now.Add(72*time.Hour)); err != nil || filed {
+		t.Fatalf("file after dismiss same month: expected no-op, got filed=%v err=%v", filed, err)
+	}
+
+	// A new month is a fresh episode even after a dismissal.
+	_, filed, err := s.FileCreditRequest(acc, time.Date(2026, 8, 2, 9, 0, 0, 0, time.UTC))
+	if err != nil || !filed {
+		t.Fatalf("file in new month: expected filed, got filed=%v err=%v", filed, err)
+	}
+}
+
+func TestFileCreditRequest_ConcurrentSingleWinner(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-5", "cr5@example.com", 5)
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	const workers = 8
+	var wg sync.WaitGroup
+	filedCount := make(chan bool, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, filed, err := s.FileCreditRequest(acc, now)
+			if err != nil {
+				t.Errorf("concurrent file: %v", err)
+				return
+			}
+			filedCount <- filed
+		}()
+	}
+	wg.Wait()
+	close(filedCount)
+
+	winners := 0
+	for filed := range filedCount {
+		if filed {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Errorf("expected exactly 1 winner, got %d", winners)
+	}
+	if n := countCreditRequests(t, s, acc); n != 1 {
+		t.Errorf("expected 1 request row, got %d", n)
+	}
+}
+
+func TestResolveCreditRequest_Errors(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-6", "cr6@example.com", 5)
+
+	if err := s.ResolveCreditRequest(999999, "granted", ""); err != ErrCreditRequestNotFound {
+		t.Errorf("unknown id: expected ErrCreditRequestNotFound, got %v", err)
+	}
+
+	id, _, err := s.FileCreditRequest(acc, time.Now())
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	if err := s.ResolveCreditRequest(id, "granted", "+$1"); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	if err := s.ResolveCreditRequest(id, "dismissed", ""); err != ErrCreditRequestResolved {
+		t.Errorf("second resolve: expected ErrCreditRequestResolved, got %v", err)
+	}
+}
+
+func TestListCreditRequests_JoinsAccountDisplay(t *testing.T) {
+	s := setupTestStore(t)
+	accA := provisionEndUser(t, s, "cr-7a", "alice@example.com", 5)
+	accB := provisionEndUser(t, s, "cr-7b", "bob@example.com", 5)
+	override := 12.5
+	if err := s.SetMonthlyGrant(accB, &override); err != nil {
+		t.Fatalf("SetMonthlyGrant: %v", err)
+	}
+
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	idA, _, _ := s.FileCreditRequest(accA, now)
+	if _, _, err := s.FileCreditRequest(accB, now.Add(time.Minute)); err != nil {
+		t.Fatalf("file B: %v", err)
+	}
+
+	rows, err := s.ListCreditRequests("pending")
+	if err != nil {
+		t.Fatalf("ListCreditRequests: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 pending rows, got %d", len(rows))
+	}
+	// Newest first.
+	if rows[0].AccountID != accB || rows[1].AccountID != accA {
+		t.Errorf("expected newest-first [B, A], got [%d, %d]", rows[0].AccountID, rows[1].AccountID)
+	}
+	if rows[0].Email == nil || *rows[0].Email != "bob@example.com" {
+		t.Errorf("expected bob email, got %v", rows[0].Email)
+	}
+	if rows[0].MonthlyGrant == nil || *rows[0].MonthlyGrant != 12.5 {
+		t.Errorf("expected override grant 12.5, got %v", rows[0].MonthlyGrant)
+	}
+	if rows[1].MonthlyGrant != nil {
+		t.Errorf("expected nil grant override for A, got %v", *rows[1].MonthlyGrant)
+	}
+	// Provisioned with grant 5 and nothing spent: balance rides along for display.
+	if rows[1].Balance != 5 {
+		t.Errorf("expected balance 5 for A, got %v", rows[1].Balance)
+	}
+
+	if err := s.ResolveCreditRequest(idA, "granted", "+$5"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	granted, err := s.ListCreditRequests("granted")
+	if err != nil {
+		t.Fatalf("list granted: %v", err)
+	}
+	if len(granted) != 1 || granted[0].ID != idA {
+		t.Errorf("expected [%d] granted, got %+v", idA, granted)
+	}
+	if granted[0].ResolvedAt == nil || granted[0].ResolvedNote == nil || *granted[0].ResolvedNote != "+$5" {
+		t.Errorf("expected resolution metadata, got at=%v note=%v", granted[0].ResolvedAt, granted[0].ResolvedNote)
+	}
+}
+
+func TestGetCreditRequestInfo(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-8", "carol@example.com", 5)
+	// Burn the whole allowance so the cap-hit state is realistic.
+	if err := s.AddCredits(acc, -5, "test burn"); err != nil {
+		t.Fatalf("burn: %v", err)
+	}
+
+	id, _, err := s.FileCreditRequest(acc, time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+
+	info, err := s.GetCreditRequestInfo(id)
+	if err != nil {
+		t.Fatalf("GetCreditRequestInfo: %v", err)
+	}
+	if info.AccountID != acc {
+		t.Errorf("account: expected %d, got %d", acc, info.AccountID)
+	}
+	if info.Email == nil || *info.Email != "carol@example.com" {
+		t.Errorf("email: got %v", info.Email)
+	}
+	if info.DisplayName == nil || *info.DisplayName != "Test User" {
+		t.Errorf("display name: got %v", info.DisplayName)
+	}
+	if info.MonthlyGrant != nil {
+		t.Errorf("expected nil grant override, got %v", *info.MonthlyGrant)
+	}
+	if info.Balance != 0 {
+		t.Errorf("expected balance 0, got %v", info.Balance)
+	}
+	if info.Period.Format("2006-01-02") != "2026-07-01" {
+		t.Errorf("period: got %s", info.Period.Format("2006-01-02"))
+	}
+
+	if _, err := s.GetCreditRequestInfo(999999); err == nil {
+		t.Error("expected error for unknown request id")
+	}
+}

--- a/internal/store/credit_requests_test.go
+++ b/internal/store/credit_requests_test.go
@@ -83,7 +83,7 @@ func TestFileCreditRequest_RefileAfterGrant(t *testing.T) {
 	if err != nil {
 		t.Fatalf("file: %v", err)
 	}
-	if err := s.ResolveCreditRequest(id, "granted", "+$5 via test"); err != nil {
+	if err := s.ResolveCreditRequest(id, "granted", "+$5 via test", time.Now()); err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func TestFileCreditRequest_DismissSilencesMonth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("file: %v", err)
 	}
-	if err := s.ResolveCreditRequest(id, "dismissed", ""); err != nil {
+	if err := s.ResolveCreditRequest(id, "dismissed", "", time.Now()); err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 
@@ -162,7 +162,7 @@ func TestResolveCreditRequest_Errors(t *testing.T) {
 	s := setupTestStore(t)
 	acc := provisionEndUser(t, s, "cr-6", "cr6@example.com", 5)
 
-	if err := s.ResolveCreditRequest(999999, "granted", ""); err != ErrCreditRequestNotFound {
+	if err := s.ResolveCreditRequest(999999, "granted", "", time.Now()); err != ErrCreditRequestNotFound {
 		t.Errorf("unknown id: expected ErrCreditRequestNotFound, got %v", err)
 	}
 
@@ -170,10 +170,10 @@ func TestResolveCreditRequest_Errors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("file: %v", err)
 	}
-	if err := s.ResolveCreditRequest(id, "granted", "+$1"); err != nil {
+	if err := s.ResolveCreditRequest(id, "granted", "+$1", time.Now()); err != nil {
 		t.Fatalf("first resolve: %v", err)
 	}
-	if err := s.ResolveCreditRequest(id, "dismissed", ""); err != ErrCreditRequestResolved {
+	if err := s.ResolveCreditRequest(id, "dismissed", "", time.Now()); err != ErrCreditRequestResolved {
 		t.Errorf("second resolve: expected ErrCreditRequestResolved, got %v", err)
 	}
 }
@@ -193,7 +193,7 @@ func TestListCreditRequests_JoinsAccountDisplay(t *testing.T) {
 		t.Fatalf("file B: %v", err)
 	}
 
-	rows, err := s.ListCreditRequests("pending")
+	rows, err := s.ListCreditRequests("pending", time.Now())
 	if err != nil {
 		t.Fatalf("ListCreditRequests: %v", err)
 	}
@@ -218,10 +218,10 @@ func TestListCreditRequests_JoinsAccountDisplay(t *testing.T) {
 		t.Errorf("expected balance 5 for A, got %v", rows[1].Balance)
 	}
 
-	if err := s.ResolveCreditRequest(idA, "granted", "+$5"); err != nil {
+	if err := s.ResolveCreditRequest(idA, "granted", "+$5", time.Now()); err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	granted, err := s.ListCreditRequests("granted")
+	granted, err := s.ListCreditRequests("granted", time.Now())
 	if err != nil {
 		t.Fatalf("list granted: %v", err)
 	}
@@ -230,6 +230,69 @@ func TestListCreditRequests_JoinsAccountDisplay(t *testing.T) {
 	}
 	if granted[0].ResolvedAt == nil || granted[0].ResolvedNote == nil || *granted[0].ResolvedNote != "+$5" {
 		t.Errorf("expected resolution metadata, got at=%v note=%v", granted[0].ResolvedAt, granted[0].ResolvedNote)
+	}
+}
+
+func TestListCreditRequests_StalePendingExpires(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-9", "stale@example.com", 5)
+
+	july := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	august := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	id, _, err := s.FileCreditRequest(acc, july)
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+
+	// Listing in August: the July request stops being actionable — the
+	// allowance has reset, so granting against it would be a double grant.
+	pending, err := s.ListCreditRequests("pending", august)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("expected no actionable requests after rollover, got %+v", pending)
+	}
+	expired, err := s.ListCreditRequests("expired", august)
+	if err != nil {
+		t.Fatalf("list expired: %v", err)
+	}
+	if len(expired) != 1 || expired[0].ID != id {
+		t.Fatalf("expected the July request expired, got %+v", expired)
+	}
+	if expired[0].ResolvedNote == nil || *expired[0].ResolvedNote != "expired at month rollover" {
+		t.Errorf("expected rollover note, got %v", expired[0].ResolvedNote)
+	}
+}
+
+func TestResolveCreditRequest_StalePeriodRefused(t *testing.T) {
+	s := setupTestStore(t)
+	acc := provisionEndUser(t, s, "cr-10", "stale2@example.com", 5)
+
+	july := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	august := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	id, _, err := s.FileCreditRequest(acc, july)
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+
+	// Resolving directly (an old Discord card) without any listing having
+	// run the lazy expiry first: still refused, and the row is expired.
+	if err := s.ResolveCreditRequest(id, "granted", "+$5", august); err != ErrCreditRequestExpired {
+		t.Fatalf("expected ErrCreditRequestExpired, got %v", err)
+	}
+	expired, err := s.ListCreditRequests("expired", august)
+	if err != nil || len(expired) != 1 || expired[0].ID != id {
+		t.Errorf("expected row expired after stale resolve, got %+v err=%v", expired, err)
+	}
+
+	// A fresh August request on the same account resolves normally.
+	id2, filed, err := s.FileCreditRequest(acc, august)
+	if err != nil || !filed {
+		t.Fatalf("august file: filed=%v err=%v", filed, err)
+	}
+	if err := s.ResolveCreditRequest(id2, "granted", "+$5", august); err != nil {
+		t.Errorf("august resolve: %v", err)
 	}
 }
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -325,3 +325,27 @@ CREATE INDEX IF NOT EXISTS idx_federated_identities_account
 -- per-account owning-user email lookup filters users on account_id.
 CREATE INDEX IF NOT EXISTS idx_users_account
     ON users(account_id, id);
+
+-- ---------------------------------------------------------------------------
+-- Credit requests (docs/design/credit-requests.md): auto-filed on the first
+-- monthly_limit_reached 402 of a cap-hit episode. Filing policy per
+-- (account, UTC month): a pending row dedupes, a dismissed row silences the
+-- rest of the month, granted rows allow re-filing (each episode gets one).
+
+CREATE TABLE IF NOT EXISTS credit_requests (
+    id            BIGSERIAL PRIMARY KEY,
+    account_id    BIGINT NOT NULL REFERENCES accounts(id),
+    period        DATE NOT NULL,      -- first day of the UTC month, like allowance_period
+    status        TEXT NOT NULL DEFAULT 'pending',  -- pending | granted | dismissed
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at   TIMESTAMPTZ,
+    resolved_note TEXT
+);
+
+-- Race-safety for concurrent 402s: only one pending row can exist per
+-- account+month, so the losing inserter's ON CONFLICT no-ops.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credit_requests_pending
+    ON credit_requests(account_id, period) WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_credit_requests_status
+    ON credit_requests(status, created_at);

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -37,6 +37,7 @@ func setupTestStore(t *testing.T) *Store {
 		_, _ = s.pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = s.pool.Exec(c, "DELETE FROM users")
 		_, _ = s.pool.Exec(c, "DELETE FROM federated_identities")
+		_, _ = s.pool.Exec(c, "DELETE FROM credit_requests")
 		_, _ = s.pool.Exec(c, "DELETE FROM accounts")
 	}
 
@@ -79,6 +80,7 @@ func TestNew(t *testing.T) {
 		_, _ = s.pool.Exec(c, "DELETE FROM api_keys")
 		_, _ = s.pool.Exec(c, "DELETE FROM users")
 		_, _ = s.pool.Exec(c, "DELETE FROM federated_identities")
+		_, _ = s.pool.Exec(c, "DELETE FROM credit_requests")
 		_, _ = s.pool.Exec(c, "DELETE FROM accounts")
 		s.Close()
 	})

--- a/internal/user/authlimit_integration_test.go
+++ b/internal/user/authlimit_integration_test.go
@@ -43,6 +43,7 @@ func setupGuardedUserTest(t *testing.T, cfg authlimit.Config) (http.Handler, *au
 		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
 		_, _ = s.Pool().Exec(c, "DELETE FROM users")
 		_, _ = s.Pool().Exec(c, "DELETE FROM federated_identities")
+		_, _ = s.Pool().Exec(c, "DELETE FROM credit_requests")
 		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/user/handler_metrics_test.go
+++ b/internal/user/handler_metrics_test.go
@@ -42,6 +42,7 @@ func setupUserMetricsTest(t *testing.T) (http.Handler, *store.Store, *metrics.Me
 		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
 		_, _ = s.Pool().Exec(c, "DELETE FROM users")
 		_, _ = s.Pool().Exec(c, "DELETE FROM federated_identities")
+		_, _ = s.Pool().Exec(c, "DELETE FROM credit_requests")
 		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
 	}
 	wipe()

--- a/internal/user/handler_test.go
+++ b/internal/user/handler_test.go
@@ -41,6 +41,7 @@ func setupUserTest(t *testing.T) (http.Handler, *store.Store) {
 		_, _ = s.Pool().Exec(c, "DELETE FROM api_keys")
 		_, _ = s.Pool().Exec(c, "DELETE FROM users")
 		_, _ = s.Pool().Exec(c, "DELETE FROM federated_identities")
+		_, _ = s.Pool().Exec(c, "DELETE FROM credit_requests")
 		_, _ = s.Pool().Exec(c, "DELETE FROM accounts")
 	}
 


### PR DESCRIPTION
## Problem

End users who exhaust their monthly allowance hit a dead-end 402 (`monthly_limit_reached`) in chat — no way to request more credits, and the admin is never told anyone is blocked.

## What this adds (phase BE-1 of docs/design/credit-requests.md)

- **`credit_requests` table** — auto-filed on the first `monthly_limit_reached` 402 of a cap-hit episode. Filing policy per (account, UTC month): pending dedupes (partial unique index elects one winner among concurrent 402s), dismissed silences the rest of the month, granted allows re-filing.
- **`creditrequest.Recorder`** — async cap-hit recording wired into both 402 sites (credit-gate pre-check + reserve failure). Fire-and-forget webhook to `CREDIT_ALERT_WEBHOOK_URL` (validated at boot; empty = record-only) with one retry; the table is the source of truth, so a lost notification self-heals via bot reconcile / admin listing.
- **Actionable 402** — allowance-managed message now says the admin has been notified.
- **Admin API** — `GET /api/admin/credit-requests` (status filter defaulting to pending, list envelope, account/email/effective-grant/balance join) and `PUT /api/admin/credit-requests/{id}` (`granted`/`dismissed`, 409 `already_resolved`). Resolution never moves money — grants go through the existing audited credits endpoint first.
- **`effective_monthly_grant`** on the accounts listing (override resolved against the env default server-side, null for non-managed accounts).

## Testing

TDD: 23 new tests (store filing policy incl. concurrency single-winner, recorder webhook delivery/retry/dedupe, both 402 sites, admin HTTP surface, config validation). Full suite: 942 green with `-race -count=1 -p 1`.

Rollout: deploy with `CREDIT_ALERT_WEBHOOK_URL` unset → detection + admin API live, no Discord traffic. BOT-2 (Discord card) and FE-3 (admin UI) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe