### PR TITLE
Per-account rate limiting (phases A+B: core limiter + override)

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -207,14 +207,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	limiter := ratelimit.New()
+	// Two limiter instances, deliberately separate: key IDs and account IDs
+	// share the int64 space, so one map would collide key #7 with account #7
+	// (docs/design/per-account-rate-limiting.md §3.1).
+	keyLimiter := ratelimit.New()
+	accountLimiter := ratelimit.New()
 	capHits := creditrequest.New(db, cfg.CreditAlertWebhookURL, cfg.EndUserMonthlyGrant)
 	proxyHandler := proxy.NewHandler(reg, usageCh, cfg.MaxRequestBody, db, m,
 		proxy.Options{ModelsListAll: cfg.ModelsListAll, CapHits: capHits})
 	authMiddleware := auth.Middleware(db)
 	billingResolver := billing.Middleware(db, cfg.EndUserMonthlyGrant)
 	creditGate := credits.CreditGate(db, m, capHits)
-	rateLimitMiddleware := ratelimit.Middleware(limiter, m)
+	rateLimitMiddleware := ratelimit.Middleware(keyLimiter, accountLimiter, ratelimit.Limits{
+		EndUserPerMin: cfg.EndUserRateLimitPerMin,
+		ServicePerMin: cfg.AccountRateLimitPerMin,
+	}, m)
 	cors := middleware.CORS(cfg.CORSOrigins)
 
 	// Brute-force / bcrypt-DoS protection for the public auth surface.
@@ -251,6 +258,8 @@ func main() {
 		AuthRegisterRateLimitPerMinute:   cfg.AuthRegisterPerMinIP,
 		AuthGeneralRateLimitPerMinute:    cfg.AuthGeneralPerMinIP,
 		AuthBcryptMaxConcurrent:          cfg.AuthBcryptConcurrency,
+		AccountRateLimitPerMinute:        cfg.AccountRateLimitPerMin,
+		EndUserRateLimitPerMinute:        cfg.EndUserRateLimitPerMin,
 		UsageChannelCapacity:             usageChannelCapacity,
 		AdminSessionDurationHrs:          int(user.AdminSessionDuration / time.Hour),
 		UserSessionDurationHrs:           int(user.UserSessionDuration / time.Hour),
@@ -271,6 +280,8 @@ func main() {
 
 		AdminServiceCreditGrant: cfg.AdminServiceCreditGrant,
 		EndUserMonthlyGrant:     cfg.EndUserMonthlyGrant,
+		AccountRateLimitPerMin:  cfg.AccountRateLimitPerMin,
+		EndUserRateLimitPerMin:  cfg.EndUserRateLimitPerMin,
 	})
 	bootstrapHandler := bootstrap.New(db, cfg.AdminBootstrapToken, m)
 	userHandler := user.NewHandler(db, cfg.DefaultCreditGrant, m, authGuard)
