### PR TITLE
Enable credit-request webhook env on the proxy deployment

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -53,6 +53,11 @@ spec:
                   optional: true
             - name: LOG_LEVEL
               value: "info"
+            # Cap-hit notifications → Discord bot (docs/design/credit-requests.md).
+            # Remove (or empty) to disable notifications; requests are still
+            # recorded in credit_requests either way.
+            - name: CREDIT_ALERT_WEBHOOK_URL
+              value: "http://openwebui-discord-bot.openwebui.svc.cluster.local:8080/credit-request"
           livenessProbe:
             httpGet:
               path: /api/healthz/live

--- a/docs/design/credit-requests.md
+++ b/docs/design/credit-requests.md
@@ -145,9 +145,12 @@ Extends `local-ai-chat/discord-approval-bot/` (same deployment):
 - Startup reconcile: `GET /api/admin/credit-requests?status=pending` → announce any
   request whose marker is absent from recent channel history.
 - New env/secrets: `PROXY_ADMIN_URL` (`http://ai-proxy.local-ai.svc.cluster.local`),
-  `PROXY_ADMIN_KEY` (a dedicated admin key minted for the bot, stored in a k8s
-  secret + the repo-external secrets dir, per convention). Admin rate limit
-  (10 req/min) is far above bot traffic.
+  `PROXY_ADMIN_KEY` in the bot's k8s secret. The proxy has a single admin key
+  (no scoped admin keys exist), so this is the proxy's ADMIN_KEY copied
+  secret-to-secret on the cluster — the bot pod already holds OpenWebUI admin
+  credentials, so its trust level is unchanged. Revisit with scoped admin keys
+  if a third consumer ever needs one. Admin rate limit (10 req/min) is far
+  above bot traffic.
 
 ## 6. Admin console (FE-3, folds in the FE-4 allowance-editor remainder)
 


### PR DESCRIPTION
Rollout step 3 of `docs/design/credit-requests.md`: sets `CREDIT_ALERT_WEBHOOK_URL` on the ai-proxy deployment, pointing at the Discord bot's internal service. Also documents that `PROXY_ADMIN_KEY` for the bot is the proxy's single ADMIN_KEY copied secret-to-secret on-cluster (no scoped admin keys exist).

**Merge order**: only after the extended bot (BOT-2) is deployed and healthy — until then the backend keeps recording cap-hits with notifications disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe