### PR TITLE
Per-account concurrency caps (phase D)

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -212,15 +212,18 @@ func main() {
 	// (docs/design/per-account-rate-limiting.md §3.1).
 	keyLimiter := ratelimit.New()
 	accountLimiter := ratelimit.New()
+	concurrency := ratelimit.NewConcurrency()
 	capHits := creditrequest.New(db, cfg.CreditAlertWebhookURL, cfg.EndUserMonthlyGrant)
 	proxyHandler := proxy.NewHandler(reg, usageCh, cfg.MaxRequestBody, db, m,
 		proxy.Options{ModelsListAll: cfg.ModelsListAll, CapHits: capHits})
 	authMiddleware := auth.Middleware(db)
 	billingResolver := billing.Middleware(db, cfg.EndUserMonthlyGrant)
 	creditGate := credits.CreditGate(db, m, capHits)
-	rateLimitMiddleware := ratelimit.Middleware(keyLimiter, accountLimiter, ratelimit.Limits{
-		EndUserPerMin: cfg.EndUserRateLimitPerMin,
-		ServicePerMin: cfg.AccountRateLimitPerMin,
+	rateLimitMiddleware := ratelimit.Middleware(keyLimiter, accountLimiter, concurrency, ratelimit.Limits{
+		EndUserPerMin:        cfg.EndUserRateLimitPerMin,
+		ServicePerMin:        cfg.AccountRateLimitPerMin,
+		EndUserMaxConcurrent: cfg.EndUserMaxConcurrent,
+		ServiceMaxConcurrent: cfg.AccountMaxConcurrent,
 	}, m)
 	cors := middleware.CORS(cfg.CORSOrigins)
 
@@ -260,6 +263,8 @@ func main() {
 		AuthBcryptMaxConcurrent:          cfg.AuthBcryptConcurrency,
 		AccountRateLimitPerMinute:        cfg.AccountRateLimitPerMin,
 		EndUserRateLimitPerMinute:        cfg.EndUserRateLimitPerMin,
+		AccountMaxConcurrent:             cfg.AccountMaxConcurrent,
+		EndUserMaxConcurrent:             cfg.EndUserMaxConcurrent,
 		UsageChannelCapacity:             usageChannelCapacity,
 		AdminSessionDurationHrs:          int(user.AdminSessionDuration / time.Hour),
 		UserSessionDurationHrs:           int(user.UserSessionDuration / time.Hour),

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -69,6 +69,13 @@ spec:
               value: "300"
             - name: END_USER_RATELIMIT_PER_MIN
               value: "30"
+            # In-flight non-GET caps — bound GPU occupancy, which req/min
+            # cannot. 5 end-user: one visible chat message = 1 visible stream
+            # + 2–4 background completions, so 3 can trip on a single send.
+            - name: ACCOUNT_MAX_CONCURRENT
+              value: "8"
+            - name: END_USER_MAX_CONCURRENT
+              value: "5"
           livenessProbe:
             httpGet:
               path: /api/healthz/live

--- a/internal/admin/config_health.go
+++ b/internal/admin/config_health.go
@@ -32,6 +32,8 @@ type ConfigSnapshot struct {
 	AuthBcryptMaxConcurrent          int     `json:"auth_bcrypt_max_concurrent"`
 	AccountRateLimitPerMinute        int     `json:"account_rate_limit_per_minute"`
 	EndUserRateLimitPerMinute        int     `json:"end_user_rate_limit_per_minute"`
+	AccountMaxConcurrent             int     `json:"account_max_concurrent"`
+	EndUserMaxConcurrent             int     `json:"end_user_max_concurrent"`
 	UsageChannelCapacity             int     `json:"usage_channel_capacity"`
 	AdminSessionDurationHrs          int     `json:"admin_session_duration_hours"`
 	UserSessionDurationHrs           int     `json:"user_session_duration_hours"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,11 @@ type Config struct {
 	// docs/design/per-account-rate-limiting.md.
 	AccountRateLimitPerMin int // ACCOUNT_RATELIMIT_PER_MIN, service accounts
 	EndUserRateLimitPerMin int // END_USER_RATELIMIT_PER_MIN, allowance-managed accounts
+
+	// Per-account caps on in-flight non-GET requests (the control that
+	// bounds GPU occupancy; requests/min only bounds arrival rate).
+	AccountMaxConcurrent int // ACCOUNT_MAX_CONCURRENT, service accounts
+	EndUserMaxConcurrent int // END_USER_MAX_CONCURRENT, allowance-managed accounts
 }
 
 func Load() (Config, error) {
@@ -182,6 +187,17 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	// Concurrency caps: 5 for end users (one visible Open WebUI message =
+	// 1 visible stream + 2–4 parallel background completions, so 3 can trip
+	// on a single send), 8 for service accounts.
+	accountMaxConcurrent, err := boundedIntEnvOrDefault("ACCOUNT_MAX_CONCURRENT", 8, maxConcurrentCap)
+	if err != nil {
+		return Config{}, err
+	}
+	endUserMaxConcurrent, err := boundedIntEnvOrDefault("END_USER_MAX_CONCURRENT", 5, maxConcurrentCap)
+	if err != nil {
+		return Config{}, err
+	}
 
 	// Track explicit presence of OLLAMA_URL (empty counts as unset, matching
 	// the rest of the config): node synthesis must distinguish "operator
@@ -244,12 +260,17 @@ func Load() (Config, error) {
 
 		AccountRateLimitPerMin: accountRateLimit,
 		EndUserRateLimitPerMin: endUserRateLimit,
+		AccountMaxConcurrent:   accountMaxConcurrent,
+		EndUserMaxConcurrent:   endUserMaxConcurrent,
 	}, nil
 }
 
 // maxRateLimitPerMin mirrors ratelimit.MaxConfigPerMinute (typo guard) —
 // duplicated here to keep config free of the ratelimit package's HTTP deps.
 const maxRateLimitPerMin = 10000
+
+// maxConcurrentCap bounds the per-account concurrency caps (typo guard).
+const maxConcurrentCap = 100
 
 // boundedIntEnvOrDefault is intEnvOrDefault with an upper bound.
 func boundedIntEnvOrDefault(key string, fallback, max int) (int, error) {

--- a/internal/credits/chain_order_test.go
+++ b/internal/credits/chain_order_test.go
@@ -28,7 +28,7 @@ func buildChain(db *store.Store, capHits *creditrequest.Recorder, limits ratelim
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	rl := ratelimit.Middleware(keys, accounts, limits, nil)
+	rl := ratelimit.Middleware(keys, accounts, ratelimit.NewConcurrency(), limits, nil)
 	gate := CreditGate(db, nil, capHits)
 	return billing.Middleware(db, 0)(rl(gate(next)))
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -32,6 +32,9 @@ type Metrics struct {
 	// Infrastructure
 	OllamaUp prometheus.Gauge
 	NodeUp   *prometheus.GaugeVec // labels: node — per-node probe health (1=up, 0=down)
+	// StreamsInflight counts non-GET /api/v1/ requests currently holding a
+	// concurrency slot — "is GPU occupancy saturated right now".
+	StreamsInflight prometheus.Gauge
 
 	// Sweeper
 	SweeperRuns  *prometheus.CounterVec // labels: operation (stale_holds|settled_cleanup), outcome (success|error)
@@ -115,6 +118,11 @@ func New(usageChLen func() int) *Metrics {
 			Help: "Whether a backend node is healthy per its last probe (1=up, 0=down), by node name.",
 		}, []string{"node"}),
 
+		StreamsInflight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "aiproxy_streams_inflight",
+			Help: "Non-GET proxy requests currently holding a per-account concurrency slot.",
+		}),
+
 		SweeperRuns: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "aiproxy_credit_sweeper_runs_total",
 			Help: "Credit-hold sweeper tick invocations by operation and outcome.",
@@ -157,6 +165,7 @@ func New(usageChLen func() int) *Metrics {
 		m.UsageDrops,
 		m.OllamaUp,
 		m.NodeUp,
+		m.StreamsInflight,
 		m.SweeperRuns,
 		m.SweeperSwept,
 		m.Registrations,
@@ -203,6 +212,22 @@ func (m *Metrics) RecordCreditGateReject() {
 		return
 	}
 	m.CreditGateRejects.Inc()
+}
+
+// RecordStreamStart marks a concurrency slot acquired. Nil-safe.
+func (m *Metrics) RecordStreamStart() {
+	if m == nil {
+		return
+	}
+	m.StreamsInflight.Inc()
+}
+
+// RecordStreamEnd marks a concurrency slot released. Nil-safe.
+func (m *Metrics) RecordStreamEnd() {
+	if m == nil {
+		return
+	}
+	m.StreamsInflight.Dec()
 }
 
 // RecordAccountRateLimitReject increments the account-level limiter reject

--- a/internal/ratelimit/concurrency.go
+++ b/internal/ratelimit/concurrency.go
@@ -1,0 +1,70 @@
+package ratelimit
+
+import "sync"
+
+// ConcurrencyLimiter caps in-flight non-GET requests per billing account —
+// the control that actually bounds GPU occupancy, which a requests/minute
+// bucket cannot (one account could open its whole minute budget as
+// simultaneous long-lived SSE streams). A keyed generalization of the
+// authlimit bcrypt semaphore: entries are deleted at zero, so idle accounts
+// cost nothing and there is nothing to prune. In-flight slots die with the
+// pod, which is exactly right — so do the streams they represent
+// (docs/design/per-account-rate-limiting.md §3.2).
+type ConcurrencyLimiter struct {
+	mu    sync.Mutex
+	inUse map[int64]int
+}
+
+func NewConcurrency() *ConcurrencyLimiter {
+	return &ConcurrencyLimiter{inUse: make(map[int64]int)}
+}
+
+// TryAcquire reserves a slot for id without blocking; max <= 0 means no cap
+// (unconfigured — boot validation keeps prod values >= 1). Callers must pair
+// a successful acquire with Release.
+func (c *ConcurrencyLimiter) TryAcquire(id int64, max int) bool {
+	if c == nil || max <= 0 {
+		return true
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inUse[id] >= max {
+		return false
+	}
+	c.inUse[id]++
+	return true
+}
+
+// Release frees a slot taken by TryAcquire. Deletes the entry at zero and
+// never goes negative.
+func (c *ConcurrencyLimiter) Release(id int64) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n, ok := c.inUse[id]
+	if !ok {
+		return
+	}
+	if n <= 1 {
+		delete(c.inUse, id)
+		return
+	}
+	c.inUse[id] = n - 1
+}
+
+// InFlight reports the total slots currently held across all accounts
+// (feeds the aiproxy_streams_inflight gauge).
+func (c *ConcurrencyLimiter) InFlight() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	total := 0
+	for _, n := range c.inUse {
+		total += n
+	}
+	return total
+}

--- a/internal/ratelimit/concurrency_test.go
+++ b/internal/ratelimit/concurrency_test.go
@@ -1,0 +1,277 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/krishna/local-ai-proxy/internal/auth"
+	"github.com/krishna/local-ai-proxy/internal/billing"
+	"github.com/krishna/local-ai-proxy/internal/metrics"
+	"github.com/krishna/local-ai-proxy/internal/store"
+)
+
+// Per-account concurrency cap (docs/design/per-account-rate-limiting.md §3.2
+// step 3, phase D).
+
+func TestConcurrency_TryAcquireRelease(t *testing.T) {
+	c := NewConcurrency()
+
+	if !c.TryAcquire(1, 2) || !c.TryAcquire(1, 2) {
+		t.Fatal("first two acquires should succeed")
+	}
+	if c.TryAcquire(1, 2) {
+		t.Error("third acquire above cap must fail")
+	}
+	// Independent accounts.
+	if !c.TryAcquire(2, 2) {
+		t.Error("other account must be unaffected")
+	}
+
+	c.Release(1)
+	if !c.TryAcquire(1, 2) {
+		t.Error("released slot should be reusable")
+	}
+}
+
+func TestConcurrency_EntriesDeletedAtZero(t *testing.T) {
+	c := NewConcurrency()
+	c.TryAcquire(1, 5)
+	c.Release(1)
+	c.mu.Lock()
+	_, exists := c.inUse[1]
+	c.mu.Unlock()
+	if exists {
+		t.Error("entry must be deleted at zero (idle accounts cost nothing)")
+	}
+}
+
+func TestConcurrency_ReleaseNeverGoesNegative(t *testing.T) {
+	c := NewConcurrency()
+	c.Release(1) // no acquire — must not panic or create state
+	c.Release(1)
+	if !c.TryAcquire(1, 1) {
+		t.Error("acquire after spurious releases should succeed")
+	}
+	if c.TryAcquire(1, 1) {
+		t.Error("spurious releases must not have minted extra capacity")
+	}
+}
+
+func TestConcurrency_ZeroCapMeansNoCap(t *testing.T) {
+	c := NewConcurrency()
+	for i := 0; i < 50; i++ {
+		if !c.TryAcquire(1, 0) {
+			t.Fatal("cap <= 0 (unconfigured) must never reject")
+		}
+	}
+	if c.InFlight() != 0 {
+		t.Errorf("uncapped acquires must not track slots, got %d", c.InFlight())
+	}
+}
+
+// blockingChain builds the middleware with concurrency caps and a next
+// handler that blocks until released, so tests can hold slots open.
+func blockingChain(limits Limits, m *metrics.Metrics) (http.Handler, chan struct{}, *ConcurrencyLimiter) {
+	clock := newTestClock()
+	release := make(chan struct{})
+	conc := NewConcurrency()
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := Middleware(NewWithClock(clock.now), NewWithClock(clock.now), conc, limits, m)(next)
+	return mw, release, conc
+}
+
+// waitFor spins (with scheduling yields) until cond holds or the deadline
+// passes — only used to wait for goroutine scheduling, never for refill.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition not reached within deadline")
+		}
+		runtime.Gosched()
+	}
+}
+
+func endUserReq(method string, key *store.APIKey, accountID int64) *http.Request {
+	req := httptest.NewRequest(method, "/api/v1/chat/completions", nil)
+	if method == http.MethodGet {
+		req = httptest.NewRequest(method, "/api/v1/models", nil)
+	}
+	ctx := auth.WithKey(req.Context(), key)
+	ctx = billing.WithResolution(ctx, billing.Resolution{AccountID: accountID, AllowanceManaged: true})
+	return req.WithContext(ctx)
+}
+
+func TestMiddleware_ConcurrencyCapRejects(t *testing.T) {
+	m := metrics.New(func() int { return 0 })
+	limits := Limits{EndUserPerMin: 100, ServicePerMin: 300, EndUserMaxConcurrent: 1, ServiceMaxConcurrent: 8}
+	mw, release, _ := blockingChain(limits, m)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+
+	// Hold one slot open.
+	first := make(chan *httptest.ResponseRecorder)
+	go func() {
+		rec := httptest.NewRecorder()
+		mw.ServeHTTP(rec, endUserReq(http.MethodPost, key, 7))
+		first <- rec
+	}()
+	// Wait until the in-flight request holds its slot.
+	waitFor(t, func() bool { return testutil.ToFloat64(m.StreamsInflight) == 1 })
+
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, endUserReq(http.MethodPost, key, 7))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("second concurrent request must 429, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "concurrent requests for your account (max 1)") {
+		t.Errorf("expected concurrency-scope message, got: %s", rec.Body.String())
+	}
+	if rec.Header().Get("Retry-After") != "5" {
+		t.Errorf("expected advisory Retry-After 5, got %q", rec.Header().Get("Retry-After"))
+	}
+	if got := testutil.ToFloat64(m.AccountRateLimitRejects.WithLabelValues("concurrency", "enduser")); got != 1 {
+		t.Errorf("expected 1 concurrency reject metric, got %v", got)
+	}
+
+	close(release)
+	if rec := <-first; rec.Code != http.StatusOK {
+		t.Fatalf("held request should complete 200, got %d", rec.Code)
+	}
+	if got := testutil.ToFloat64(m.StreamsInflight); got != 0 {
+		t.Errorf("gauge must return to 0 after release, got %v", got)
+	}
+
+	// Slot released on normal return: next request passes.
+	rec2 := httptest.NewRecorder()
+	mw.ServeHTTP(rec2, endUserReq(http.MethodPost, key, 7))
+	if rec2.Code != http.StatusOK {
+		t.Errorf("slot must be reusable after release, got %d", rec2.Code)
+	}
+}
+
+// A concurrency reject deliberately does NOT refund the account rate token —
+// a free retry would let a client busy-poll the semaphore at zero cost.
+func TestMiddleware_ConcurrencyRejectKeepsRateToken(t *testing.T) {
+	limits := Limits{EndUserPerMin: 5, ServicePerMin: 300, EndUserMaxConcurrent: 1, ServiceMaxConcurrent: 8}
+	clock := newTestClock()
+	accounts := NewWithClock(clock.now)
+	conc := NewConcurrency()
+	release := make(chan struct{})
+	started := make(chan struct{})
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := Middleware(NewWithClock(clock.now), accounts, conc, limits, nil)(next)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+
+	done := make(chan struct{})
+	go func() {
+		mw.ServeHTTP(httptest.NewRecorder(), endUserReq(http.MethodPost, key, 7))
+		close(done)
+	}()
+	<-started
+
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, endUserReq(http.MethodPost, key, 7))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected concurrency 429, got %d", rec.Code)
+	}
+
+	accounts.mu.Lock()
+	tokens := accounts.buckets[7].tokens
+	accounts.mu.Unlock()
+	// 5 capacity − 1 (held request) − 1 (rejected request, NOT refunded) = 3.
+	if tokens != 3 {
+		t.Errorf("concurrency reject must consume the rate token: expected 3, got %f", tokens)
+	}
+
+	close(release)
+	<-done
+}
+
+func TestMiddleware_GETsNeverTakeSlots(t *testing.T) {
+	m := metrics.New(func() int { return 0 })
+	limits := Limits{EndUserPerMin: 100, ServicePerMin: 300, EndUserMaxConcurrent: 1, ServiceMaxConcurrent: 8}
+	mw, release, conc := blockingChain(limits, m)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+
+	// Hold the only slot with a POST.
+	postDone := make(chan struct{})
+	go func() {
+		mw.ServeHTTP(httptest.NewRecorder(), endUserReq(http.MethodPost, key, 7))
+		close(postDone)
+	}()
+	waitFor(t, func() bool { return testutil.ToFloat64(m.StreamsInflight) == 1 })
+
+	// GET must pass despite the saturated slot — but it blocks on the same
+	// next handler, so run it concurrently and release both.
+	got := make(chan int)
+	go func() {
+		rec := httptest.NewRecorder()
+		mw.ServeHTTP(rec, endUserReq(http.MethodGet, key, 7))
+		got <- rec.Code
+	}()
+	// The GET completing 200 proves it passed the concurrency gate while
+	// the POST held the only slot; the gauge never exceeding 1 proves it
+	// took no slot of its own.
+	close(release)
+	if code := <-got; code != http.StatusOK {
+		t.Fatalf("GET must bypass the concurrency cap, got %d", code)
+	}
+	<-postDone
+	if n := conc.InFlight(); n != 0 {
+		t.Errorf("expected all slots released, got %d", n)
+	}
+}
+
+// A leaked slot silently strangles an account until pod restart — the defer
+// must release on handler panic.
+func TestMiddleware_SlotReleasedOnPanic(t *testing.T) {
+	clock := newTestClock()
+	conc := NewConcurrency()
+	limits := Limits{EndUserPerMin: 100, ServicePerMin: 300, EndUserMaxConcurrent: 1, ServiceMaxConcurrent: 8}
+	panicking := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	})
+	mw := Middleware(NewWithClock(clock.now), NewWithClock(clock.now), conc, limits, nil)(panicking)
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected the handler panic to propagate")
+			}
+		}()
+		mw.ServeHTTP(httptest.NewRecorder(), endUserReq(http.MethodPost, key, 7))
+	}()
+
+	if !conc.TryAcquire(7, 1) {
+		t.Error("slot must be released after a handler panic")
+	}
+	conc.Release(7)
+}
+
+func TestMiddleware_NilConcurrencyLimiterSkipsCap(t *testing.T) {
+	clock := newTestClock()
+	limits := Limits{EndUserPerMin: 100, ServicePerMin: 300, EndUserMaxConcurrent: 1, ServiceMaxConcurrent: 1}
+	mw := Middleware(NewWithClock(clock.now), NewWithClock(clock.now), nil, limits, nil)(okNext())
+	key := &store.APIKey{ID: 1, RateLimit: 1000}
+
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, endUserReq(http.MethodPost, key, 7))
+	if rec.Code != http.StatusOK {
+		t.Errorf("nil concurrency limiter must pass through, got %d", rec.Code)
+	}
+}

--- a/internal/ratelimit/middleware.go
+++ b/internal/ratelimit/middleware.go
@@ -12,12 +12,24 @@ import (
 	"github.com/krishna/local-ai-proxy/internal/metrics"
 )
 
-// Limits carries the class-default account rate limits (requests/minute).
-// A per-account override (accounts.rate_limit_per_min) takes precedence via
-// EffectiveLimit.
+// Limits carries the class-default account rate limits (requests/minute)
+// and concurrency caps (in-flight non-GET requests). A per-account override
+// (accounts.rate_limit_per_min) takes precedence over the per-minute
+// defaults via EffectiveLimit; concurrency caps are env-only. Zero-value
+// caps mean "no cap" (boot validation keeps prod values >= 1).
 type Limits struct {
 	EndUserPerMin int // accounts with AllowanceManaged=true (END_USER_RATELIMIT_PER_MIN)
 	ServicePerMin int // every other account (ACCOUNT_RATELIMIT_PER_MIN)
+
+	EndUserMaxConcurrent int // END_USER_MAX_CONCURRENT
+	ServiceMaxConcurrent int // ACCOUNT_MAX_CONCURRENT
+}
+
+func (l Limits) maxConcurrent(allowanceManaged bool) int {
+	if allowanceManaged {
+		return l.EndUserMaxConcurrent
+	}
+	return l.ServiceMaxConcurrent
 }
 
 // EffectiveLimit resolves one account's rate limit: the per-account override
@@ -33,8 +45,9 @@ func EffectiveLimit(override *int, allowanceManaged bool, limits Limits) int {
 	return limits.ServicePerMin
 }
 
-// Middleware enforces the account-level and key-level rate limits, in that
-// order (docs/design/per-account-rate-limiting.md §3.2):
+// Middleware enforces the account-level and key-level rate limits and the
+// per-account concurrency cap, in that order
+// (docs/design/per-account-rate-limiting.md §3.2):
 //
 //  1. Account bucket, keyed by the billing resolution's account ID. Checked
 //     first so a throttled user's rejects never drain the shared key's
@@ -42,11 +55,18 @@ func EffectiveLimit(override *int, allowanceManaged bool, limits Limits) int {
 //  2. Key bucket, unchanged semantics. A key-level reject refunds the
 //     account token — different owners on the shared trusted key (see
 //     Limiter.Return).
+//  3. Concurrency slot (non-GET only — GETs like /api/v1/models don't
+//     occupy GPU). A concurrency reject deliberately does NOT refund the
+//     account token: a free retry would let a client busy-poll the
+//     semaphore at zero cost, and it is the polling client's own budget.
+//     The slot is released in this middleware's own defer, which covers
+//     full stream lifetime, client disconnects, and handler panics
+//     (handleStreaming runs synchronously inside the handler; no Hijack).
 //
 // Requests without a billing resolution (legacy nil-account keys — a
 // reachable prod path that 403s at the credit gate) see only the key
 // bucket; requests without a key pass through untouched.
-func Middleware(keys, accounts *Limiter, limits Limits, m *metrics.Metrics) func(http.Handler) http.Handler {
+func Middleware(keys, accounts *Limiter, conc *ConcurrencyLimiter, limits Limits, m *metrics.Metrics) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			key := auth.KeyFromContext(r.Context())
@@ -75,6 +95,23 @@ func Middleware(keys, accounts *Limiter, limits Limits, m *metrics.Metrics) func
 				writeRateLimited(w, r, retryAfter,
 					fmt.Sprintf("Rate limit exceeded for this API key (%d req/min)", key.RateLimit))
 				return
+			}
+
+			if hasRes && r.Method != http.MethodGet {
+				max := limits.maxConcurrent(res.AllowanceManaged)
+				if !conc.TryAcquire(res.AccountID, max) {
+					m.RecordAccountRateLimitReject("concurrency", classLabel(res.AllowanceManaged))
+					// Retry-After is advisory — stream end time is unknowable.
+					w.Header().Set("Retry-After", "5")
+					apierror.WriteError(w, r, http.StatusTooManyRequests, "rate_limit_exceeded", "rate_limit_exceeded",
+						fmt.Sprintf("Too many concurrent requests for your account (max %d); retry shortly", max))
+					return
+				}
+				m.RecordStreamStart()
+				defer func() {
+					conc.Release(res.AccountID)
+					m.RecordStreamEnd()
+				}()
 			}
 
 			next.ServeHTTP(w, r)

--- a/internal/ratelimit/middleware_test.go
+++ b/internal/ratelimit/middleware_test.go
@@ -44,7 +44,7 @@ func newMiddleware(limits Limits, m *metrics.Metrics) (http.Handler, *Limiter, *
 	clock := newTestClock()
 	keys := NewWithClock(clock.now)
 	accounts := NewWithClock(clock.now)
-	return Middleware(keys, accounts, limits, m)(okNext()), keys, accounts
+	return Middleware(keys, accounts, NewConcurrency(), limits, m)(okNext()), keys, accounts
 }
 
 func TestMiddleware_NoKeyInContext(t *testing.T) {


### PR DESCRIPTION
## Summary
Phase D of [docs/design/per-account-rate-limiting.md](../blob/main/docs/design/per-account-rate-limiting.md): cap in-flight non-GET requests per billing account. A req/min bucket bounds arrival rate, not GPU occupancy — one account could hold its whole minute budget open as simultaneous long-lived SSE streams.

- `ConcurrencyLimiter`: keyed counting semaphore (bcrypt-semaphore pattern), entries deleted at zero; slots die with the pod, exactly like the streams they represent.
- Checked after both rate gates, **non-GET only** (`/api/v1/models` consumes rate tokens but no slot). Reject → 429 with advisory `Retry-After: 5` and **no rate-token refund** (a free retry would allow zero-cost busy-polling).
- Release in the middleware's own defer — covers stream lifetime, client disconnects, and handler panics (a leaked slot strangles the account until restart; pinned by test).
- Env `ACCOUNT_MAX_CONCURRENT=8` / `END_USER_MAX_CONCURRENT=5` (validated 1..100; 5 because one visible Open WebUI message fans out to 1 visible + 2–4 background completions), in the admin config snapshot + deploy manifest.
- `aiproxy_streams_inflight` gauge; `kind="concurrency"` on `aiproxy_account_ratelimit_rejects_total`.

## Test plan
- Full suite `go test -race -count=1 -p 1 ./...` green locally (21 packages).
- New: semaphore unit tests (delete-at-zero, never-negative, zero-cap passthrough), middleware concurrency reject shape/metric, GET slot exemption, slot released on normal return AND handler panic, no-refund-on-concurrency-reject bucket assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrdvV7xxnPpoFbkCwFCFe