@@ -282,11 +293,15 @@ func main() {
 	mux.HandleFunc("GET /api/healthz/ready", hc.ReadyHandler)
 	mux.HandleFunc("GET /api/healthz", hc.LiveHandler) // backward compat alias
 
-	// Client API — CORS + auth + billing resolution + credit gate + rate limit
-	// + proxy (instrumented). Billing MUST precede the credit gate: the gate
-	// pre-checks the resolved billing account, not the key's own account
-	// (docs/design/end-user-accounts.md §4).
-	mux.Handle("/api/v1/", m.InstrumentHandler(cors(authMiddleware(billingResolver(creditGate(rateLimitMiddleware(proxyHandler)))))))
+	// Client API — CORS + auth + billing resolution + rate limit + credit
+	// gate + proxy (instrumented). Billing MUST precede both gates: they act
+	// on the resolved billing account, not the key's own account
+	// (docs/design/end-user-accounts.md §4). Rate limit precedes the credit
+	// gate so 402-spam cannot drive unthrottled per-request credit-status
+	// queries; consequence: an over-cap AND over-rate account sees 429, and
+	// cap-hit recording (the credit-request trigger) fires on its first
+	// rate-passing request (docs/design/per-account-rate-limiting.md §3.3).
+	mux.Handle("/api/v1/", m.InstrumentHandler(cors(authMiddleware(billingResolver(rateLimitMiddleware(creditGate(proxyHandler)))))))
 
 	// Metrics endpoint — unauthenticated, cluster-internal only
 	mux.Handle("GET /metrics", m.Handler())

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -58,6 +58,17 @@ spec:
             # recorded in credit_requests either way.
             - name: CREDIT_ALERT_WEBHOOK_URL
               value: "http://openwebui-discord-bot.openwebui.svc.cluster.local:8080/credit-request"
+            # Account-level rate limits (docs/design/per-account-rate-limiting.md).
+            # Per-account override: accounts.rate_limit_per_min via
+            # PUT /api/admin/accounts/{id}/rate-limit. Runbook: the shared
+            # Open WebUI key's per-key limit (120/min) is the aggregate
+            # ceiling — raise it via PUT /api/admin/keys/{id}/rate-limit as
+            # headcount grows (>4 concurrently active users at 30/min each
+            # will collectively starve at 120/min).
+            - name: ACCOUNT_RATELIMIT_PER_MIN
+              value: "300"
+            - name: END_USER_RATELIMIT_PER_MIN
+              value: "30"
           livenessProbe:
             httpGet:
               path: /api/healthz/live

--- a/docs/design/per-account-rate-limiting.md
+++ b/docs/design/per-account-rate-limiting.md
@@ -1,0 +1,365 @@
+# Per-Account Rate Limiting
+
+Status: accepted (2026-07-21 — Krishna approved the §8 recommendations as written:
+30/min end-user default, shared-key ceiling stays 120/min with a runbook note,
+/models keeps consuming rate tokens, chain reorder accepted with regression test,
+grandfathering audit pre-deploy, concurrency defaults 5/8 env-only)
+Author: Claude, synthesized from three design explorations + cross-review
+
+## 1. Problem & abuse model
+
+Rate limiting today is keyed on the **API key**, but the billing/fairness entity is the
+**account**. That mismatch produces two inverse holes, plus a gap no req/min limit covers:
+
+- **Scenario 1 — key multiplication.** A service account with N keys gets N× the per-key
+  limit. Per-key buckets can never fix this; the ceiling must live on the account.
+- **Scenario 2 — shared-key starvation.** All Open WebUI end users arrive on ONE trusted
+  service key (prod: 120 req/min). One user hammering the key 429s everyone; there is no
+  per-user isolation at all. End users are auto-provisioned accounts, so keying on the
+  account gives each user a private bucket for free.
+- **Scenario 3 — streaming occupancy.** The scarce resource is GPU inference capacity, and
+  a req/min limit does not bound it: one account can open its whole minute budget as
+  simultaneous long-lived SSE streams (`WriteTimeout=0`, per-node timeout default 5 min).
+  Requests/min bounds arrival rate, not occupancy. A per-account concurrent-stream cap does.
+- **Scenario 4 — NOT fixed (say so honestly).** A scripted client grinding steadily inside
+  its own limits is not stopped by any rate limiter. Credits bound its spend; account
+  deactivation (existing creditGate 403) is the kill-switch; metrics make it visible.
+  Do not oversell this feature as abuse-proof.
+
+Constraint that shapes every default: Open WebUI fires **2–4 upstream completions per
+visible chat message** (title/tag/follow-up generation) plus `/models` fetches. Limits
+sized for "one request per message" break normal UX opaquely — background tasks fail with
+raw error strings surfaced in the UI.
+
+## 2. Current state
+
+- **Chat chain** (`cmd/proxy/main.go:289`): `cors(auth(billingResolver(creditGate(rateLimit(proxy)))))`.
+  Rate limiting already runs after billing resolution, so `billing.Resolution
+  {AccountID, AllowanceManaged}` (`internal/billing/billing.go`) is in context at
+  rate-limit time. **The keying change needs zero new per-request DB reads.**
+- **Per-key limiter** (`internal/ratelimit/ratelimit.go`): in-memory token bucket keyed on
+  `api_keys.id`, per-key `rate_limit` column, capacity = limit, refill = limit/60
+  tokens/sec, new bucket seeds capacity−1, 1-min prune ticker / 10-min idle cutoff, 429
+  with Retry-After. Nil key passes through (`ratelimit.go:100-104`). Tests use
+  `time.Sleep` (no injectable clock yet).
+- **`internal/authlimit`**: keyed limiters (per-IP / per-email) guarding the public auth
+  surface; documents the single-replica in-memory assumption (`authlimit.go:8-9`) and has
+  the two patterns we reuse: injectable clock (`NewWithClock`) and the bcrypt counting
+  semaphore (`authlimit.go:192-213`).
+- **No concurrency bound anywhere** on `/api/v1/`.
+- House style for per-account settings: `accounts.monthly_grant` nullable override +
+  `PUT /api/admin/accounts/{id}/allowance` + admin-UI AllowanceDialog
+  (`internal/store/federated.go:217-229`, schema guard at `schema.sql:281-285`).
+
+## 3. Recommended design
+
+Three explorations (minimal / robust / abuse-model) were cross-reviewed by three judges who
+split 1-1-1. The synthesis below takes **minimal's** phasing, plumbing, and refund
+mechanics, **robust's** concurrency semaphore and correctness details, and
+**abuse-model's** scenario framing and 429 message UX. Judge disagreements are resolved
+inline, with reasons.
+
+### 3.1 Keying and classes
+
+Add a **second, separate `Limiter` instance** inside `internal/ratelimit` (not the same
+map — key IDs and account IDs share the int64 space; one map would collide key #7 with
+account #7). Same lazy-refill token bucket as today; capacity/refill rewritten on every
+`Allow` call so limit changes apply on the next request. While touching the package,
+retrofit injectable `nowFn` (`NewWithClock`, the authlimit pattern) into both limiters to
+kill the `time.Sleep` tests.
+
+- Bucket key: `billing.Resolution.AccountID` via `billing.FromContext` — never `key.ID` or
+  `key.AccountID`, because the shared trusted key resolves a *different* end-user account
+  per request.
+- Class discriminator: `Resolution.AllowanceManaged` — **not** `key.TrustUserHeaders` (a
+  trusted key without forwarded headers bills its own service account).
+- Effective limit = per-account override if non-NULL, else `END_USER_RATELIMIT_PER_MIN`
+  when AllowanceManaged, else `ACCOUNT_RATELIMIT_PER_MIN`. This override-else-class-default
+  resolution lives in **one exported helper in `ratelimit`** that the limiter, admin
+  `listAccounts`, and any future site all call — the logic is already duplicated twice for
+  monthly_grant; do not ship a third copy.
+- Fallbacks, stated precisely: `Resolution.AccountID` is a non-pointer int64; the only
+  guard is `FromContext`'s ok bool. Missing Resolution → per-key bucket only. **This path
+  is reachable in prod**, not test-only: billing attaches no Resolution for legacy
+  nil-account keys, which under the new chain order consume a key token and then 403 at
+  creditGate. Nil key → pass through, unchanged.
+
+### 3.2 Check order and refund semantics (judges disagreed; resolved)
+
+Every `/api/v1/` request passes gates in this order, centralized in one exported
+`CheckAll`-style function so ordering and unwinding are tested in one place:
+
+1. **Account bucket** `Allow(accountID, effectiveLimit)` — reject → 429. Account-first is
+   load-bearing: a throttled user's rejects must never drain the shared key's aggregate
+   bucket.
+2. **Key bucket** `Allow(key.ID, key.RateLimit)` — unchanged semantics. Reject → 429 **and
+   refund the account token** (`Limiter.Return(id)`: `tokens = min(capacity, tokens+1)`,
+   ~10 lines, clamped at capacity, property-tested `tokens ≤ capacity`). The refund is not
+   optional polish: on the shared Open WebUI key the key bucket belongs to the *service
+   key* and the account bucket to the *individual end user* — different owners. Without
+   the refund, aggregate saturation burns every innocent user's personal budget on
+   requests that never ran, and their Retry-After is a lie. (abuse-model's "both budgets
+   belong to the same account, skip refunds" rests on a false premise; two judges
+   confirmed. Do not delete `Return()` as needless complexity — this paragraph is why it
+   exists.)
+3. **Concurrency semaphore** (non-GET only) `TryAcquire(accountID, classCap)` — a mutexed
+   `map[int64]int` (keyed generalization of the bcrypt semaphore), entries deleted at
+   zero. Reject → 429. **No refund on concurrency reject** — resolved deliberately: a
+   full refund would let a client busy-poll the semaphore at zero cost; consuming one
+   account rate token bounds the poll rate, and it is the polling client's own budget.
+   `Release` in the middleware's **outermost defer** after `next.ServeHTTP` returns —
+   `handleStreaming` runs synchronously inside the handler (no Hijack path), so this
+   correctly covers full stream lifetime, client disconnects, and panics. GETs
+   (`/api/v1/models`) consume rate tokens (abuse bound) but never a concurrency slot
+   (they don't occupy GPU).
+
+Net effect: multi-key service accounts are bounded by one account bucket (Scenario 1
+closed); each Open WebUI user gets a private bucket and stream cap (Scenarios 2 and 3
+closed); the shared key's per-key bucket remains as the deliberate **aggregate ceiling**.
+
+**Keep the per-key check for end-user traffic — it is load-bearing, not legacy.** New
+buckets seed capacity−1, so an attacker rotating forged `X-OpenWebUI-User-Id` values mints
+a fresh near-full 30-token bucket per identity. The shared key's per-key bucket is the only
+aggregate bound that makes identity-rotation unprofitable. Raise it via the existing
+`PUT /api/admin/keys/{id}/rate-limit` as headcount grows (runbook: >4 simultaneously
+active users at 30/min each will collectively starve at 120/min).
+
+### 3.3 Middleware placement
+
+One-line chain swap: `cors(auth(billingResolver(rateLimit(creditGate(proxy)))))`. The
+limiter needs Resolution so it cannot move earlier than billingResolver; moving it before
+creditGate shields the per-request credit-status query from unthrottled 402-spam.
+
+**Known interaction, decided deliberately:** `RecordCapHit` — the trigger for the
+just-shipped Discord credit-request flow — fires only inside creditGate's 402 branch
+(`internal/credits/middleware.go:65`). Under the new order, an over-cap end user who is
+*also* over-rate sees 429s and never files a top-up request. **Accepted**: cap-hit
+recording fires on the first request that passes the rate gates, which a capped-but-human
+user will produce within seconds; the alternative (recording cap-hits from the limiter
+path) couples the limiter to billing state for no real gain. A regression test must pin
+that the credit-request auto-trigger still fires for rate-passing over-cap requests.
+
+### 3.4 429 + Retry-After semantics
+
+- Emit via `apierror.WriteError` — it produces the identical OpenAI envelope
+  `{"error":{message, type, code}}` that creditGate and billing already use on `/api/v1/`
+  (minimal's "SDKs will mis-parse apierror" rationale was checked and is wrong).
+- `type`/`code` stay `rate_limit_exceeded` for **all three** gates — SDK parsers key on
+  these; a novel code buys nothing (resolves robust's separate `concurrency_limit_exceeded`
+  code against abuse-model's keep-identical graft).
+- **Human messages are scope-differentiated** — Open WebUI surfaces the raw message string,
+  and identical bodies make background title/tag failures undiagnosable:
+  - `"Rate limit exceeded for your account (30 req/min); retry in 4s"`
+  - `"Rate limit exceeded for this API key (120 req/min); retry in 2s"`
+  - `"Too many concurrent requests for your account (max 5); retry shortly"`
+- Retry-After = `ceil((1−tokens)/refillRate)` from whichever bucket rejected, floor 1s.
+  Truthful because of the refund rule. Concurrency rejects send fixed `Retry-After: 5`
+  (advisory — stream end time is unknowable). OpenAI SDKs auto-retry 429s honoring
+  Retry-After, so accuracy matters to avoid retry storms.
+
+### 3.5 Metrics
+
+- New nil-safe counter `aiproxy_account_ratelimit_rejects_total{kind="rate"|"concurrency",
+  class="enduser"|"service"}` — bounded vocabulary, **no account_id label** (cardinality
+  rule). The class label answers "are the defaults too tight for end users?" straight from
+  Prometheus.
+- Legacy `aiproxy_ratelimit_rejects_total` keeps counting **key-level** rejects only — the
+  two counters partition rejects by gate, no double-counting; the new counter is
+  authoritative for account-level throttling.
+- Unlabeled gauge `aiproxy_streams_inflight` — answers "is GPU occupancy saturated right
+  now" for free once the semaphore exists.
+
+### 3.6 State and deploys
+
+In-memory, single-replica — the documented house assumption (`authlimit.go:8-9`),
+restated here. Buckets reset to near-full on every deploy and 10-min idle prune (a free
+burst; accepted). RollingUpdate maxSurge briefly runs two pods with independent buckets —
+a seconds-long 2× window. **Accepted rather than set `maxSurge: 0`**, which implies
+`maxUnavailable: 1`, i.e. brief downtime on every deploy — the wrong trade for a homelab.
+Concurrency counters reset *correctly* by construction: in-flight streams die with the pod
+(10s graceful shutdown) — a genuine advantage of the semaphore over any persisted design.
+
+Deferred multi-replica path: keep the state behind thin seams
+(`Allow(id, limit) (ok, retryAfter)`, `Return(id)`, `TryAcquire(id, cap)`/`Release(id)`);
+a v2 Postgres fixed-window counter (`INSERT … ON CONFLICT DO UPDATE … RETURNING`) exists
+as a sketch only — note its caveats before anyone adopts it blind: 2× burst at window
+boundaries and one DB write per request. Distributed *concurrency* limiting is deliberately
+not promised (crash-leaked slots); scaling out requires revisiting this doc, not flipping
+`replicas: 2`.
+
+Bucket `capacity` and `refillRate` are already independent fields, so a future
+`ACCOUNT_RATELIMIT_BURST` knob is a config addition, not a redesign.
+
+## 4. Config & schema
+
+### 4.1 Env (parsed in `internal/config/config.go`, boot-fail on invalid per the `intEnvOrDefault` house style — silently disabling a security limit is worse than failing to boot)
+
+| Var | Default | Applies to |
+|---|---|---|
+| `ACCOUNT_RATELIMIT_PER_MIN` | **300** | service accounts (`AllowanceManaged=false`) |
+| `END_USER_RATELIMIT_PER_MIN` | **30** | end-user accounts (`AllowanceManaged=true`) |
+| `ACCOUNT_MAX_CONCURRENT` | **8** | service accounts, non-GET in-flight |
+| `END_USER_MAX_CONCURRENT` | **5** | end-user accounts, non-GET in-flight |
+
+- Range 1..10000 (concurrency 1..100); zero/negative/non-numeric refuse to boot. **No
+  `0=disabled` semantic** (that is authlimit's convention, rejected here) — to effectively
+  disable, set the max.
+- 300 (not robust's 120) for services: generous so existing multi-key accounts mostly
+  don't break on day one, but finally bounded. 30 (not the earlier 20) for end users:
+  Open WebUI's 2–4 upstream calls per message plus `/models` fetches make 30/min ≈ 7–10
+  visible messages/min; 20 ≈ 5–7 and risks breaking background tasks.
+- `END_USER_MAX_CONCURRENT=5`, not robust's 3: one visible message = 1 visible stream +
+  2–4 parallel background completions; 3 can trip on a *single send*.
+- All four surfaced read-only in the admin config view — which requires **all three**
+  wiring points or the value stays invisible: `config.go` parse, the ConfigSnapshot
+  whitelist (`internal/admin/config_health.go:15-43`), and the literal assignment in
+  `cmd/proxy/main.go:239-262`.
+
+### 4.2 Schema (Phase B)
+
+One nullable column, monthly_grant recipe, with minimal's name to avoid the
+`api_keys.rate_limit` collision inside the very JOINs we add:
+
+```sql
+DO $$ BEGIN
+    ALTER TABLE accounts ADD COLUMN rate_limit_per_min INTEGER;
+EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+```
+
+NULL = class env default. No backfill (NULL is correct initially). No `max_concurrent`
+column in v1 — concurrency is env-only until a concrete account needs a bespoke cap.
+
+Override plumbing rides existing queries — no new per-request query paths: join
+`accounts.rate_limit_per_min` into `GetKeyByHash` (`store.go:307-322`, service path) and
+into the accounts SELECT inside `ResolveEndUserAccount` (`federated.go:163-179`, end-user
+path); carry it as `Resolution.RateLimitPerMin *int`. Honest caveat (a judge caught the
+"zero plumbing" overstatement): the end-user SELECT lives inside `applyMonthlyAllowance`,
+whose signature/return must widen to carry the value out — small but real work, counted in
+the estimate. Unlike monthly_grant's next-reset latency, overrides apply on the **next
+request** (both carrier queries run per-request; `Allow` rewrites capacity/refill).
+
+### 4.3 Admin API/UI (monthly_grant recipe, cloned end-to-end)
+
+- `PUT /api/admin/accounts/{id}/rate-limit`, body `{"rate_limit_per_min": number|null}`
+  via `json.RawMessage`: absent field → 400; explicit null → clear override; value
+  validated 1..10000. **Explicit 0 rejected with 400** — resolved against abuse-model's
+  `0=blocked` kill-switch: blocking is the job of credits and account deactivation
+  (creditGate already 403s inactive accounts), and a 429-based block invites SDK
+  auto-retry hammering forever; a third zero-semantic (column-0=blocked vs
+  monthly_grant-0=blocked vs validate.go-0=default) is a maintenance trap.
+  `RowsAffected==0` → 404. `Store.SetAccountRateLimit` mirrors `SetMonthlyGrant`
+  (`federated.go:217-229`).
+- `listAccounts` DTO gains `rate_limit_per_min` + `effective_rate_limit_per_min` (handler
+  already selects `allowance_managed`; class defaults threaded via admin Options like
+  `endUserMonthlyGrant`), both computed through the shared resolver helper.
+- FE: `RateLimitDialog` cloned from AllowanceDialog (Apply = override / Use default = null
+  / Cancel; "(default)" vs "(override)" marker), rate-limit column in the accounts table,
+  `useSetRateLimit` mutation invalidating `qk.accounts.all`, Zod fields, MSW
+  handlers + fixtures. Per-key `PUT /api/admin/keys/{id}/rate-limit` stays untouched.
+
+## 5. Alternatives considered & rejected
+
+- **Env-only, defer concurrency entirely (minimal's cut).** Cheapest diff, but it defers
+  the only control that bounds GPU occupancy — the stated scarce resource — to an
+  appetite question. Rejected; concurrency ships in v1 as its own severable phase, in the
+  cheap form (env-only, no column, no FE).
+- **Override=0 as abuse kill-switch (abuse-model).** Duplicates the existing account-
+  deactivation 403 with the wrong status code; 429 + Retry-After: 60 means SDKs politely
+  hammer a blocked account forever, each attempt still paying auth + billing queries
+  including the per-request `federated_identities.last_seen_at` write. Rejected.
+- **Full `GET /api/v1/models` exemption (abuse-model).** GPU-wise sound (serves from the
+  in-memory node snapshot + a pricing SELECT), but it reopens an unthrottled authed path
+  doing per-request billing DB work. Rejected for v1; kept token-consuming, slot-exempt
+  (§8 Q3).
+- **No refunds ("don't engineer refund complexity", abuse-model).** Rests on the false
+  premise that key and account buckets share an owner; false exactly for the shared-key
+  end-user case this feature exists for. Rejected — see §3.2.
+- **`GET /api/admin/ratelimit/hot` top-throttled panel (abuse-model).** Unimplementable
+  as specified: reject counts are pruned with the 10-min-*idle* bucket, so the counter is
+  cumulative for hot buckets and the abuser vanishes 10 minutes after stopping — exactly
+  when you go look. The class-labeled Prometheus counter covers the tuning question;
+  per-account visibility deferred until a real need defines retention.
+- **Per-account `max_concurrent` column + combined Limits dialog (robust).** Admin
+  surface no concrete account has earned. Env-only per-class caps in v1.
+- **Postgres fixed-window limiter in v1 (robust's reserved path).** Speculative
+  scaffolding for a single-replica deployment. Deferred with caveats labeled (§3.6).
+- **Hand-written 429 body instead of apierror (minimal).** Rationale ("SDKs mis-parse
+  apierror") is factually wrong — apierror emits the same envelope creditGate already
+  uses on `/api/v1/`. Unified on apierror.
+- **Skipping the per-key check for AllowanceManaged traffic.** No — it is the only bound
+  making forged-identity rotation unprofitable (§3.2).
+
+## 6. Rollout plan
+
+Phases are independently shippable; A+B deliberately land as **one backend PR** so the
+override lever exists before the new ceiling bites anyone (resolving minimal's
+self-flagged Phase-A gap). Per house rules: branch + PR, images via CI→GHCR, never
+scp+build.
+
+- **Phase A+B — backend core + override (M, ~2–2.5d, one PR).** `nowFn` retrofit +
+  account Limiter + `Return` + `CheckAll` + chain reorder + env config + ConfigSnapshot
+  wiring + metrics; schema column, `GetKeyByHash`/`ResolveEndUserAccount` joins
+  (incl. `applyMonthlyAllowance` widening), `Resolution.RateLimitPerMin`, admin PUT +
+  `listAccounts` fields, shared resolver helper.
+- **Phase C — admin FE (S, ~0.5–1d, one PR).** Dialog, column, hook, Zod, MSW. Can lag A+B.
+- **Phase D — concurrency cap (S, ~0.5–1d, one PR).** Keyed semaphore, class env caps,
+  outermost-defer Release, slot-exempt GETs, `aiproxy_streams_inflight`. Severable but
+  committed to v1.
+- **Deploy (S).** Env vars in `deploy/k8s/deployment.yaml`; schema change idempotent-
+  guarded, no rollback hazard; buckets reset on deploy (accepted). **Pre-deploy
+  grandfathering pass:** enumerate service accounts whose multi-key aggregate exceeds
+  300/min and set overrides *before* the ceiling lands, rather than tuning off day-one
+  429s. One manual decision: the shared Open WebUI key's per-key limit (§8 Q2). Watch
+  `aiproxy_account_ratelimit_rejects_total` for a few days before tightening any default.
+  Grafana panel + (later) Discord alerting via the credit-request bot hook — follow-up,
+  not v1.
+
+## 7. Test plan
+
+TDD per house rule — tests first, all deterministic via the injected clock (no
+`time.Sleep`):
+
+- **Unit (ratelimit):** two-bucket ordering; refund on key-reject; `Return` clamped at
+  capacity with a property test (`tokens ≤ capacity` under any interleaving — a wrong
+  refund ordering silently doubles effective limits); no refund on concurrency reject;
+  Retry-After computed from the rejecting bucket; resolver helper
+  (override > class default, both classes).
+- **Middleware:** context seeded via `auth.WithKey` + `billing.WithResolution` covering
+  end-user vs service defaults, override precedence, missing-Resolution → per-key-only
+  fallback (the reachable prod path), nil-key pass-through, both metrics with correct
+  `kind`/`class` labels, scope-differentiated messages.
+- **Concurrency:** slot released on normal return, client disconnect, and a **panicking
+  handler** (a leaked slot silently strangles an account until pod restart); GETs never
+  take slots; gauge tracks in-flight.
+- **Regression (chain reorder):** over-cap + rate-passing end user still records a
+  cap-hit and files the credit request (Discord flow); over-cap + over-rate sees 429;
+  audit existing middleware/integration tests assuming 402-before-429 order.
+- **Admin:** `setAccountRateLimit` handler tests beside `eua_admin_test.go` (absent/null/
+  0/out-of-range/404); `listAccounts` effective values.
+- **FE:** dialog + mutation + MSW per the AllowanceDialog test suite; e2e via GitHub
+  Actions (local Playwright is unreliable on this machine).
+
+## 8. Open decisions for Krishna
+
+1. **End-user default: 30/min (recommended) vs your earlier 20/min.** 20 ≈ 5–7 visible
+   messages/min after Open WebUI's 2–4× amplification, before subtracting `/models`
+   polling — tight for real chat. Recommend 30, tune down later from the class-labeled
+   reject metric, not before shipping.
+2. **Shared Open WebUI key ceiling.** Keep 120/min as the deliberate aggregate backstop,
+   or raise now? Recommend raising to ~expected concurrent users × 30 via the existing
+   per-key admin endpoint, and a runbook note to scale it with headcount. Do not remove
+   it — it is the anti-identity-rotation bound.
+3. **`GET /api/v1/models`:** keep consuming rate tokens (recommended — it is an authed
+   path doing per-request billing DB work; exemption reopens an unbounded path) vs exempt
+   so polling never erodes chat budget. Revisit only if reject metrics show models
+   polling causing user-visible 429s.
+4. **Chain reorder sign-off:** rateLimit before creditGate changes precedence — an
+   over-cap AND over-rate account sees 429 where it saw 402, and cap-hit/Discord
+   recording waits for the first rate-passing request. Recommend accepting with the
+   regression test; severable if you object.
+5. **Grandfathering:** approve the pre-deploy audit + overrides for service accounts
+   currently exceeding 300/min aggregate (recommended), vs letting them hit the ceiling
+   and tuning reactively.
+6. **Concurrency defaults:** 5 end-user / 8 service (recommended; 3 end-user can trip on
+   a single Open WebUI send). Also confirm concurrency stays env-only (no column, no FE)
+   until an account actually needs a bespoke cap.

--- a/internal/admin/account_rate_limit_test.go
+++ b/internal/admin/account_rate_limit_test.go
@@ -1,0 +1,183 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// PUT /api/admin/accounts/{id}/rate-limit + effective values on the accounts
+// listing (docs/design/per-account-rate-limiting.md §4.3).
+
+func TestAdmin_SetAccountRateLimit(t *testing.T) {
+	h, s := setupAdminTest(t)
+	res, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "admin-rl-1", Email: "rl@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	idStr := strconv.FormatInt(res.AccountID, 10)
+
+	rec := adminPut(t, h, "/api/admin/accounts/"+idStr+"/rate-limit", `{"rate_limit_per_min":45}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Status          string `json:"status"`
+		RateLimitPerMin *int   `json:"rate_limit_per_min"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.Status != "updated" || resp.RateLimitPerMin == nil || *resp.RateLimitPerMin != 45 {
+		t.Errorf("unexpected response: %s", rec.Body.String())
+	}
+
+	// Explicit null clears the override.
+	rec = adminPut(t, h, "/api/admin/accounts/"+idStr+"/rate-limit", `{"rate_limit_per_min":null}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	res2, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "admin-rl-1", Email: "rl@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("re-resolve: %v", err)
+	}
+	if res2.RateLimitPerMin != nil {
+		t.Errorf("expected cleared override, got %v", *res2.RateLimitPerMin)
+	}
+}
+
+func TestAdmin_SetAccountRateLimit_Errors(t *testing.T) {
+	h, s := setupAdminTest(t)
+	res, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "admin-rl-err", Email: "rl-err@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	idStr := strconv.FormatInt(res.AccountID, 10)
+	path := "/api/admin/accounts/" + idStr + "/rate-limit"
+
+	// Absent field ≠ null: {} must 400, never silently clear.
+	if rec := adminPut(t, h, path, `{}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("absent field: expected 400, got %d", rec.Code)
+	}
+	// Explicit 0 rejected — blocking is credits/deactivation's job, not a
+	// 429 that SDKs retry forever.
+	if rec := adminPut(t, h, path, `{"rate_limit_per_min":0}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("zero: expected 400, got %d", rec.Code)
+	}
+	if rec := adminPut(t, h, path, `{"rate_limit_per_min":-5}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("negative: expected 400, got %d", rec.Code)
+	}
+	if rec := adminPut(t, h, path, `{"rate_limit_per_min":10001}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("above cap: expected 400, got %d", rec.Code)
+	}
+	if rec := adminPut(t, h, path, `{"rate_limit_per_min":"fast"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("non-integer: expected 400, got %d", rec.Code)
+	}
+	if rec := adminPut(t, h, "/api/admin/accounts/999999/rate-limit", `{"rate_limit_per_min":45}`); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown account: expected 404, got %d", rec.Code)
+	}
+}
+
+func TestListAccounts_EffectiveRateLimit(t *testing.T) {
+	_, s := setupAdminTest(t)
+	// Fresh handler with class defaults wired (setupAdminTest passes zero
+	// Options; effective values need the env defaults).
+	usageCh := make(chan store.UsageEntry, 10)
+	h := NewHandler(s, testAdminKey, usageCh, Options{
+		AccountRateLimitPerMin: 300,
+		EndUserRateLimitPerMin: 30,
+	})
+
+	// End-user account with an override; service (personal) account without.
+	eua, err := s.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "admin-rl-list", Email: "rl-list@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	override := 12
+	if err := s.SetAccountRateLimit(eua.AccountID, &override); err != nil {
+		t.Fatalf("SetAccountRateLimit: %v", err)
+	}
+	svcAcc, _, err := s.RegisterUser("svc-rl@example.com", "hash", "svc-rl")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+
+	req := adminGet(t, h, "/api/admin/accounts?envelope=1&limit=100")
+	if req.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", req.Code, req.Body.String())
+	}
+	var envelope struct {
+		Data []struct {
+			ID                       int64 `json:"id"`
+			RateLimitPerMin          *int  `json:"rate_limit_per_min"`
+			EffectiveRateLimitPerMin int   `json:"effective_rate_limit_per_min"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(req.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rows := envelope.Data
+
+	var sawEUA, sawSvc bool
+	for _, r := range rows {
+		switch r.ID {
+		case eua.AccountID:
+			sawEUA = true
+			if r.RateLimitPerMin == nil || *r.RateLimitPerMin != 12 {
+				t.Errorf("end-user override: expected 12, got %v", r.RateLimitPerMin)
+			}
+			if r.EffectiveRateLimitPerMin != 12 {
+				t.Errorf("end-user effective: expected 12 (override wins), got %d", r.EffectiveRateLimitPerMin)
+			}
+		case svcAcc:
+			sawSvc = true
+			if r.RateLimitPerMin != nil {
+				t.Errorf("service override: expected null, got %v", *r.RateLimitPerMin)
+			}
+			if r.EffectiveRateLimitPerMin != 300 {
+				t.Errorf("service effective: expected class default 300, got %d", r.EffectiveRateLimitPerMin)
+			}
+		}
+	}
+	if !sawEUA || !sawSvc {
+		t.Fatalf("missing accounts in listing (eua=%v svc=%v)", sawEUA, sawSvc)
+	}
+}
+
+func TestConfigSnapshot_IncludesAccountRateLimits(t *testing.T) {
+	_, s := setupAdminTest(t)
+	usageCh := make(chan store.UsageEntry, 10)
+	h := NewHandler(s, testAdminKey, usageCh, Options{
+		Snapshot: ConfigSnapshot{
+			AccountRateLimitPerMinute: 300,
+			EndUserRateLimitPerMinute: 30,
+		},
+	})
+
+	rec := adminGet(t, h, "/api/admin/config")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var snap map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &snap); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if snap["account_rate_limit_per_minute"] != float64(300) {
+		t.Errorf("expected account_rate_limit_per_minute 300, got %v", snap["account_rate_limit_per_minute"])
+	}
+	if snap["end_user_rate_limit_per_minute"] != float64(30) {
+		t.Errorf("expected end_user_rate_limit_per_minute 30, got %v", snap["end_user_rate_limit_per_minute"])
+	}
+}

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -67,6 +68,10 @@ type handler struct {
 	// Env-default monthly allowance, used to resolve each account's
 	// effective grant server-side (accounts + credit-requests listings).
 	endUserMonthlyGrant float64
+
+	// Class-default account rate limits, used to resolve each account's
+	// effective_rate_limit_per_min server-side (accounts listing).
+	rateLimits ratelimit.Limits
 }
 
 // NodeSnapshotter exposes the node registry's current routing state.
@@ -103,6 +108,11 @@ type Options struct {
 	// Env-default monthly allowance (cfg.EndUserMonthlyGrant); see
 	// handler.endUserMonthlyGrant.
 	EndUserMonthlyGrant float64
+
+	// Class-default account rate limits (cfg.AccountRateLimitPerMin /
+	// cfg.EndUserRateLimitPerMin); see handler.rateLimits.
+	AccountRateLimitPerMin int
+	EndUserRateLimitPerMin int
 }
 
 type adminSessionCtxKey struct{}
@@ -164,6 +174,10 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 
 		adminServiceCreditGrant: opts.AdminServiceCreditGrant,
 		endUserMonthlyGrant:     opts.EndUserMonthlyGrant,
+		rateLimits: ratelimit.Limits{
+			EndUserPerMin: opts.EndUserRateLimitPerMin,
+			ServicePerMin: opts.AccountRateLimitPerMin,
+		},
 	}
 
 	mux := http.NewServeMux()
@@ -195,6 +209,7 @@ func NewHandler(dataStore *store.Store, adminKey string, usageCh chan<- store.Us
 	mux.HandleFunc("POST /api/admin/accounts/{id}/credits", handler.grantCredits)
 	mux.HandleFunc("POST /api/admin/accounts/{id}/keys", handler.createAccountKey)
 	mux.HandleFunc("PUT /api/admin/accounts/{id}/allowance", handler.setAccountAllowance)
+	mux.HandleFunc("PUT /api/admin/accounts/{id}/rate-limit", handler.setAccountRateLimit)
 
 	// Credit requests (docs/design/credit-requests.md).
 	mux.HandleFunc("GET /api/admin/credit-requests", handler.listCreditRequests)
@@ -705,6 +720,10 @@ func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 		// default server-side; null for non-allowance-managed accounts.
 		EffectiveMonthlyGrant *float64 `json:"effective_monthly_grant"`
 		Email                 *string  `json:"email"`
+		RateLimitPerMin       *int     `json:"rate_limit_per_min"`
+		// EffectiveRateLimitPerMin resolves the override against the class
+		// env default server-side (never null — every account has a limit).
+		EffectiveRateLimitPerMin int `json:"effective_rate_limit_per_min"`
 	}
 
 	resp := make([]accountResponse, 0, len(accounts))
@@ -724,18 +743,20 @@ func (h *handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 			effectiveGrant = &g
 		}
 		resp = append(resp, accountResponse{
-			ID:                    a.ID,
-			Name:                  a.Name,
-			Type:                  a.Type,
-			IsActive:              a.IsActive,
-			Balance:               a.Balance,
-			Reserved:              a.Reserved,
-			Available:             a.Balance - a.Reserved,
-			CreatedAt:             a.CreatedAt.Format(time.RFC3339),
-			AllowanceManaged:      a.AllowanceManaged,
-			MonthlyGrant:          a.MonthlyGrant,
-			EffectiveMonthlyGrant: effectiveGrant,
-			Email:                 a.FederatedEmail,
+			ID:                       a.ID,
+			Name:                     a.Name,
+			Type:                     a.Type,
+			IsActive:                 a.IsActive,
+			Balance:                  a.Balance,
+			Reserved:                 a.Reserved,
+			Available:                a.Balance - a.Reserved,
+			CreatedAt:                a.CreatedAt.Format(time.RFC3339),
+			AllowanceManaged:         a.AllowanceManaged,
+			MonthlyGrant:             a.MonthlyGrant,
+			EffectiveMonthlyGrant:    effectiveGrant,
+			Email:                    a.FederatedEmail,
+			RateLimitPerMin:          a.RateLimitPerMin,
+			EffectiveRateLimitPerMin: ratelimit.EffectiveLimit(a.RateLimitPerMin, a.AllowanceManaged, h.rateLimits),
 		})
 	}
 
@@ -1182,6 +1203,56 @@ func (h *handler) setAccountAllowance(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"status": "updated", "monthly_grant": grant})
+}
+
+// setAccountRateLimit sets (value) or clears (null → class env default) an
+// account's per-minute rate-limit override. Takes effect on the account's
+// next request (docs/design/per-account-rate-limiting.md §4.3).
+func (h *handler) setAccountRateLimit(w http.ResponseWriter, r *http.Request) {
+	accountID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_id", "invalid_request_error", "Invalid account ID")
+		return
+	}
+
+	// json.RawMessage distinguishes an ABSENT field from explicit null:
+	// null is the destructive "clear the override" operation, so it must be
+	// spelled out — {} is a 400, never a silent clear.
+	var req struct {
+		RateLimitPerMin json.RawMessage `json:"rate_limit_per_min"`
+	}
+	if !apierror.DecodeJSON(w, r, &req) {
+		return
+	}
+	if len(req.RateLimitPerMin) == 0 {
+		proxy.WriteError(w, r, http.StatusBadRequest, "missing_field", "invalid_request_error", "rate_limit_per_min is required (integer to set, null to clear)")
+		return
+	}
+	var perMin *int
+	if err := json.Unmarshal(req.RateLimitPerMin, &perMin); err != nil {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_rate_limit", "invalid_request_error", "rate_limit_per_min must be an integer or null")
+		return
+	}
+	// Explicit 0 is rejected: blocking is the job of credits and account
+	// deactivation (403), not a 429 that SDKs politely retry forever.
+	if perMin != nil && (*perMin < 1 || *perMin > ratelimit.MaxConfigPerMinute) {
+		proxy.WriteError(w, r, http.StatusBadRequest, "invalid_rate_limit", "invalid_request_error",
+			fmt.Sprintf("rate_limit_per_min must be between 1 and %d", ratelimit.MaxConfigPerMinute))
+		return
+	}
+
+	if err := h.store.SetAccountRateLimit(accountID, perMin); err != nil {
+		if err.Error() == "account not found" {
+			proxy.WriteError(w, r, http.StatusNotFound, "not_found", "invalid_request_error", "Account not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "set account rate limit error", "error", err, "account_id", accountID)
+		proxy.WriteError(w, r, http.StatusInternalServerError, "internal_error", "server_error", "Failed to set rate limit")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"status": "updated", "rate_limit_per_min": perMin})
 }
 
 func min(a, b float64) float64 {

--- a/internal/admin/config_health.go
+++ b/internal/admin/config_health.go
@@ -30,6 +30,8 @@ type ConfigSnapshot struct {
 	AuthRegisterRateLimitPerMinute   int     `json:"auth_register_rate_limit_per_minute"`
 	AuthGeneralRateLimitPerMinute    int     `json:"auth_general_rate_limit_per_minute"`
 	AuthBcryptMaxConcurrent          int     `json:"auth_bcrypt_max_concurrent"`
+	AccountRateLimitPerMinute        int     `json:"account_rate_limit_per_minute"`
+	EndUserRateLimitPerMinute        int     `json:"end_user_rate_limit_per_minute"`
 	UsageChannelCapacity             int     `json:"usage_channel_capacity"`
 	AdminSessionDurationHrs          int     `json:"admin_session_duration_hours"`
 	UserSessionDurationHrs           int     `json:"user_session_duration_hours"`

--- a/internal/billing/billing.go
+++ b/internal/billing/billing.go
@@ -94,9 +94,13 @@ func Middleware(db *store.Store, defaultGrant float64) func(http.Handler) http.H
 			}
 
 			if key.AccountID != nil {
+				// AllowanceManaged comes from the ACCOUNT, not the identity
+				// path: a key created directly on an end-user account keeps
+				// that account's limiter class and 402 semantics.
 				r = r.WithContext(WithResolution(r.Context(), Resolution{
-					AccountID:       *key.AccountID,
-					RateLimitPerMin: key.AccountRateLimitPerMin,
+					AccountID:        *key.AccountID,
+					AllowanceManaged: key.AccountAllowanceManaged,
+					RateLimitPerMin:  key.AccountRateLimitPerMin,
 				}))
 			}
 			next.ServeHTTP(w, r)

--- a/internal/billing/billing.go
+++ b/internal/billing/billing.go
@@ -36,6 +36,10 @@ const SourceOpenWebUI = "openwebui"
 type Resolution struct {
 	AccountID        int64
 	AllowanceManaged bool // true for auto-provisioned end-user accounts (drives 402 wording)
+	// RateLimitPerMin is the billing account's rate_limit_per_min override;
+	// nil = class env default. Carried here so the rate limiter (which runs
+	// right after billing) needs no extra DB read.
+	RateLimitPerMin *int
 }
 
 type ctxKey struct{}
@@ -83,13 +87,17 @@ func Middleware(db *store.Store, defaultGrant float64) func(http.Handler) http.H
 					next.ServeHTTP(w, r.WithContext(WithResolution(r.Context(), Resolution{
 						AccountID:        res.AccountID,
 						AllowanceManaged: true,
+						RateLimitPerMin:  res.RateLimitPerMin,
 					})))
 					return
 				}
 			}
 
 			if key.AccountID != nil {
-				r = r.WithContext(WithResolution(r.Context(), Resolution{AccountID: *key.AccountID}))
+				r = r.WithContext(WithResolution(r.Context(), Resolution{
+					AccountID:       *key.AccountID,
+					RateLimitPerMin: key.AccountRateLimitPerMin,
+				}))
 			}
 			next.ServeHTTP(w, r)
 		})

--- a/internal/billing/middleware_test.go
+++ b/internal/billing/middleware_test.go
@@ -146,6 +146,47 @@ func TestMiddleware_TrustedKeyNoHeaders_BillsKeyAccount(t *testing.T) {
 	}
 }
 
+// The rate limiter reads the per-account override off the Resolution — both
+// billing paths must thread it (docs/design/per-account-rate-limiting.md §4.2).
+func TestMiddleware_ThreadsRateLimitOverride_EndUser(t *testing.T) {
+	db := setupBillingTest(t)
+	sharedAcc, _, _ := db.RegisterUser("shared-rl@example.com", "hash", "SharedRL")
+	key := &store.APIKey{ID: 1, AccountID: &sharedAcc, TrustUserHeaders: true}
+
+	res, _ := serve(t, db, key, owuiHeaders())
+	if res == nil {
+		t.Fatal("expected a billing resolution")
+	}
+	if res.RateLimitPerMin != nil {
+		t.Errorf("fresh end-user account: expected nil override, got %v", *res.RateLimitPerMin)
+	}
+
+	perMin := 15
+	if err := db.SetAccountRateLimit(res.AccountID, &perMin); err != nil {
+		t.Fatalf("SetAccountRateLimit: %v", err)
+	}
+	res2, _ := serve(t, db, key, owuiHeaders())
+	if res2 == nil || res2.RateLimitPerMin == nil || *res2.RateLimitPerMin != 15 {
+		t.Errorf("expected override 15 on resolution, got %+v", res2)
+	}
+}
+
+func TestMiddleware_ThreadsRateLimitOverride_ServiceAccount(t *testing.T) {
+	db := setupBillingTest(t)
+	accID, _, _ := db.RegisterUser("svc-rl@example.com", "hash", "SvcRL")
+	perMin := 99
+	if err := db.SetAccountRateLimit(accID, &perMin); err != nil {
+		t.Fatalf("SetAccountRateLimit: %v", err)
+	}
+
+	// Service path reads the override off the key row (GetKeyByHash join).
+	key := &store.APIKey{ID: 1, AccountID: &accID, AccountRateLimitPerMin: &perMin}
+	res, _ := serve(t, db, key, nil)
+	if res == nil || res.RateLimitPerMin == nil || *res.RateLimitPerMin != 99 {
+		t.Errorf("expected override 99 on service resolution, got %+v", res)
+	}
+}
+
 func TestMiddleware_NoKey_PassesThroughWithoutResolution(t *testing.T) {
 	db := setupBillingTest(t)
 	res, rec := serve(t, db, nil, owuiHeaders())

--- a/internal/billing/middleware_test.go
+++ b/internal/billing/middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/krishna/local-ai-proxy/internal/auth"
 	"github.com/krishna/local-ai-proxy/internal/store"
@@ -184,6 +185,30 @@ func TestMiddleware_ThreadsRateLimitOverride_ServiceAccount(t *testing.T) {
 	res, _ := serve(t, db, key, nil)
 	if res == nil || res.RateLimitPerMin == nil || *res.RateLimitPerMin != 99 {
 		t.Errorf("expected override 99 on service resolution, got %+v", res)
+	}
+}
+
+// A direct key on an allowance-managed account keeps that account's class:
+// end-user limiter default and monthly-limit 402 semantics, not service ones.
+func TestMiddleware_DirectKeyOnEndUserAccount_KeepsClass(t *testing.T) {
+	db := setupBillingTest(t)
+	res, err := db.ResolveEndUserAccount(store.FederatedIdentity{
+		Source: "openwebui", ExternalID: "direct-key-eua", Email: "direct@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	key := &store.APIKey{ID: 1, AccountID: &res.AccountID, AccountAllowanceManaged: true}
+
+	billed, rec := serve(t, db, key, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if billed == nil || billed.AccountID != res.AccountID {
+		t.Fatalf("expected key-account billing, got %+v", billed)
+	}
+	if !billed.AllowanceManaged {
+		t.Error("direct key on an end-user account must keep AllowanceManaged=true")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,13 @@ type Config struct {
 	AuthRegisterPerMinIP  int
 	AuthGeneralPerMinIP   int
 	AuthBcryptConcurrency int
+
+	// Account-level chat rate limits (requests per minute), by account
+	// class; per-account override via accounts.rate_limit_per_min. There is
+	// no 0=disabled semantic — to effectively disable, set the max. See
+	// docs/design/per-account-rate-limiting.md.
+	AccountRateLimitPerMin int // ACCOUNT_RATELIMIT_PER_MIN, service accounts
+	EndUserRateLimitPerMin int // END_USER_RATELIMIT_PER_MIN, allowance-managed accounts
 }
 
 func Load() (Config, error) {
@@ -163,6 +170,19 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
+	// Account-level chat rate limits. Defaults: 300/min for service accounts
+	// (generous — existing multi-key accounts mostly don't break on day one,
+	// but finally bounded), 30/min for end users (Open WebUI fires 2–4
+	// upstream completions per visible message, so 30 ≈ 7–10 messages/min).
+	accountRateLimit, err := boundedIntEnvOrDefault("ACCOUNT_RATELIMIT_PER_MIN", 300, maxRateLimitPerMin)
+	if err != nil {
+		return Config{}, err
+	}
+	endUserRateLimit, err := boundedIntEnvOrDefault("END_USER_RATELIMIT_PER_MIN", 30, maxRateLimitPerMin)
+	if err != nil {
+		return Config{}, err
+	}
+
 	// Track explicit presence of OLLAMA_URL (empty counts as unset, matching
 	// the rest of the config): node synthesis must distinguish "operator
 	// pointed us at an Ollama" from "nothing configured", so it keys off
@@ -221,7 +241,26 @@ func Load() (Config, error) {
 		AuthRegisterPerMinIP:  authRegisterIP,
 		AuthGeneralPerMinIP:   authGeneralIP,
 		AuthBcryptConcurrency: bcryptConcurrency,
+
+		AccountRateLimitPerMin: accountRateLimit,
+		EndUserRateLimitPerMin: endUserRateLimit,
 	}, nil
+}
+
+// maxRateLimitPerMin mirrors ratelimit.MaxConfigPerMinute (typo guard) —
+// duplicated here to keep config free of the ratelimit package's HTTP deps.
+const maxRateLimitPerMin = 10000
+
+// boundedIntEnvOrDefault is intEnvOrDefault with an upper bound.
+func boundedIntEnvOrDefault(key string, fallback, max int) (int, error) {
+	n, err := intEnvOrDefault(key, fallback)
+	if err != nil {
+		return 0, err
+	}
+	if n > max {
+		return 0, fmt.Errorf("invalid %s: must be <= %d, got %d", key, max, n)
+	}
+	return n, nil
 }
 
 // intEnvOrDefault parses a positive integer env var, returning fallback when

--- a/internal/config/config_ratelimit_test.go
+++ b/internal/config/config_ratelimit_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Account-level rate-limit env parsing
+// (docs/design/per-account-rate-limiting.md §4.1). Base env so Load()
+// passes its required-var checks.
+func setBaseEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ADMIN_KEY", "test-admin")
+	t.Setenv("DATABASE_URL", "postgres://test")
+}
+
+func TestLoad_AccountRateLimitDefaults(t *testing.T) {
+	setBaseEnv(t)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AccountRateLimitPerMin != 300 {
+		t.Errorf("expected ACCOUNT_RATELIMIT_PER_MIN default 300, got %d", cfg.AccountRateLimitPerMin)
+	}
+	if cfg.EndUserRateLimitPerMin != 30 {
+		t.Errorf("expected END_USER_RATELIMIT_PER_MIN default 30, got %d", cfg.EndUserRateLimitPerMin)
+	}
+}
+
+func TestLoad_AccountRateLimitOverrides(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("ACCOUNT_RATELIMIT_PER_MIN", "120")
+	t.Setenv("END_USER_RATELIMIT_PER_MIN", "10")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AccountRateLimitPerMin != 120 || cfg.EndUserRateLimitPerMin != 10 {
+		t.Errorf("expected 120/10, got %d/%d", cfg.AccountRateLimitPerMin, cfg.EndUserRateLimitPerMin)
+	}
+}
+
+func TestLoad_AccountRateLimitInvalid(t *testing.T) {
+	// No 0=disabled semantic: silently disabling a security limit is worse
+	// than failing to boot.
+	cases := []struct {
+		name, key, value string
+	}{
+		{"zero account", "ACCOUNT_RATELIMIT_PER_MIN", "0"},
+		{"negative account", "ACCOUNT_RATELIMIT_PER_MIN", "-5"},
+		{"non-numeric account", "ACCOUNT_RATELIMIT_PER_MIN", "abc"},
+		{"above cap account", "ACCOUNT_RATELIMIT_PER_MIN", "10001"},
+		{"zero end-user", "END_USER_RATELIMIT_PER_MIN", "0"},
+		{"above cap end-user", "END_USER_RATELIMIT_PER_MIN", "999999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setBaseEnv(t)
+			t.Setenv(tc.key, tc.value)
+			if _, err := Load(); err == nil {
+				t.Fatalf("expected boot failure for %s=%s", tc.key, tc.value)
+			} else if !strings.Contains(err.Error(), tc.key) {
+				t.Errorf("error should name the variable, got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/credits/chain_order_test.go
+++ b/internal/credits/chain_order_test.go
@@ -1,0 +1,92 @@
+package credits
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/creditrequest"
+	"github.com/krishna/local-ai-proxy/internal/ratelimit"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// Chain-order regression (docs/design/per-account-rate-limiting.md §3.3):
+// main.go mounts billing → rateLimit → creditGate. RecordCapHit — the
+// credit-request/Discord trigger — only fires inside the gate's 402 branch,
+// so it must still fire for an over-cap request that PASSES the rate gates,
+// and an over-cap AND over-rate request must see 429 (rate gate first).
+
+// buildChain mirrors the /api/v1/ middleware order from cmd/proxy/main.go.
+func buildChain(db *store.Store, capHits *creditrequest.Recorder, limits ratelimit.Limits) http.Handler {
+	clockNow := time.Now
+	keys := ratelimit.NewWithClock(clockNow)
+	accounts := ratelimit.NewWithClock(clockNow)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	rl := ratelimit.Middleware(keys, accounts, limits, nil)
+	gate := CreditGate(db, nil, capHits)
+	return billing.Middleware(db, 0)(rl(gate(next)))
+}
+
+func overCapRequest(t *testing.T, chain http.Handler, key *store.APIKey, externalID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/chat/completions", nil)
+	req.Header.Set(billing.HeaderUserID, externalID)
+	req.Header.Set(billing.HeaderUserEmail, externalID+"@example.com")
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req.WithContext(auth.WithKey(req.Context(), key)))
+	return rec
+}
+
+func TestChainOrder_CapHitStillFiresThroughRateLimiter(t *testing.T) {
+	db := setupTestStore(t)
+	capHits := creditrequest.New(db, "", 0) // zero default grant: capped from the first request
+	chain := buildChain(db, capHits, ratelimit.Limits{EndUserPerMin: 100, ServicePerMin: 300})
+
+	sharedAcc, _, _ := db.RegisterUser("chain-shared@example.com", "hash", "ChainShared")
+	key := &store.APIKey{ID: 1, AccountID: &sharedAcc, TrustUserHeaders: true, RateLimit: 100}
+
+	rec := overCapRequest(t, chain, key, "chain-cap-1")
+	if rec.Code != http.StatusPaymentRequired {
+		t.Fatalf("rate-passing over-cap request must 402, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "monthly_limit_reached") {
+		t.Errorf("expected monthly_limit_reached, got: %s", rec.Body.String())
+	}
+
+	capHits.Wait()
+	rows, err := db.ListCreditRequests("pending", time.Now())
+	if err != nil {
+		t.Fatalf("ListCreditRequests: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("cap-hit through the reordered chain must file exactly 1 credit request, got %d", len(rows))
+	}
+}
+
+func TestChainOrder_OverCapAndOverRateSees429(t *testing.T) {
+	db := setupTestStore(t)
+	capHits := creditrequest.New(db, "", 0)
+	chain := buildChain(db, capHits, ratelimit.Limits{EndUserPerMin: 1, ServicePerMin: 300})
+
+	sharedAcc, _, _ := db.RegisterUser("chain-shared-2@example.com", "hash", "ChainShared2")
+	key := &store.APIKey{ID: 1, AccountID: &sharedAcc, TrustUserHeaders: true, RateLimit: 100}
+
+	// First request consumes the 1/min account budget and 402s at the gate.
+	if rec := overCapRequest(t, chain, key, "chain-cap-2"); rec.Code != http.StatusPaymentRequired {
+		t.Fatalf("first request should 402, got %d", rec.Code)
+	}
+	// Second request is over-rate AND over-cap: the rate gate wins (429).
+	rec := overCapRequest(t, chain, key, "chain-cap-2")
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("over-rate + over-cap must 429 under the new order, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "rate_limit_exceeded") {
+		t.Errorf("expected rate_limit_exceeded body, got: %s", rec.Body.String())
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -23,7 +23,11 @@ type Metrics struct {
 	// Credit/rate limit
 	CreditGateRejects prometheus.Counter
 	RateLimitRejects  prometheus.Counter
-	UsageDrops        prometheus.Counter
+	// Account-level limiter rejects (docs/design/per-account-rate-limiting.md).
+	// Partitions rejects with RateLimitRejects by gate: key-level rejects stay
+	// in the legacy counter, account-level ones land here.
+	AccountRateLimitRejects *prometheus.CounterVec // labels: kind (rate|concurrency), class (enduser|service)
+	UsageDrops              prometheus.Counter
 
 	// Infrastructure
 	OllamaUp prometheus.Gauge
@@ -88,8 +92,13 @@ func New(usageChLen func() int) *Metrics {
 
 		RateLimitRejects: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "aiproxy_ratelimit_rejects_total",
-			Help: "Requests rejected by rate limiter.",
+			Help: "Requests rejected by the key-level rate limiter. Account-level rejects are counted in aiproxy_account_ratelimit_rejects_total.",
 		}),
+
+		AccountRateLimitRejects: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "aiproxy_account_ratelimit_rejects_total",
+			Help: "Requests rejected by the account-level limiter, by kind (rate|concurrency) and account class (enduser|service).",
+		}, []string{"kind", "class"}),
 
 		UsageDrops: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "aiproxy_usage_drops_total",
@@ -144,6 +153,7 @@ func New(usageChLen func() int) *Metrics {
 		m.TokensTotal,
 		m.CreditGateRejects,
 		m.RateLimitRejects,
+		m.AccountRateLimitRejects,
 		m.UsageDrops,
 		m.OllamaUp,
 		m.NodeUp,
@@ -193,6 +203,16 @@ func (m *Metrics) RecordCreditGateReject() {
 		return
 	}
 	m.CreditGateRejects.Inc()
+}
+
+// RecordAccountRateLimitReject increments the account-level limiter reject
+// counter. Nil-safe. kind is "rate" or "concurrency"; class is "enduser" or
+// "service" — bounded vocabularies, never an account ID (cardinality rule).
+func (m *Metrics) RecordAccountRateLimitReject(kind, class string) {
+	if m == nil {
+		return
+	}
+	m.AccountRateLimitRejects.WithLabelValues(kind, class).Inc()
 }
 
 // RecordRateLimitReject increments the rate limit reject counter. Nil-safe.

--- a/internal/ratelimit/middleware.go
+++ b/internal/ratelimit/middleware.go
@@ -1,0 +1,109 @@
+package ratelimit
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+
+	"github.com/krishna/local-ai-proxy/internal/apierror"
+	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/metrics"
+)
+
+// Limits carries the class-default account rate limits (requests/minute).
+// A per-account override (accounts.rate_limit_per_min) takes precedence via
+// EffectiveLimit.
+type Limits struct {
+	EndUserPerMin int // accounts with AllowanceManaged=true (END_USER_RATELIMIT_PER_MIN)
+	ServicePerMin int // every other account (ACCOUNT_RATELIMIT_PER_MIN)
+}
+
+// EffectiveLimit resolves one account's rate limit: the per-account override
+// when set, else the class default. Single source of truth — the middleware
+// and the admin accounts listing both go through it.
+func EffectiveLimit(override *int, allowanceManaged bool, limits Limits) int {
+	if override != nil {
+		return *override
+	}
+	if allowanceManaged {
+		return limits.EndUserPerMin
+	}
+	return limits.ServicePerMin
+}
+
+// Middleware enforces the account-level and key-level rate limits, in that
+// order (docs/design/per-account-rate-limiting.md §3.2):
+//
+//  1. Account bucket, keyed by the billing resolution's account ID. Checked
+//     first so a throttled user's rejects never drain the shared key's
+//     aggregate bucket.
+//  2. Key bucket, unchanged semantics. A key-level reject refunds the
+//     account token — different owners on the shared trusted key (see
+//     Limiter.Return).
+//
+// Requests without a billing resolution (legacy nil-account keys — a
+// reachable prod path that 403s at the credit gate) see only the key
+// bucket; requests without a key pass through untouched.
+func Middleware(keys, accounts *Limiter, limits Limits, m *metrics.Metrics) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := auth.KeyFromContext(r.Context())
+			if key == nil {
+				// No key in context means auth middleware didn't run (shouldn't happen)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			res, hasRes := billing.FromContext(r.Context())
+			if hasRes {
+				limit := EffectiveLimit(res.RateLimitPerMin, res.AllowanceManaged, limits)
+				if allowed, retryAfter := accounts.Allow(res.AccountID, limit); !allowed {
+					m.RecordAccountRateLimitReject("rate", classLabel(res.AllowanceManaged))
+					writeRateLimited(w, r, retryAfter,
+						fmt.Sprintf("Rate limit exceeded for your account (%d req/min)", limit))
+					return
+				}
+			}
+
+			if allowed, retryAfter := keys.Allow(key.ID, key.RateLimit); !allowed {
+				if hasRes {
+					accounts.Return(res.AccountID)
+				}
+				m.RecordRateLimitReject()
+				writeRateLimited(w, r, retryAfter,
+					fmt.Sprintf("Rate limit exceeded for this API key (%d req/min)", key.RateLimit))
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func classLabel(allowanceManaged bool) string {
+	if allowanceManaged {
+		return "enduser"
+	}
+	return "service"
+}
+
+// writeRateLimited emits the OpenAI-envelope 429. The message is
+// scope-differentiated (account vs key) because Open WebUI surfaces the raw
+// string — identical bodies would make background title/tag failures
+// undiagnosable. Retry-After is clamped to [1s, 1h]: OpenAI SDKs auto-retry
+// honoring it, so it must never be 0 (retry storm) or infinite (a zero-limit
+// bucket's refill rate is 0).
+func writeRateLimited(w http.ResponseWriter, r *http.Request, retryAfter float64, scope string) {
+	secs := math.Ceil(retryAfter)
+	if secs < 1 || math.IsNaN(secs) {
+		secs = 1
+	}
+	if secs > 3600 || math.IsInf(secs, 1) {
+		secs = 3600
+	}
+	w.Header().Set("Retry-After", strconv.Itoa(int(secs)))
+	apierror.WriteError(w, r, http.StatusTooManyRequests, "rate_limit_exceeded", "rate_limit_exceeded",
+		fmt.Sprintf("%s; retry in %ds", scope, int(secs)))
+}

--- a/internal/ratelimit/middleware_test.go
+++ b/internal/ratelimit/middleware_test.go
@@ -1,0 +1,295 @@
+package ratelimit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/metrics"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+var testLimits = Limits{EndUserPerMin: 30, ServicePerMin: 300}
+
+// serveChain sends one request through the middleware, optionally attaching
+// an auth key and a billing resolution to the context.
+func serveChain(t *testing.T, mw http.Handler, key *store.APIKey, res *billing.Resolution) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", nil)
+	ctx := req.Context()
+	if key != nil {
+		ctx = auth.WithKey(ctx, key)
+	}
+	if res != nil {
+		ctx = billing.WithResolution(ctx, *res)
+	}
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req.WithContext(ctx))
+	return rec
+}
+
+func okNext() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func newMiddleware(limits Limits, m *metrics.Metrics) (http.Handler, *Limiter, *Limiter) {
+	clock := newTestClock()
+	keys := NewWithClock(clock.now)
+	accounts := NewWithClock(clock.now)
+	return Middleware(keys, accounts, limits, m)(okNext()), keys, accounts
+}
+
+func TestMiddleware_NoKeyInContext(t *testing.T) {
+	mw, _, _ := newMiddleware(testLimits, nil)
+	rec := serveChain(t, mw, nil, nil)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 pass-through without key, got %d", rec.Code)
+	}
+}
+
+func TestMiddleware_KeyOnlyWhenNoResolution(t *testing.T) {
+	mw, _, accounts := newMiddleware(testLimits, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 2}
+
+	for i := 0; i < 2; i++ {
+		if rec := serveChain(t, mw, key, nil); rec.Code != http.StatusOK {
+			t.Fatalf("request %d should pass, got %d", i+1, rec.Code)
+		}
+	}
+	rec := serveChain(t, mw, key, nil)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "API key") {
+		t.Errorf("key-scope 429 must name the API key, got: %s", rec.Body.String())
+	}
+
+	// No billing resolution → the account limiter must stay untouched.
+	accounts.mu.Lock()
+	n := len(accounts.buckets)
+	accounts.mu.Unlock()
+	if n != 0 {
+		t.Errorf("account limiter must be untouched without a resolution, has %d buckets", n)
+	}
+}
+
+func TestMiddleware_EndUserDefaultApplied(t *testing.T) {
+	mw, _, _ := newMiddleware(Limits{EndUserPerMin: 2, ServicePerMin: 300}, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+	res := &billing.Resolution{AccountID: 7, AllowanceManaged: true}
+
+	for i := 0; i < 2; i++ {
+		if rec := serveChain(t, mw, key, res); rec.Code != http.StatusOK {
+			t.Fatalf("request %d should pass, got %d", i+1, rec.Code)
+		}
+	}
+	rec := serveChain(t, mw, key, res)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 at the end-user default, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "your account (2 req/min)") {
+		t.Errorf("account-scope 429 must state the account limit, got: %s", rec.Body.String())
+	}
+}
+
+func TestMiddleware_ServiceDefaultApplied(t *testing.T) {
+	mw, _, _ := newMiddleware(Limits{EndUserPerMin: 300, ServicePerMin: 2}, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+	res := &billing.Resolution{AccountID: 8, AllowanceManaged: false}
+
+	for i := 0; i < 2; i++ {
+		if rec := serveChain(t, mw, key, res); rec.Code != http.StatusOK {
+			t.Fatalf("request %d should pass, got %d", i+1, rec.Code)
+		}
+	}
+	if rec := serveChain(t, mw, key, res); rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 at the service default, got %d", rec.Code)
+	}
+}
+
+func TestMiddleware_OverridePrecedence(t *testing.T) {
+	mw, _, _ := newMiddleware(Limits{EndUserPerMin: 300, ServicePerMin: 300}, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+	override := 1
+	res := &billing.Resolution{AccountID: 9, AllowanceManaged: true, RateLimitPerMin: &override}
+
+	if rec := serveChain(t, mw, key, res); rec.Code != http.StatusOK {
+		t.Fatalf("first request should pass, got %d", rec.Code)
+	}
+	rec := serveChain(t, mw, key, res)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("override of 1/min must beat the class default, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "(1 req/min)") {
+		t.Errorf("429 must state the effective (override) limit, got: %s", rec.Body.String())
+	}
+}
+
+// The shared-key fix: exhausting one end user's bucket must not affect
+// another user riding the same key.
+func TestMiddleware_AccountIsolation(t *testing.T) {
+	mw, _, _ := newMiddleware(Limits{EndUserPerMin: 2, ServicePerMin: 300}, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+	userA := &billing.Resolution{AccountID: 100, AllowanceManaged: true}
+	userB := &billing.Resolution{AccountID: 101, AllowanceManaged: true}
+
+	serveChain(t, mw, key, userA)
+	serveChain(t, mw, key, userA)
+	if rec := serveChain(t, mw, key, userA); rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("user A should be throttled, got %d", rec.Code)
+	}
+	if rec := serveChain(t, mw, key, userB); rec.Code != http.StatusOK {
+		t.Errorf("user B must be unaffected by user A's throttle, got %d", rec.Code)
+	}
+}
+
+// Account-first ordering: an account-level reject must not consume a key
+// token (a throttled user must never drain the shared aggregate bucket).
+func TestMiddleware_AccountRejectDoesNotChargeKeyBucket(t *testing.T) {
+	mw, keys, _ := newMiddleware(Limits{EndUserPerMin: 1, ServicePerMin: 300}, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 5}
+	res := &billing.Resolution{AccountID: 100, AllowanceManaged: true}
+
+	serveChain(t, mw, key, res) // passes; key tokens 5→4
+	for i := 0; i < 3; i++ {
+		if rec := serveChain(t, mw, key, res); rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("account reject expected, got %d", rec.Code)
+		}
+	}
+
+	keys.mu.Lock()
+	b := keys.buckets[key.ID]
+	tokens := b.tokens
+	keys.mu.Unlock()
+	if tokens != 4 {
+		t.Errorf("account rejects must not charge the key bucket: expected 4 tokens, got %f", tokens)
+	}
+}
+
+// Key-level reject refunds the account token: on the shared key the two
+// buckets have different owners, so aggregate saturation must not burn the
+// individual user's budget.
+func TestMiddleware_KeyRejectRefundsAccountToken(t *testing.T) {
+	mw, _, accounts := newMiddleware(Limits{EndUserPerMin: 5, ServicePerMin: 300}, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 1}
+	res := &billing.Resolution{AccountID: 100, AllowanceManaged: true}
+
+	if rec := serveChain(t, mw, key, res); rec.Code != http.StatusOK {
+		t.Fatalf("first request should pass, got %d", rec.Code)
+	}
+	rec := serveChain(t, mw, key, res)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request should hit the key limit, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "API key") {
+		t.Errorf("expected key-scope message, got: %s", rec.Body.String())
+	}
+
+	accounts.mu.Lock()
+	tokens := accounts.buckets[res.AccountID].tokens
+	accounts.mu.Unlock()
+	// 5 capacity − 1 (request 1) − 1 (request 2) + 1 (refund) = 4.
+	if tokens != 4 {
+		t.Errorf("key reject must refund the account token: expected 4, got %f", tokens)
+	}
+}
+
+func TestMiddleware_KeyLevel429Shape(t *testing.T) {
+	mw, _, _ := newMiddleware(testLimits, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 1}
+
+	serveChain(t, mw, key, nil)
+	rec := serveChain(t, mw, key, nil)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse response body: %v", err)
+	}
+	errObj, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'error' object in response")
+	}
+	if errObj["code"] != "rate_limit_exceeded" {
+		t.Errorf("expected code 'rate_limit_exceeded', got %v", errObj["code"])
+	}
+	if errObj["type"] != "rate_limit_exceeded" {
+		t.Errorf("expected type 'rate_limit_exceeded', got %v", errObj["type"])
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header")
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("expected JSON Content-Type, got %q", ct)
+	}
+}
+
+func TestMiddleware_AccountLevel429ShapeAndRetryAfter(t *testing.T) {
+	mw, _, _ := newMiddleware(Limits{EndUserPerMin: 1, ServicePerMin: 300}, nil)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+	res := &billing.Resolution{AccountID: 7, AllowanceManaged: true}
+
+	serveChain(t, mw, key, res)
+	rec := serveChain(t, mw, key, res)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	errObj := body["error"].(map[string]any)
+	// Same code/type as the key gate — SDK parsers key on these — but a
+	// scope-differentiated human message.
+	if errObj["code"] != "rate_limit_exceeded" {
+		t.Errorf("expected code 'rate_limit_exceeded', got %v", errObj["code"])
+	}
+	ra := rec.Header().Get("Retry-After")
+	if ra == "" || ra == "0" {
+		t.Errorf("Retry-After must be at least 1s, got %q", ra)
+	}
+}
+
+func TestMiddleware_MetricsLabels(t *testing.T) {
+	m := metrics.New(func() int { return 0 })
+	mw, _, _ := newMiddleware(Limits{EndUserPerMin: 1, ServicePerMin: 1}, m)
+
+	// End-user account reject.
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+	endUser := &billing.Resolution{AccountID: 1, AllowanceManaged: true}
+	serveChain(t, mw, key, endUser)
+	serveChain(t, mw, key, endUser)
+	if got := testutil.ToFloat64(m.AccountRateLimitRejects.WithLabelValues("rate", "enduser")); got != 1 {
+		t.Errorf("expected 1 enduser rate reject, got %v", got)
+	}
+
+	// Service account reject.
+	service := &billing.Resolution{AccountID: 2, AllowanceManaged: false}
+	serveChain(t, mw, key, service)
+	serveChain(t, mw, key, service)
+	if got := testutil.ToFloat64(m.AccountRateLimitRejects.WithLabelValues("rate", "service")); got != 1 {
+		t.Errorf("expected 1 service rate reject, got %v", got)
+	}
+
+	// Key-level reject stays in the legacy counter, not the account one.
+	tightKey := &store.APIKey{ID: 9, RateLimit: 1}
+	serveChain(t, mw, tightKey, nil)
+	serveChain(t, mw, tightKey, nil)
+	if got := testutil.ToFloat64(m.RateLimitRejects); got != 1 {
+		t.Errorf("expected 1 key-level reject in legacy counter, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.AccountRateLimitRejects.WithLabelValues("rate", "enduser")) +
+		testutil.ToFloat64(m.AccountRateLimitRejects.WithLabelValues("rate", "service")); got != 2 {
+		t.Errorf("key-level reject must not increment the account counter, got %v", got)
+	}
+}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -1,14 +1,22 @@
+// Package ratelimit provides the token-bucket rate limiting for the chat
+// proxy path: a key-level limiter (per api_keys.rate_limit) and an
+// account-level limiter keyed by the billing account
+// (docs/design/per-account-rate-limiting.md). The deployment is
+// single-replica, so in-memory buckets are sufficient; a shared/distributed
+// limiter is intentionally out of scope.
 package ratelimit
 
 import (
-	"fmt"
 	"math"
-	"net/http"
 	"sync"
 	"time"
+)
 
-	"github.com/krishna/local-ai-proxy/internal/auth"
-	"github.com/krishna/local-ai-proxy/internal/metrics"
+// pruneInterval is how often idle buckets are evicted; idleCutoff is the
+// minimum idle time before eviction (matches authlimit).
+const (
+	pruneInterval = 1 * time.Minute
+	idleCutoff    = 10 * time.Minute
 )
 
 type bucket struct {
@@ -19,19 +27,22 @@ type bucket struct {
 	lastAccess time.Time
 }
 
-// Limiter manages per-key token buckets.
+// Limiter manages token buckets keyed by int64 ID. The proxy runs two
+// instances — one keyed by API-key ID, one keyed by billing-account ID.
+// They must stay separate instances: the two ID spaces overlap, so a shared
+// map would collide key #7 with account #7.
 type Limiter struct {
 	mu      sync.Mutex
 	buckets map[int64]*bucket
+	nowFn   func() time.Time
 }
 
+// New builds a Limiter on the wall clock and starts the background prune
+// goroutine. Use this from main.
 func New() *Limiter {
-	limiter := &Limiter{
-		buckets: make(map[int64]*bucket),
-	}
-	// Prune stale buckets every minute
+	limiter := NewWithClock(time.Now)
 	go func() {
-		ticker := time.NewTicker(1 * time.Minute)
+		ticker := time.NewTicker(pruneInterval)
 		defer ticker.Stop()
 		for range ticker.C {
 			limiter.prune()
@@ -40,14 +51,24 @@ func New() *Limiter {
 	return limiter
 }
 
-// Allow checks if a request is allowed for the given key ID and rate limit.
-// Returns (allowed, retryAfter in seconds).
-func (l *Limiter) Allow(keyID int64, rateLimit int) (bool, float64) {
+// NewWithClock builds a Limiter with an injectable clock and no prune
+// goroutine (the authlimit pattern). Exported for deterministic tests.
+func NewWithClock(nowFn func() time.Time) *Limiter {
+	return &Limiter{
+		buckets: make(map[int64]*bucket),
+		nowFn:   nowFn,
+	}
+}
+
+// Allow checks if a request is allowed for the given ID and rate limit.
+// Returns (allowed, retryAfter in seconds). Capacity and refill rate are
+// rewritten on every call, so limit changes apply on the next request.
+func (l *Limiter) Allow(id int64, rateLimit int) (bool, float64) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	now := time.Now()
-	tokenBucket, exists := l.buckets[keyID]
+	now := l.nowFn()
+	tokenBucket, exists := l.buckets[id]
 
 	if !exists {
 		tokenBucket = &bucket{
@@ -57,7 +78,7 @@ func (l *Limiter) Allow(keyID int64, rateLimit int) (bool, float64) {
 			lastRefill: now,
 			lastAccess: now,
 		}
-		l.buckets[keyID] = tokenBucket
+		l.buckets[id] = tokenBucket
 		return true, 0
 	}
 
@@ -81,39 +102,29 @@ func (l *Limiter) Allow(keyID int64, rateLimit int) (bool, float64) {
 	return false, retryAfter
 }
 
+// Return refunds one token to id's bucket, clamped at capacity. Used when a
+// later gate rejects a request whose account bucket already charged it: on
+// the shared trusted key the key bucket (service key's aggregate) and the
+// account bucket (individual end user) have different owners, so an
+// aggregate rejection must not burn the individual's budget — and their
+// Retry-After must stay truthful. No-op for unknown IDs.
+func (l *Limiter) Return(id int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	b, exists := l.buckets[id]
+	if !exists {
+		return
+	}
+	b.tokens = math.Min(b.capacity, b.tokens+1)
+}
+
 func (l *Limiter) prune() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	cutoff := time.Now().Add(-10 * time.Minute)
-	for keyID, tokenBucket := range l.buckets {
+	cutoff := l.nowFn().Add(-idleCutoff)
+	for id, tokenBucket := range l.buckets {
 		if tokenBucket.lastAccess.Before(cutoff) {
-			delete(l.buckets, keyID)
+			delete(l.buckets, id)
 		}
-	}
-}
-
-// Middleware returns HTTP middleware that enforces per-key rate limits.
-func Middleware(limiter *Limiter, m *metrics.Metrics) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			key := auth.KeyFromContext(r.Context())
-			if key == nil {
-				// No key in context means auth middleware didn't run (shouldn't happen)
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			allowed, retryAfter := limiter.Allow(key.ID, key.RateLimit)
-			if !allowed {
-				m.RecordRateLimitReject()
-				w.Header().Set("Content-Type", "application/json")
-				w.Header().Set("Retry-After", fmt.Sprintf("%.0f", math.Ceil(retryAfter)))
-				w.WriteHeader(http.StatusTooManyRequests)
-				w.Write([]byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_exceeded","code":"rate_limit_exceeded"}}`))
-				return
-			}
-
-			next.ServeHTTP(w, r)
-		})
 	}
 }

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -1,18 +1,28 @@
 package ratelimit
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
+	"math/rand"
 	"testing"
 	"time"
-
-	"github.com/krishna/local-ai-proxy/internal/auth"
-	"github.com/krishna/local-ai-proxy/internal/store"
 )
 
+// testClock is a manually-advanced clock so refill behavior is asserted
+// deterministically (no time.Sleep).
+type testClock struct{ t time.Time }
+
+func newTestClock() *testClock {
+	return &testClock{t: time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)}
+}
+func (c *testClock) now() time.Time          { return c.t }
+func (c *testClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newTestLimiter() (*Limiter, *testClock) {
+	clock := newTestClock()
+	return NewWithClock(clock.now), clock
+}
+
 func TestAllow_FirstRequest(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
+	l, _ := newTestLimiter()
 	allowed, retryAfter := l.Allow(1, 60)
 	if !allowed {
 		t.Error("first request should be allowed")
@@ -23,9 +33,7 @@ func TestAllow_FirstRequest(t *testing.T) {
 }
 
 func TestAllow_WithinLimit(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
-
-	// Use a rate limit of 10 so the bucket starts with 10 tokens
+	l, _ := newTestLimiter()
 	for i := 0; i < 10; i++ {
 		allowed, _ := l.Allow(1, 10)
 		if !allowed {
@@ -35,14 +43,10 @@ func TestAllow_WithinLimit(t *testing.T) {
 }
 
 func TestAllow_ExceedsLimit(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
-
-	// Exhaust all tokens (rate limit of 5)
+	l, _ := newTestLimiter()
 	for i := 0; i < 5; i++ {
 		l.Allow(1, 5)
 	}
-
-	// Next request should be denied
 	allowed, retryAfter := l.Allow(1, 5)
 	if allowed {
 		t.Error("request exceeding limit should be denied")
@@ -52,108 +56,146 @@ func TestAllow_ExceedsLimit(t *testing.T) {
 	}
 }
 
-func TestAllow_DifferentKeysIndependent(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
-
-	// Exhaust key 1 (rate limit 2)
+func TestAllow_DifferentIDsIndependent(t *testing.T) {
+	l, _ := newTestLimiter()
 	l.Allow(1, 2)
 	l.Allow(1, 2)
-	allowed, _ := l.Allow(1, 2)
-	if allowed {
-		t.Error("key 1 should be exhausted")
+	if allowed, _ := l.Allow(1, 2); allowed {
+		t.Error("id 1 should be exhausted")
 	}
-
-	// Key 2 should still work
-	allowed, _ = l.Allow(2, 2)
-	if !allowed {
-		t.Error("key 2 should be independent and allowed")
+	if allowed, _ := l.Allow(2, 2); !allowed {
+		t.Error("id 2 should be independent and allowed")
 	}
 }
 
 func TestAllow_TokenRefill(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
+	l, clock := newTestLimiter()
+	rateLimit := 60 // 1 token/second
 
-	// Use a small rate limit: 60 tokens/minute = 1 token/second
-	rateLimit := 60
-
-	// Use all tokens
 	for i := 0; i < rateLimit; i++ {
 		l.Allow(1, rateLimit)
 	}
-
-	// Should be denied now
-	allowed, _ := l.Allow(1, rateLimit)
-	if allowed {
+	if allowed, _ := l.Allow(1, rateLimit); allowed {
 		t.Error("should be denied after exhausting tokens")
 	}
 
-	// Wait enough time for at least 1 token to refill
-	// 60 tokens / 60 seconds = 1 token/sec, so 1.1 seconds should give us 1+ tokens
-	time.Sleep(1200 * time.Millisecond)
-
-	allowed, _ = l.Allow(1, rateLimit)
-	if !allowed {
+	clock.advance(1200 * time.Millisecond)
+	if allowed, _ := l.Allow(1, rateLimit); !allowed {
 		t.Error("should be allowed after token refill")
 	}
 }
 
 func TestAllow_ZeroRateLimit(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
+	l, _ := newTestLimiter()
 
-	// Zero rate limit: first request creates a bucket with capacity 0
-	// and tokens = 0 - 1 = -1, so it should still be "allowed" for the first call
-	// because the bucket is newly created (first request always allowed).
-	allowed, _ := l.Allow(1, 0)
-	if !allowed {
+	// Zero rate limit: first request creates the bucket (always allowed);
+	// afterwards capacity 0 denies everything with a zero refill rate.
+	if allowed, _ := l.Allow(1, 0); !allowed {
 		t.Error("first request should be allowed even with zero rate limit")
 	}
-
-	// Second request: capacity is 0, tokens will be refilled to min(0, ...)
-	// which is 0 or negative, so should be denied
 	allowed, retryAfter := l.Allow(1, 0)
 	if allowed {
 		t.Error("second request with zero rate limit should be denied")
 	}
-	// With zero refill rate, retryAfter calculation involves division by zero
-	// or infinity; just check it doesn't panic and retryAfter is not negative
 	if retryAfter < 0 {
 		t.Errorf("retryAfter should not be negative, got %f", retryAfter)
 	}
 }
 
 func TestAllow_CapacityUpdateOnRateLimitChange(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
+	l, clock := newTestLimiter()
 
-	// Start with rate limit 2
 	l.Allow(1, 2)
 	l.Allow(1, 2)
-
-	// Exhausted at rate limit 2
-	allowed, _ := l.Allow(1, 2)
-	if allowed {
+	if allowed, _ := l.Allow(1, 2); allowed {
 		t.Error("should be exhausted at rate limit 2")
 	}
 
-	// Now increase rate limit to 6000 — refill rate = 6000/60 = 100 tokens/sec.
-	// After 100ms, we get ~10 tokens refilled, which is >= 1.
-	time.Sleep(100 * time.Millisecond)
-	allowed, _ = l.Allow(1, 6000)
-	if !allowed {
+	// Raise the limit to 6000 → refill 100 tokens/sec; 100ms refills ~10.
+	clock.advance(100 * time.Millisecond)
+	if allowed, _ := l.Allow(1, 6000); !allowed {
 		t.Error("should be allowed after increasing rate limit (higher refill rate)")
 	}
 }
 
-func TestPrune(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
+func TestReturn_RefundsToken(t *testing.T) {
+	l, _ := newTestLimiter()
 
-	// Add a bucket with old lastAccess
+	l.Allow(1, 2)
+	l.Allow(1, 2)
+	if allowed, _ := l.Allow(1, 2); allowed {
+		t.Fatal("should be exhausted before the refund")
+	}
+	l.Return(1)
+	if allowed, _ := l.Allow(1, 2); !allowed {
+		t.Error("refunded token should allow one more request")
+	}
+}
+
+func TestReturn_ClampedAtCapacity(t *testing.T) {
+	l, _ := newTestLimiter()
+
+	// One consume then three refunds: tokens must clamp at capacity (5),
+	// so exactly 5 further requests pass before denial.
+	l.Allow(1, 5)
+	l.Return(1)
+	l.Return(1)
+	l.Return(1)
+	for i := 0; i < 5; i++ {
+		if allowed, _ := l.Allow(1, 5); !allowed {
+			t.Fatalf("request %d should be allowed (clamped refund)", i+1)
+		}
+	}
+	if allowed, _ := l.Allow(1, 5); allowed {
+		t.Error("over-refunded bucket must not exceed capacity")
+	}
+}
+
+func TestReturn_UnknownIDIsNoop(t *testing.T) {
+	l, _ := newTestLimiter()
+	l.Return(42) // must not panic or create a bucket
+	l.mu.Lock()
+	_, exists := l.buckets[42]
+	l.mu.Unlock()
+	if exists {
+		t.Error("Return must not create buckets")
+	}
+}
+
+// A wrong refund ordering silently doubles effective limits — pin the
+// invariant tokens <= capacity under arbitrary Allow/Return/refill
+// interleavings.
+func TestReturn_NeverExceedsCapacity(t *testing.T) {
+	l, clock := newTestLimiter()
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 2000; i++ {
+		switch r.Intn(3) {
+		case 0:
+			l.Allow(1, 5)
+		case 1:
+			l.Return(1)
+		case 2:
+			clock.advance(time.Duration(r.Intn(500)) * time.Millisecond)
+		}
+		l.mu.Lock()
+		if b, ok := l.buckets[1]; ok && b.tokens > b.capacity {
+			l.mu.Unlock()
+			t.Fatalf("iteration %d: tokens %f exceeded capacity %f", i, b.tokens, b.capacity)
+		}
+		l.mu.Unlock()
+	}
+}
+
+func TestPrune(t *testing.T) {
+	l, clock := newTestLimiter()
+
 	l.mu.Lock()
 	l.buckets[99] = &bucket{
 		tokens:     5,
 		capacity:   10,
 		refillRate: 10.0 / 60.0,
-		lastRefill: time.Now().Add(-15 * time.Minute),
-		lastAccess: time.Now().Add(-15 * time.Minute),
+		lastRefill: clock.now().Add(-15 * time.Minute),
+		lastAccess: clock.now().Add(-15 * time.Minute),
 	}
 	l.mu.Unlock()
 
@@ -162,59 +204,34 @@ func TestPrune(t *testing.T) {
 	l.mu.Lock()
 	_, exists := l.buckets[99]
 	l.mu.Unlock()
-
 	if exists {
 		t.Error("stale bucket should have been pruned")
 	}
 }
 
 func TestPrune_KeepsRecent(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
-
-	// Use Allow to create a recent bucket
+	l, _ := newTestLimiter()
 	l.Allow(42, 10)
-
 	l.prune()
-
 	l.mu.Lock()
 	_, exists := l.buckets[42]
 	l.mu.Unlock()
-
 	if !exists {
 		t.Error("recent bucket should not be pruned")
 	}
 }
 
 func TestPrune_MixedBuckets(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
-
-	now := time.Now()
+	l, clock := newTestLimiter()
+	now := clock.now()
 
 	l.mu.Lock()
-	// Stale bucket
-	l.buckets[1] = &bucket{
-		tokens:     5,
-		capacity:   10,
-		refillRate: 10.0 / 60.0,
-		lastRefill: now.Add(-20 * time.Minute),
-		lastAccess: now.Add(-20 * time.Minute),
-	}
-	// Recent bucket
-	l.buckets[2] = &bucket{
-		tokens:     5,
-		capacity:   10,
-		refillRate: 10.0 / 60.0,
-		lastRefill: now,
-		lastAccess: now,
-	}
-	// Exactly at cutoff boundary (10 minutes ago) - should be kept
-	l.buckets[3] = &bucket{
-		tokens:     5,
-		capacity:   10,
-		refillRate: 10.0 / 60.0,
-		lastRefill: now.Add(-9 * time.Minute),
-		lastAccess: now.Add(-9 * time.Minute),
-	}
+	l.buckets[1] = &bucket{tokens: 5, capacity: 10, refillRate: 10.0 / 60.0,
+		lastRefill: now.Add(-20 * time.Minute), lastAccess: now.Add(-20 * time.Minute)}
+	l.buckets[2] = &bucket{tokens: 5, capacity: 10, refillRate: 10.0 / 60.0,
+		lastRefill: now, lastAccess: now}
+	l.buckets[3] = &bucket{tokens: 5, capacity: 10, refillRate: 10.0 / 60.0,
+		lastRefill: now.Add(-9 * time.Minute), lastAccess: now.Add(-9 * time.Minute)}
 	l.mu.Unlock()
 
 	l.prune()
@@ -236,139 +253,34 @@ func TestPrune_MixedBuckets(t *testing.T) {
 	}
 }
 
-func TestMiddleware_NoKeyInContext(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
-
-	nextCalled := false
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nextCalled = true
-		w.WriteHeader(http.StatusOK)
-	})
-
-	mw := Middleware(l, nil)(next)
-
-	// Request with no auth key in context
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/models", nil)
-	rec := httptest.NewRecorder()
-
-	mw.ServeHTTP(rec, req)
-
-	if !nextCalled {
-		t.Error("next handler should be called when no key in context")
-	}
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", rec.Code)
-	}
-}
-
-func TestMiddleware_AllowedRequest(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
-
-	nextCalled := false
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nextCalled = true
-		w.WriteHeader(http.StatusOK)
-	})
-
-	mw := Middleware(l, nil)(next)
-
-	key := &store.APIKey{
-		ID:        1,
-		Name:      "test",
-		RateLimit: 60,
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/models", nil)
-	ctx := auth.WithKey(req.Context(), key)
-	req = req.WithContext(ctx)
-	rec := httptest.NewRecorder()
-
-	mw.ServeHTTP(rec, req)
-
-	if !nextCalled {
-		t.Error("next handler should be called for allowed request")
-	}
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", rec.Code)
-	}
-}
-
-func TestMiddleware_RateLimited(t *testing.T) {
-	l := &Limiter{buckets: make(map[int64]*bucket)}
-
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	mw := Middleware(l, nil)(next)
-
-	key := &store.APIKey{
-		ID:        1,
-		Name:      "test",
-		RateLimit: 2, // very low limit
-	}
-
-	// Exhaust the rate limit
-	for i := 0; i < 2; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		ctx := auth.WithKey(req.Context(), key)
-		req = req.WithContext(ctx)
-		rec := httptest.NewRecorder()
-		mw.ServeHTTP(rec, req)
-		if rec.Code != http.StatusOK {
-			t.Errorf("request %d should be allowed, got %d", i+1, rec.Code)
-		}
-	}
-
-	// This request should be rate limited
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	ctx := auth.WithKey(req.Context(), key)
-	req = req.WithContext(ctx)
-	rec := httptest.NewRecorder()
-	mw.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusTooManyRequests {
-		t.Errorf("expected 429, got %d", rec.Code)
-	}
-
-	// Check response body
-	var body map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("failed to parse response body: %v", err)
-	}
-	errObj, ok := body["error"].(map[string]any)
-	if !ok {
-		t.Fatal("expected 'error' object in response")
-	}
-	if errObj["code"] != "rate_limit_exceeded" {
-		t.Errorf("expected code 'rate_limit_exceeded', got %v", errObj["code"])
-	}
-
-	// Check Retry-After header
-	retryAfter := rec.Header().Get("Retry-After")
-	if retryAfter == "" {
-		t.Error("expected Retry-After header")
-	}
-
-	// Check Content-Type
-	ct := rec.Header().Get("Content-Type")
-	if ct != "application/json" {
-		t.Errorf("expected Content-Type 'application/json', got %q", ct)
-	}
-}
-
 func TestNew_CreatesLimiter(t *testing.T) {
 	l := New()
 	if l == nil {
 		t.Fatal("New() returned nil")
 	}
-	if l.buckets == nil {
-		t.Error("buckets map should be initialized")
-	}
-
-	// Verify it works by making a request
-	allowed, _ := l.Allow(1, 10)
-	if !allowed {
+	if allowed, _ := l.Allow(1, 10); !allowed {
 		t.Error("first request should be allowed")
+	}
+}
+
+func TestEffectiveLimit(t *testing.T) {
+	limits := Limits{EndUserPerMin: 30, ServicePerMin: 300}
+	override := 45
+
+	cases := []struct {
+		name             string
+		override         *int
+		allowanceManaged bool
+		want             int
+	}{
+		{"end-user default", nil, true, 30},
+		{"service default", nil, false, 300},
+		{"end-user override", &override, true, 45},
+		{"service override", &override, false, 45},
+	}
+	for _, tc := range cases {
+		if got := EffectiveLimit(tc.override, tc.allowanceManaged, limits); got != tc.want {
+			t.Errorf("%s: expected %d, got %d", tc.name, tc.want, got)
+		}
 	}
 }

--- a/internal/store/account_rate_limit_test.go
+++ b/internal/store/account_rate_limit_test.go
@@ -83,6 +83,30 @@ func TestGetKeyByHash_IncludesAccountRateLimit(t *testing.T) {
 	}
 }
 
+// A key created directly on an allowance-managed account must carry the
+// account's class so the limiter and 402 wording don't silently degrade to
+// service semantics (codex review finding on PR #65).
+func TestGetKeyByHash_CarriesAllowanceManaged(t *testing.T) {
+	s := setupTestStore(t)
+	res, err := s.ResolveEndUserAccount(FederatedIdentity{
+		Source: "openwebui", ExternalID: "rl-direct", Email: "rl-direct@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	if _, err := s.CreateKeyForAccountOnly(res.AccountID, "direct-eua-key", "hash-rl-direct", "laip_dr", 60); err != nil {
+		t.Fatalf("CreateKeyForAccountOnly: %v", err)
+	}
+
+	key, err := s.GetKeyByHash("hash-rl-direct")
+	if err != nil || key == nil {
+		t.Fatalf("GetKeyByHash: %v, %v", key, err)
+	}
+	if !key.AccountAllowanceManaged {
+		t.Error("key on an allowance-managed account must report AccountAllowanceManaged=true")
+	}
+}
+
 func TestGetKeyByHash_LegacyKeyWithoutAccount(t *testing.T) {
 	s := setupTestStore(t)
 	if _, err := s.CreateKey("legacy-rl", "hash-legacy-rl", "laip_lg", 60); err != nil {

--- a/internal/store/account_rate_limit_test.go
+++ b/internal/store/account_rate_limit_test.go
@@ -1,0 +1,154 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Per-account rate-limit override plumbing
+// (docs/design/per-account-rate-limiting.md §4.2).
+
+func TestSetAccountRateLimit_SetAndClear(t *testing.T) {
+	s := setupTestStore(t)
+	res, err := s.ResolveEndUserAccount(FederatedIdentity{
+		Source: "openwebui", ExternalID: "rl-1", Email: "rl@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+
+	perMin := 45
+	if err := s.SetAccountRateLimit(res.AccountID, &perMin); err != nil {
+		t.Fatalf("SetAccountRateLimit: %v", err)
+	}
+	var got *int
+	if err := s.pool.QueryRow(context.Background(),
+		`SELECT rate_limit_per_min FROM accounts WHERE id = $1`, res.AccountID).Scan(&got); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if got == nil || *got != 45 {
+		t.Errorf("expected override 45, got %v", got)
+	}
+
+	// nil clears back to the class default.
+	if err := s.SetAccountRateLimit(res.AccountID, nil); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if err := s.pool.QueryRow(context.Background(),
+		`SELECT rate_limit_per_min FROM accounts WHERE id = $1`, res.AccountID).Scan(&got); err != nil {
+		t.Fatalf("read back after clear: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected NULL after clear, got %v", *got)
+	}
+}
+
+func TestSetAccountRateLimit_NotFound(t *testing.T) {
+	s := setupTestStore(t)
+	perMin := 45
+	if err := s.SetAccountRateLimit(999999, &perMin); err == nil {
+		t.Error("expected error for unknown account")
+	}
+}
+
+func TestGetKeyByHash_IncludesAccountRateLimit(t *testing.T) {
+	s := setupTestStore(t)
+	accountID, _, err := s.RegisterUser("rl-svc@example.com", "hash", "rl-svc")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	if _, err := s.CreateKeyForAccountOnly(accountID, "rl-svc-key", "hash-rl-svc", "laip_rl", 60); err != nil {
+		t.Fatalf("CreateKeyForAccountOnly: %v", err)
+	}
+
+	key, err := s.GetKeyByHash("hash-rl-svc")
+	if err != nil || key == nil {
+		t.Fatalf("GetKeyByHash: %v, %v", key, err)
+	}
+	if key.AccountRateLimitPerMin != nil {
+		t.Errorf("expected nil override before set, got %v", *key.AccountRateLimitPerMin)
+	}
+
+	perMin := 77
+	if err := s.SetAccountRateLimit(accountID, &perMin); err != nil {
+		t.Fatalf("SetAccountRateLimit: %v", err)
+	}
+	key, err = s.GetKeyByHash("hash-rl-svc")
+	if err != nil || key == nil {
+		t.Fatalf("GetKeyByHash after set: %v, %v", key, err)
+	}
+	if key.AccountRateLimitPerMin == nil || *key.AccountRateLimitPerMin != 77 {
+		t.Errorf("expected override 77 on key lookup, got %v", key.AccountRateLimitPerMin)
+	}
+}
+
+func TestGetKeyByHash_LegacyKeyWithoutAccount(t *testing.T) {
+	s := setupTestStore(t)
+	if _, err := s.CreateKey("legacy-rl", "hash-legacy-rl", "laip_lg", 60); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	key, err := s.GetKeyByHash("hash-legacy-rl")
+	if err != nil || key == nil {
+		t.Fatalf("GetKeyByHash: %v, %v", key, err)
+	}
+	if key.AccountRateLimitPerMin != nil {
+		t.Errorf("legacy nil-account key must have nil override, got %v", *key.AccountRateLimitPerMin)
+	}
+}
+
+func TestResolveEndUserAccount_CarriesRateLimit(t *testing.T) {
+	s := setupTestStore(t)
+	id := FederatedIdentity{Source: "openwebui", ExternalID: "rl-eua", Email: "rl-eua@example.com"}
+
+	res, err := s.ResolveEndUserAccount(id, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	if res.RateLimitPerMin != nil {
+		t.Errorf("fresh end-user account must have nil override, got %v", *res.RateLimitPerMin)
+	}
+
+	perMin := 12
+	if err := s.SetAccountRateLimit(res.AccountID, &perMin); err != nil {
+		t.Fatalf("SetAccountRateLimit: %v", err)
+	}
+	res2, err := s.ResolveEndUserAccount(id, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if res2.AccountID != res.AccountID {
+		t.Fatalf("expected stable account, got %d then %d", res.AccountID, res2.AccountID)
+	}
+	if res2.RateLimitPerMin == nil || *res2.RateLimitPerMin != 12 {
+		t.Errorf("expected override 12 carried out of resolve, got %v", res2.RateLimitPerMin)
+	}
+}
+
+func TestListAccountsWithBalances_IncludesRateLimit(t *testing.T) {
+	s := setupTestStore(t)
+	res, err := s.ResolveEndUserAccount(FederatedIdentity{
+		Source: "openwebui", ExternalID: "rl-list", Email: "rl-list@example.com",
+	}, 5.0, time.Now())
+	if err != nil {
+		t.Fatalf("ResolveEndUserAccount: %v", err)
+	}
+	perMin := 20
+	if err := s.SetAccountRateLimit(res.AccountID, &perMin); err != nil {
+		t.Fatalf("SetAccountRateLimit: %v", err)
+	}
+
+	rows, err := s.ListAccountsWithBalances()
+	if err != nil {
+		t.Fatalf("ListAccountsWithBalances: %v", err)
+	}
+	for _, r := range rows {
+		if r.ID == res.AccountID {
+			if r.RateLimitPerMin == nil || *r.RateLimitPerMin != 20 {
+				t.Errorf("expected override 20 in listing, got %v", r.RateLimitPerMin)
+			}
+			return
+		}
+	}
+	t.Fatal("account not found in listing")
+}

--- a/internal/store/credits.go
+++ b/internal/store/credits.go
@@ -592,6 +592,7 @@ type AccountWithBalance struct {
 	AllowanceManaged bool
 	MonthlyGrant     *float64 // nil = env default applies
 	FederatedEmail   *string  // nil = no federated identity
+	RateLimitPerMin  *int     // nil = class env default applies
 }
 
 func (s *Store) ListAccountsWithBalances() ([]AccountWithBalance, error) {
@@ -599,7 +600,7 @@ func (s *Store) ListAccountsWithBalances() ([]AccountWithBalance, error) {
 		context.Background(),
 		`SELECT a.id, a.name, a.type, a.is_active, a.created_at,
 		        COALESCE(cb.balance, 0), COALESCE(cb.reserved, 0),
-		        a.allowance_managed, a.monthly_grant, fi.email
+		        a.allowance_managed, a.monthly_grant, fi.email, a.rate_limit_per_min
 		 FROM accounts a
 		 LEFT JOIN credit_balances cb ON cb.account_id = a.id
 		 LEFT JOIN LATERAL (
@@ -617,7 +618,7 @@ func (s *Store) ListAccountsWithBalances() ([]AccountWithBalance, error) {
 	for rows.Next() {
 		var r AccountWithBalance
 		if err := rows.Scan(&r.ID, &r.Name, &r.Type, &r.IsActive, &r.CreatedAt,
-			&r.Balance, &r.Reserved, &r.AllowanceManaged, &r.MonthlyGrant, &r.FederatedEmail); err != nil {
+			&r.Balance, &r.Reserved, &r.AllowanceManaged, &r.MonthlyGrant, &r.FederatedEmail, &r.RateLimitPerMin); err != nil {
 			return nil, err
 		}
 		results = append(results, r)

--- a/internal/store/federated.go
+++ b/internal/store/federated.go
@@ -23,6 +23,10 @@ type EndUserResolution struct {
 	AccountID        int64
 	Provisioned      bool // account was created by this call
 	AllowanceGranted bool // monthly allowance was applied by this call
+	// RateLimitPerMin is the account's rate_limit_per_min override; nil =
+	// class env default. Carried out of the per-request accounts SELECT so
+	// the rate limiter needs no extra query.
+	RateLimitPerMin *int
 }
 
 // accountName picks the display name for an auto-provisioned account:
@@ -62,7 +66,7 @@ func (s *Store) ResolveEndUserAccount(id FederatedIdentity, defaultGrant float64
 	}
 	res.AccountID = accountID
 
-	res.AllowanceGranted, err = s.applyMonthlyAllowance(ctx, accountID, defaultGrant, now)
+	res.AllowanceGranted, res.RateLimitPerMin, err = s.applyMonthlyAllowance(ctx, accountID, defaultGrant, now)
 	if err != nil {
 		return res, err
 	}
@@ -160,18 +164,21 @@ func (s *Store) provisionFederatedAccount(ctx context.Context, id FederatedIdent
 // winner under concurrency; the reset (not +=) is what makes the grant a
 // monthly spend cap — unspent allowance does not roll over. In-flight holds
 // (reserved) are deliberately untouched.
-func (s *Store) applyMonthlyAllowance(ctx context.Context, accountID int64, defaultGrant float64, now time.Time) (bool, error) {
+// It also carries out the account's rate_limit_per_min override — the SELECT
+// here runs per-request anyway, so the rate limiter gets its input for free.
+func (s *Store) applyMonthlyAllowance(ctx context.Context, accountID int64, defaultGrant float64, now time.Time) (bool, *int, error) {
 	var managed bool
 	var override *float64
+	var ratePerMin *int
 	err := s.pool.QueryRow(ctx,
-		`SELECT allowance_managed, monthly_grant FROM accounts WHERE id = $1`,
+		`SELECT allowance_managed, monthly_grant, rate_limit_per_min FROM accounts WHERE id = $1`,
 		accountID,
-	).Scan(&managed, &override)
+	).Scan(&managed, &override, &ratePerMin)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 	if !managed {
-		return false, nil
+		return false, ratePerMin, nil
 	}
 	grant := defaultGrant
 	if override != nil {
@@ -181,7 +188,7 @@ func (s *Store) applyMonthlyAllowance(ctx context.Context, accountID int64, defa
 
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return false, err
+		return false, ratePerMin, err
 	}
 	defer tx.Rollback(ctx)
 
@@ -193,22 +200,22 @@ func (s *Store) applyMonthlyAllowance(ctx context.Context, accountID int64, defa
 		accountID, grant, month,
 	)
 	if err != nil {
-		return false, err
+		return false, ratePerMin, err
 	}
 	if ct.RowsAffected() == 0 {
-		return false, nil // already granted this month (possibly by a concurrent request)
+		return false, ratePerMin, nil // already granted this month (possibly by a concurrent request)
 	}
 	if _, err = tx.Exec(ctx,
 		`INSERT INTO credit_transactions (account_id, amount, balance_after, type, description)
 		 VALUES ($1, $2, $2, 'monthly_allowance', $3)`,
 		accountID, grant, fmt.Sprintf("monthly allowance %s", month.Format("2006-01")),
 	); err != nil {
-		return false, err
+		return false, ratePerMin, err
 	}
 	if err = tx.Commit(ctx); err != nil {
-		return false, err
+		return false, ratePerMin, err
 	}
-	return true, nil
+	return true, ratePerMin, nil
 }
 
 // SetMonthlyGrant sets (or, with nil, clears back to the env default) an
@@ -218,6 +225,23 @@ func (s *Store) SetMonthlyGrant(accountID int64, grant *float64) error {
 	ct, err := s.pool.Exec(context.Background(),
 		`UPDATE accounts SET monthly_grant = $2 WHERE id = $1`,
 		accountID, grant,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return fmt.Errorf("account not found")
+	}
+	return nil
+}
+
+// SetAccountRateLimit sets (or, with nil, clears back to the class env
+// default) an account's per-minute rate-limit override. Takes effect on the
+// account's next request (docs/design/per-account-rate-limiting.md §4.2).
+func (s *Store) SetAccountRateLimit(accountID int64, perMin *int) error {
+	ct, err := s.pool.Exec(context.Background(),
+		`UPDATE accounts SET rate_limit_per_min = $2 WHERE id = $1`,
+		accountID, perMin,
 	)
 	if err != nil {
 		return err

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -284,6 +284,16 @@ EXCEPTION WHEN duplicate_column THEN
     NULL;
 END $$;
 
+-- Per-account request rate limit override (requests/minute). NULL = class
+-- env default: END_USER_RATELIMIT_PER_MIN for allowance-managed accounts,
+-- ACCOUNT_RATELIMIT_PER_MIN otherwise. Named to avoid colliding with
+-- api_keys.rate_limit inside joins. See docs/design/per-account-rate-limiting.md.
+DO $$ BEGIN
+    ALTER TABLE accounts ADD COLUMN rate_limit_per_min INTEGER;
+EXCEPTION WHEN duplicate_column THEN
+    NULL;
+END $$;
+
 -- First day (UTC) of the month the allowance was last granted for.
 DO $$ BEGIN
     ALTER TABLE credit_balances ADD COLUMN allowance_period DATE;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -65,6 +65,10 @@ type APIKey struct {
 	// AccountRateLimitPerMin is the key's account rate_limit_per_min override;
 	// nil = class env default (or no account). Populated by GetKeyByHash only.
 	AccountRateLimitPerMin *int
+	// AccountAllowanceManaged is the key's account allowance_managed flag —
+	// a key created directly on an end-user account must keep that account's
+	// limiter class and 402 semantics. Populated by GetKeyByHash only.
+	AccountAllowanceManaged bool
 }
 
 type Account struct {
@@ -313,12 +317,13 @@ func (s *Store) GetKeyByHash(hash string) (*APIKey, error) {
 		context.Background(),
 		`SELECT k.id, k.name, k.key_hash, k.key_prefix, k.rate_limit, k.created_at, k.revoked,
 		        k.user_id, k.account_id, k.session_token_limit, k.trust_user_headers,
-		        a.rate_limit_per_min
+		        a.rate_limit_per_min, COALESCE(a.allowance_managed, FALSE)
 		 FROM api_keys k
 		 LEFT JOIN accounts a ON a.id = k.account_id
 		 WHERE k.key_hash = $1 AND k.revoked = FALSE`, hash,
 	).Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyHash, &apiKey.KeyPrefix, &apiKey.RateLimit, &apiKey.CreatedAt, &apiKey.Revoked,
-		&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.TrustUserHeaders, &apiKey.AccountRateLimitPerMin)
+		&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.TrustUserHeaders,
+		&apiKey.AccountRateLimitPerMin, &apiKey.AccountAllowanceManaged)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -62,6 +62,9 @@ type APIKey struct {
 	SessionTokenLimit *int       // nil = no session limit
 	LastUsedAt        *time.Time // nil = key has never served a request; derived from usage_logs
 	TrustUserHeaders  bool       // bill the forwarded end-user identity instead of the key's account
+	// AccountRateLimitPerMin is the key's account rate_limit_per_min override;
+	// nil = class env default (or no account). Populated by GetKeyByHash only.
+	AccountRateLimitPerMin *int
 }
 
 type Account struct {
@@ -308,10 +311,14 @@ func (s *Store) GetKeyByHash(hash string) (*APIKey, error) {
 	var apiKey APIKey
 	err := s.pool.QueryRow(
 		context.Background(),
-		`SELECT id, name, key_hash, key_prefix, rate_limit, created_at, revoked, user_id, account_id, session_token_limit, trust_user_headers
-		 FROM api_keys WHERE key_hash = $1 AND revoked = FALSE`, hash,
+		`SELECT k.id, k.name, k.key_hash, k.key_prefix, k.rate_limit, k.created_at, k.revoked,
+		        k.user_id, k.account_id, k.session_token_limit, k.trust_user_headers,
+		        a.rate_limit_per_min
+		 FROM api_keys k
+		 LEFT JOIN accounts a ON a.id = k.account_id
+		 WHERE k.key_hash = $1 AND k.revoked = FALSE`, hash,
 	).Scan(&apiKey.ID, &apiKey.Name, &apiKey.KeyHash, &apiKey.KeyPrefix, &apiKey.RateLimit, &apiKey.CreatedAt, &apiKey.Revoked,
-		&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.TrustUserHeaders)
+		&apiKey.UserID, &apiKey.AccountID, &apiKey.SessionTokenLimit, &apiKey.TrustUserHeaders, &apiKey.AccountRateLimitPerMin)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}


### PR DESCRIPTION
## Summary
Implements phases A+B of [docs/design/per-account-rate-limiting.md](../blob/feature/account-rate-limiting/docs/design/per-account-rate-limiting.md) (accepted): account-keyed rate limiting closing both per-key holes — multi-key service accounts getting N× the limit, and Open WebUI end users sharing one key bucket with no per-user isolation.

- **Account bucket before key bucket**, keyed by `billing.Resolution.AccountID`; key-level rejects refund the account token (different owners on the shared trusted key — aggregate saturation must not burn individual budgets).
- **Class env defaults** `ACCOUNT_RATELIMIT_PER_MIN=300` / `END_USER_RATELIMIT_PER_MIN=30`, boot-validated (1..10000, no `0=disabled`); nullable `accounts.rate_limit_per_min` override rides existing per-request queries — zero new per-request DB reads.
- **Admin**: `PUT /api/admin/accounts/{id}/rate-limit` (RawMessage null-vs-absent, explicit 0 rejected), `rate_limit_per_min` + `effective_rate_limit_per_min` on the accounts listing, config-snapshot fields.
- **Chain reorder**: rateLimit now precedes creditGate; regression tests pin the cap-hit → credit-request (Discord) trigger for rate-passing over-cap requests, and 429 for over-rate+over-cap.
- **Observability**: `aiproxy_account_ratelimit_rejects_total{kind,class}`; scope-differentiated 429 messages with clamped Retry-After.
- Limiters now use an injectable clock; the old `time.Sleep` tests are deterministic.

Phase C (admin FE) and phase D (concurrency caps) follow as separate PRs.

## Test plan
- Full suite `go test -race -count=1 -p 1 ./...` green locally (21 packages).
- New: bucket refund/clamp property test, middleware ordering + refund + isolation + metrics-label tests, store override plumbing, config validation, admin endpoint errors (absent/null/0/range/404), chain-order regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe